### PR TITLE
ENH: Update ITKApps reference to new address

### DIFF
--- a/Documentation/Build/index.rst
+++ b/Documentation/Build/index.rst
@@ -247,7 +247,7 @@ VV
 .. _CMake:                 https://cmake.org/
 .. _FLTK:                  http://www.fltk.org/index.php
 .. _ImageViewer:           https://github.com/KitwareMedical/ImageViewer
-.. _ITKApps:               https://itk.org/ITKApps.git
+.. _ITKApps:               https://github.com/InsightSoftwareConsortium/ITKApps
 .. _ITK-SNAP:              http://www.itksnap.org/pmwiki/pmwiki.php
 .. _MITK:                  http://www.mitk.org/wiki/MITK
 .. _Paraview:              https://www.paraview.org/


### PR DESCRIPTION
ITKApps primary repository is now hosted on github.

Related to issue #94