### PR TITLE
BUG: Remove unused VectorCastImageFilter include

### DIFF
--- a/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/Code.cxx
+++ b/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/Code.cxx
@@ -20,7 +20,6 @@
 #include "itkImageFileWriter.h"
 #include "itkScalarToRGBPixelFunctor.h"
 #include "itkUnaryFunctorImageFilter.h"
-#include "itkVectorCastImageFilter.h"
 #include "itkVectorGradientAnisotropicDiffusionImageFilter.h"
 #include "itkWatershedImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"


### PR DESCRIPTION
This class has been deprecated in ITK 5.0 in favor of CastImageFilter.