### PR TITLE
DOC: Improve the README.rst code syntax.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@ A set of cookbook examples for the Insight Toolkit, ITK_.
 Download instructions
 ---------------------
 
+Clone the repository using Git::
+
   $ git clone --recursive https://itk.org/ITKExamples.git
 
 
@@ -67,7 +69,7 @@ PDF generation requires a TeX distribution like `TeX Live`_ or MiKTeX_.
 Development setup
 ------------------
 
-Run the bash scipt SetupForDevelopment.sh::
+Run the bash script ``SetupForDevelopment.sh``::
 
   $ ./Utilities/SetupForDevelopment.sh
 


### PR DESCRIPTION
Use a literal block to highlight the `git clone` command.

Use inline literal markup to highlight the `SetpForDevelopment.sh` script.

Fix a typo (scipt->script).

Change-Id: I6f033154d2b60a2f19c6adf44b5aff24e4cf6ebe