### PR TITLE
BUG: Fix the example images not being rendered.

### DIFF
--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Documentation.rst
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Documentation.rst
@@ -38,15 +38,22 @@ Results
    :align: center
    :alt: Output image histogram
 
-+-------------------------+--------------------------+
-|       Input image       |       Output image       |
-+-------------------------+--------------------------+
-|      |input_image|      |      |output_image|      |
-+-------------------------+--------------------------+
-|  Input image histogram  |  Output image histogram  |
-+-------------------------+--------------------------+
-| |input_image_histogram| | |output_image_histogram| |
-+-------------------------+--------------------------+
+.. |input_image_caption| replace:: Input image.
+.. |input_image_histogram_caption| replace:: Input image histogram.
+.. |output_image_caption| replace:: Output image.
+.. |output_image_histogram_caption| replace:: Output image histogram.
+
+.. tabularcolumns:: |c|c|
+
++                                   +                                    +
+|           |input_image|           |           |output_image|           |
++                                   +                                    +
+|        |input_image_caption|      |       |output_image_caption|       |
++                                   +                                    +
+|      |input_image_histogram|      |      |output_image_histogram|      |
++                                   +                                    +
+|  |input_image_histogram_caption|  |  |output_image_histogram_caption|  |
++-----------------------------------+------------------------------------+
 
 
 Code


### PR DESCRIPTION
In an attempt to add column headers, the previous commit (0ae9d60) seems
to have had undesired collateral effects and the images were no longer
being rendered.

Change-Id: I69dcdf4c0c83ae3c3f8ec86ffad84a91eb9ecc86