### PR TITLE
ENH: Require CMake minimum version to be 3.8.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8.2)
 foreach(p
   CMP0025
   CMP0042

--- a/Superbuild/CMakeLists.txt
+++ b/Superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 if( COMMAND CMAKE_POLICY )
   cmake_policy( SET CMP0003 NEW )

--- a/Utilities/Dashboard/itkexamples_common.cmake
+++ b/Utilities/Dashboard/itkexamples_common.cmake
@@ -88,7 +88,7 @@
 #
 #==========================================================================*/
 
-cmake_minimum_required(VERSION 2.8.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8.2 FATAL_ERROR)
 
 set(dashboard_user_home "$ENV{HOME}")
 

--- a/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(ConvertAnRGBitkImageTovtkImageData)
 

--- a/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(ConvertAnitkImageTovtkImageData)
 

--- a/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(ConvertRGBvtkImageDataToAnitkImage)
 

--- a/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(ConvertvtkImageDataToAnitkImage)
 

--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/CMakeLists.txt
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyAFilterOnlyToASpecifiedRegionOfAnImage )
 

--- a/src/Core/Common/BoundingBoxOfAPointSet/CMakeLists.txt
+++ b/src/Core/Common/BoundingBoxOfAPointSet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( BoundingBoxOfAPointSet )
 

--- a/src/Core/Common/BuildAHelloWorldProgram/CMakeLists.txt
+++ b/src/Core/Common/BuildAHelloWorldProgram/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( BuildAHelloWorldProgram )
 

--- a/src/Core/Common/ComputeTimeBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/ComputeTimeBetweenPoints/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeTimeBetweenPoints )
 

--- a/src/Core/Common/ConceptCheckingIsFloatingPoint/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsFloatingPoint/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ConceptCheckingIsFloatingPoint )
 

--- a/src/Core/Common/ConceptCheckingIsSameDimension/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsSameDimension/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ConceptCheckingIsSameDimension )
 

--- a/src/Core/Common/ConceptCheckingIsSameType/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsSameType/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ConceptCheckingIsSameType )
 

--- a/src/Core/Common/CovariantVectorDotProduct/CMakeLists.txt
+++ b/src/Core/Common/CovariantVectorDotProduct/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CovariantVectorDotProduct )
 

--- a/src/Core/Common/CovariantVectorNorm/CMakeLists.txt
+++ b/src/Core/Common/CovariantVectorNorm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CovariantVectorNorm )
 

--- a/src/Core/Common/CreateABackwardDifferenceOperator/CMakeLists.txt
+++ b/src/Core/Common/CreateABackwardDifferenceOperator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateABackwardDifferenceOperator )
 

--- a/src/Core/Common/CreateACovariantVector/CMakeLists.txt
+++ b/src/Core/Common/CreateACovariantVector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateACovariantVector )
 

--- a/src/Core/Common/CreateAFixedArray/CMakeLists.txt
+++ b/src/Core/Common/CreateAFixedArray/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateAFixedArray )
 

--- a/src/Core/Common/CreateAIndex/CMakeLists.txt
+++ b/src/Core/Common/CreateAIndex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateAIndex )
 

--- a/src/Core/Common/CreateAPointSet/CMakeLists.txt
+++ b/src/Core/Common/CreateAPointSet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateAPointSet )
 

--- a/src/Core/Common/CreateASize/CMakeLists.txt
+++ b/src/Core/Common/CreateASize/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateASize )
 

--- a/src/Core/Common/CreateAVector/CMakeLists.txt
+++ b/src/Core/Common/CreateAVector/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateAVector )
 

--- a/src/Core/Common/CreateAnImage/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(CreateAnImage)
 

--- a/src/Core/Common/CreateAnImageOfVectors/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImageOfVectors/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(CreateAnImageOfVectors)
 

--- a/src/Core/Common/CreateAnImageRegion/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImageRegion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateAnImageRegion )
 

--- a/src/Core/Common/CreateAnother/CMakeLists.txt
+++ b/src/Core/Common/CreateAnother/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateAnother )
 

--- a/src/Core/Common/DistanceBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/DistanceBetweenPoints/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( DistanceBetweenPoints )
 

--- a/src/Core/Common/DoDataParallelThreading/CMakeLists.txt
+++ b/src/Core/Common/DoDataParallelThreading/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( DoDataParallelThreading )
 

--- a/src/Core/Common/DuplicateAnImage/CMakeLists.txt
+++ b/src/Core/Common/DuplicateAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( DuplicateAnImage )
 

--- a/src/Core/Common/GetImageSize/CMakeLists.txt
+++ b/src/Core/Common/GetImageSize/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( GetImageSize )
 

--- a/src/Core/Common/GetNameOfClass/CMakeLists.txt
+++ b/src/Core/Common/GetNameOfClass/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( GetNameOfClass )
 

--- a/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
+++ b/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( GetTypeBasicInformation )
 

--- a/src/Core/Common/ImageRegionIntersection/CMakeLists.txt
+++ b/src/Core/Common/ImageRegionIntersection/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ImageRegionIntersection )
 

--- a/src/Core/Common/ImageRegionOverlap/CMakeLists.txt
+++ b/src/Core/Common/ImageRegionOverlap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ImageRegionOverlap )
 

--- a/src/Core/Common/ImportPixelBufferIntoAnImage/CMakeLists.txt
+++ b/src/Core/Common/ImportPixelBufferIntoAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(ImportPixelBufferIntoAnImage)
 

--- a/src/Core/Common/IsPixelInsideRegion/CMakeLists.txt
+++ b/src/Core/Common/IsPixelInsideRegion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( IsPixelInsideRegion )
 

--- a/src/Core/Common/IterateOnAVectorContainer/CMakeLists.txt
+++ b/src/Core/Common/IterateOnAVectorContainer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( IterateOnAVectorContainer )
 

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/CMakeLists.txt
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( IterateOverARegionWithAShapedNeighborhoodIterator )
 

--- a/src/Core/Common/MersenneTwisterRandomIntegerGenerator/CMakeLists.txt
+++ b/src/Core/Common/MersenneTwisterRandomIntegerGenerator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( MersenneTwisterRandomIntegerGenerator )
 

--- a/src/Core/Common/MersenneTwisterRandomNumberGenerator/CMakeLists.txt
+++ b/src/Core/Common/MersenneTwisterRandomNumberGenerator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( MersenneTwisterRandomNumberGenerator )
 

--- a/src/Core/Common/ObserveAnEvent/CMakeLists.txt
+++ b/src/Core/Common/ObserveAnEvent/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ObserveAnEvent )
 

--- a/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/CMakeLists.txt
+++ b/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ReRunPipelineWithChangingLargestPossibleRegion )
 

--- a/src/Core/Common/ReadAPointSet/CMakeLists.txt
+++ b/src/Core/Common/ReadAPointSet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ReadAPointSet )
 

--- a/src/Core/Common/ReadWriteVectorImage/CMakeLists.txt
+++ b/src/Core/Common/ReadWriteVectorImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(ReadWriteVectorImage)
 

--- a/src/Core/Common/SetPixelValueInOneImage/CMakeLists.txt
+++ b/src/Core/Common/SetPixelValueInOneImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( SetPixelValueInOneImage )
 

--- a/src/Core/Common/StreamAPipeline/CMakeLists.txt
+++ b/src/Core/Common/StreamAPipeline/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( StreamAPipeline )
 

--- a/src/Core/Common/TraceMemoryBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/TraceMemoryBetweenPoints/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( TraceMemoryBetweenPoints )
 

--- a/src/Core/Common/TryCatchException/CMakeLists.txt
+++ b/src/Core/Common/TryCatchException/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( TryCatchException )
 

--- a/src/Core/Common/WatchAFilter/CMakeLists.txt
+++ b/src/Core/Common/WatchAFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( WatchAFilter )
 

--- a/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/CMakeLists.txt
+++ b/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ConvertTriangleMeshToBinaryImage )
 

--- a/src/Core/Mesh/ExtractIsoSurface/CMakeLists.txt
+++ b/src/Core/Mesh/ExtractIsoSurface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ExtractIsoSurface )
 

--- a/src/Core/Mesh/TranslateOneMesh/CMakeLists.txt
+++ b/src/Core/Mesh/TranslateOneMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( TranslateOneMesh )
 

--- a/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateTriangularQuadEdgeMesh )
 

--- a/src/Core/QuadEdgeMesh/CutMesh/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/CutMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CutMesh )
 

--- a/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ExtractVertexOnMeshBoundaries )
 

--- a/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( GetListOfFacesAroundAGivenVertex )
 

--- a/src/Core/QuadEdgeMesh/PrintVertexNeighbors/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/PrintVertexNeighbors/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( PrintVertexNeighbors )
 

--- a/src/Core/TestKernel/GenerateRandomImage/CMakeLists.txt
+++ b/src/Core/TestKernel/GenerateRandomImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( GenerateRandomImage )
 

--- a/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/CMakeLists.txt
+++ b/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyAffineTransformFromHomogeneousMatrixAndResample )
 

--- a/src/Core/Transform/CopyACompositeTransform/CMakeLists.txt
+++ b/src/Core/Transform/CopyACompositeTransform/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CopyACompositeTransform )
 

--- a/src/Core/Transform/CopyANonCompositeTransform/CMakeLists.txt
+++ b/src/Core/Transform/CopyANonCompositeTransform/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CopyANonCompositeTransform )
 

--- a/src/Core/Transform/TranslateImage/CMakeLists.txt
+++ b/src/Core/Transform/TranslateImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( TranslateImage )
 

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png )
 set( output_image Output.png )

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png )
 set( output_image Output.png )

--- a/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png )
 set( output_image Output.png )

--- a/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png )
 set( output_image ComputePeronaMalikAnisotropicDiffusionTest.mha )

--- a/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/CMakeLists.txt
+++ b/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/VentricleModel.png )
 set( output_image Output.mha )

--- a/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png )
 set( output_image Output.png )

--- a/src/Filtering/Colormap/ApplyAColorMapToAnImage/CMakeLists.txt
+++ b/src/Filtering/Colormap/ApplyAColorMapToAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png )
 set( output_image Output.png )

--- a/src/Filtering/Colormap/CreateACustomColorMap/CMakeLists.txt
+++ b/src/Filtering/Colormap/CreateACustomColorMap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/sf4.png )
 set( output_image Output.png )

--- a/src/Filtering/FFT/ComputeForwardFFT/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeForwardFFT/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeForwardFFT )
 

--- a/src/Filtering/FFT/ComputeImageSpectralDensity/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeImageSpectralDensity/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeImageSpectralDensity )
 

--- a/src/Filtering/FFT/FilterImageInFourierDomain/CMakeLists.txt
+++ b/src/Filtering/FFT/FilterImageInFourierDomain/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( FilterImageInFourierDomain )
 

--- a/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/CMakeLists.txt
+++ b/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeGeodesicDistanceOnMesh )
 

--- a/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/CMakeLists.txt
+++ b/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateDistanceMapFromSeeds )
 

--- a/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/CMakeLists.txt
+++ b/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CombineTwoImagesWithCheckerBoardPattern )
 

--- a/src/Filtering/ImageFeature/ComputeLaplacian/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ComputeLaplacian/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeLaplacian )
 

--- a/src/Filtering/ImageFeature/DetectEdgesWithCannyFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/DetectEdgesWithCannyFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( DetectEdgesWithCannyFilter )
 

--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( LaplacianRecursiveGaussianImageFilter )
 

--- a/src/Filtering/ImageFeature/SegmentBloodVessels/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SegmentBloodVessels/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( SegmentBloodVessels )
 

--- a/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( SobelEdgeDetectionImageFilter )
 

--- a/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CastAnImageToAnotherType )
 

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyGradientRecursiveGaussianWithVectorInput )
 

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitude/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitude/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeGradientMagnitude )
 

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeGradientMagnitudeRecursiveGaussian )
 

--- a/src/Filtering/ImageGrid/AppendTwo3DVolumes/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/AppendTwo3DVolumes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( AppendTwo3DVolumes )
 

--- a/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ChangeImageOriginSpacingOrDirection )
 

--- a/src/Filtering/ImageGrid/Create3DVolume/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/Create3DVolume/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( Create3DVolume )
 

--- a/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 project( ExtractRegionOfInterestInOneImage )
 
 find_package( ITK REQUIRED )

--- a/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( FlipAnImageOverSpecifiedAxes )
 

--- a/src/Filtering/ImageGrid/PadAnImageByMirroring/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadAnImageByMirroring/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( PadAnImageByMirroring )
 

--- a/src/Filtering/ImageGrid/PadAnImageWithAConstant/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadAnImageWithAConstant/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( PadAnImageWithAConstant )
 

--- a/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( PasteImageIntoAnotherOne )
 

--- a/src/Filtering/ImageGrid/PermuteAxesOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PermuteAxesOfAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( PermuteAxesOfAnImage )
 

--- a/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(ProcessA2DSliceOfA3DImage)
 

--- a/src/Filtering/ImageGrid/ResampleAVectorImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAVectorImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/VisibleWomanHeadSlice.png )
 set( output_image Output.png )

--- a/src/Filtering/ImageGrid/ResampleAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ResampleAnImage )
 

--- a/src/Filtering/ImageGrid/UpsampleOrDownsampleScalarImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/UpsampleOrDownsampleScalarImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( UpsampleOrDownsampleScalarImage )
 

--- a/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(WarpAnImageUsingADeformationField)
 

--- a/src/Filtering/ImageIntensity/ApplyAtanImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyAtanImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyAtanImageFilter )
 

--- a/src/Filtering/ImageIntensity/ApplyCosImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyCosImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyCosImageFilter )
 

--- a/src/Filtering/ImageIntensity/ApplySinImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplySinImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplySinImageFilter )
 

--- a/src/Filtering/ImageIntensity/ComputeSigmoid/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ComputeSigmoid/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeSigmoid )
 

--- a/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ConvertRGBImageToGrayscaleImage )
 

--- a/src/Filtering/ImageIntensity/MultiplyImageByScalar/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MultiplyImageByScalar/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( MultiplyImageByScalar )
 

--- a/src/Filtering/ImageIntensity/MultiplyTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MultiplyTwoImages/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( MultiplyTwoImages )
 

--- a/src/Filtering/ImageIntensity/RescaleAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/RescaleAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( RescaleAnImage )
 

--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(AdaptiveHistogramEqualizationImageFilter)
 

--- a/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyAccumulateImageFilter )
 

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 project( ApplyMorphologicalClosingOnAllLabelObjects )
 
 find_package( ITK REQUIRED )

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 project( ApplyMorphologicalClosingOnSpecificLabelObject )
 
 find_package( ITK REQUIRED )

--- a/src/Filtering/LabelMap/ExtractGivenLabelObject/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ExtractGivenLabelObject/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 project( ExtractGivenLabelObject )
 
 find_package( ITK REQUIRED )

--- a/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( MaskOneImageGivenLabelMap )
 

--- a/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/CMakeLists.txt
+++ b/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png )
 set( output_image Output.png )

--- a/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateABinaryBallStructuringElement )
 

--- a/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( DilateAGrayscaleImage )
 

--- a/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ErodeAGrayscaleImage )
 

--- a/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CleanQuadEdgeMesh )
 

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeNormalsOfAMesh )
 

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputePlanarParameterizationOfAMesh )
 

--- a/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( DelaunayConformEdgeFlipping )
 

--- a/src/Filtering/Smoothing/ApplyMeanFilter/CMakeLists.txt
+++ b/src/Filtering/Smoothing/ApplyMeanFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyMeanFilter )
 

--- a/src/Filtering/Smoothing/ApplyMedianFilter/CMakeLists.txt
+++ b/src/Filtering/Smoothing/ApplyMedianFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ApplyMedianFilter )
 

--- a/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/CMakeLists.txt
+++ b/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(BlurringAnImageUsingABinomialKernel)
 

--- a/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( MedianFilteringOfAnRGBImage )
 

--- a/src/Filtering/Smoothing/SmoothWithRecursiveGaussian/CMakeLists.txt
+++ b/src/Filtering/Smoothing/SmoothWithRecursiveGaussian/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( SmoothWithRecursiveGaussian )
 

--- a/src/Filtering/Thresholding/ThresholdAnImage/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ThresholdAnImage )
 

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ThresholdAnImageUsingBinary )
 

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ThresholdAnImageUsingOtsu )
 

--- a/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/CMakeLists.txt
+++ b/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 project( ReadDICOMSeriesAndWrite3DImage )
 
 find_package( ITK REQUIRED )

--- a/src/IO/ImageBase/ConvertFileFormats/CMakeLists.txt
+++ b/src/IO/ImageBase/ConvertFileFormats/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ConvertFileFormats )
 

--- a/src/IO/ImageBase/CreateAListOfFileNames/CMakeLists.txt
+++ b/src/IO/ImageBase/CreateAListOfFileNames/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( CreateAListOfFileNames )
 

--- a/src/IO/ImageBase/GenerateSlicesFromVolume/CMakeLists.txt
+++ b/src/IO/ImageBase/GenerateSlicesFromVolume/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha )
 set( output_image Output )

--- a/src/IO/ImageBase/ReadAnImage/CMakeLists.txt
+++ b/src/IO/ImageBase/ReadAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ReadAnImage )
 

--- a/src/IO/ImageBase/ReadUnknownImageType/CMakeLists.txt
+++ b/src/IO/ImageBase/ReadUnknownImageType/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ReadUnknownImageType )
 

--- a/src/IO/ImageBase/RegisterIOFactories/CMakeLists.txt
+++ b/src/IO/ImageBase/RegisterIOFactories/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( RegisterIOFactories )
 

--- a/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
+++ b/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( WriteAnImage )
 

--- a/src/IO/Mesh/ReadMesh/CMakeLists.txt
+++ b/src/IO/Mesh/ReadMesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ReadMesh )
 

--- a/src/IO/TIFF/WriteATIFFImage/CMakeLists.txt
+++ b/src/IO/TIFF/WriteATIFFImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( WriteATIFFImage )
 

--- a/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/CMakeLists.txt
+++ b/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( SegmentBloodVesselsWithMultiScaleHessianBasedMeasure )
 

--- a/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/CMakeLists.txt
+++ b/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ComputeHistogramFromGrayscaleImage )
 

--- a/src/Numerics/Statistics/HistogramCreationAndBinAccess/CMakeLists.txt
+++ b/src/Numerics/Statistics/HistogramCreationAndBinAccess/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(HistogramCreationAndBinAccess)
 

--- a/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/CMakeLists.txt
+++ b/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 set( input_image1 ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySliceBorder20.png )
 set( input_image2 ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySliceShifted13x17y.png )

--- a/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/CMakeLists.txt
+++ b/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( PerformMultiModalityRegistrationWithMutualInformation )
 

--- a/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/CMakeLists.txt
+++ b/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(PerformRegistrationOnVectorImages)
 

--- a/src/Segmentation/LabelVoting/IterativeHoleFilling/CMakeLists.txt
+++ b/src/Segmentation/LabelVoting/IterativeHoleFilling/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( IterativeHoleFilling )
 

--- a/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/CMakeLists.txt
+++ b/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( SegmentWithGeodesicActiveContourLevelSet )
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeEvolvingDense2DLevelSetAsElevationMap/CMakeLists.txt
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeEvolvingDense2DLevelSetAsElevationMap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VisualizeEvolvingDense2DLevelSetAsElevationMap )
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeEvolvingDense2DLevelSetZeroSet/CMakeLists.txt
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeEvolvingDense2DLevelSetZeroSet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VisualizeEvolvingDense2DLevelSetZeroSet )
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VisualizeStaticDense2DLevelSetAsElevationMap )
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VisualizeStaticDense2DLevelSetZeroSet )
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VisualizeStaticMalcolm2DLevelSetLayers )
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VisualizeStaticShi2DLevelSetLayers )
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( VisualizeStaticWhitaker2DLevelSetLayers )
 

--- a/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/CMakeLists.txt
+++ b/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 project(SegmentWithWatershedImageFilter)
 

--- a/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/CMakeLists.txt
+++ b/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 2.8.6 )
+cmake_minimum_required(VERSION 3.8.2)
 
 project( ConvertAnITKGrayScaleImageToCVMat )
 


### PR DESCRIPTION
Require CMake minimum version to be 3.8.2 following ITKv5 requiring
C++11:
https://discourse.itk.org/t/minimum-cmake-version-update/585

Change-Id: I491763a77f8434430c8e479e4383dfd92583ede8