### PR TITLE
ENH: Re-enable Otsu baseline test

### DIFF
--- a/src/Filtering/Thresholding/CMakeLists.txt
+++ b/src/Filtering/Thresholding/CMakeLists.txt
@@ -1,6 +1,5 @@
-# Temporarily disabled until Python packages are updated
-#add_example( ThresholdAnImageUsingOtsu )
-#compare_to_baseline( EXAMPLE_NAME ThresholdAnImageUsingOtsu BASELINE_PREFIX OutputBaseline)
+add_example( ThresholdAnImageUsingOtsu )
+compare_to_baseline( EXAMPLE_NAME ThresholdAnImageUsingOtsu BASELINE_PREFIX OutputBaseline)
 
 add_example( ThresholdAnImageUsingBinary )
 compare_to_baseline( EXAMPLE_NAME ThresholdAnImageUsingBinary BASELINE_PREFIX OutputBaseline)


### PR DESCRIPTION
Re-enable Otsu thresholding baseline test.

Fixes #75.