### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if]

### DIFF
--- a/src/Compatibility/Deprecated/ResampleRGBImage/Code.cxx
+++ b/src/Compatibility/Deprecated/ResampleRGBImage/Code.cxx
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
         input = reader->GetOutput();
         if (argc > 2)
         {
-            factor = atof(argv[2]);
+            factor = std::stod(argv[2]);
         }
     }
 

--- a/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
+++ b/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
@@ -38,7 +38,7 @@ int main( int argc, char* argv[] )
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const auto defaultValue = static_cast< ScalarType >( atof( argv[3] ) );
+  const auto defaultValue = static_cast< ScalarType >( std::stod( argv[3] ) );
 
   using MatrixType = itk::Matrix< ScalarType, Dimension + 1, Dimension + 1 >;
   MatrixType matrix;

--- a/src/Core/Transform/TranslateImage/Code.cxx
+++ b/src/Core/Transform/TranslateImage/Code.cxx
@@ -48,8 +48,8 @@ int main( int argc, char* argv[] )
   using TransformType = itk::TranslationTransform< double, Dimension >;
 
   TransformType::OutputVectorType vector;
-  vector[0] = atof( argv[3] );
-  vector[1] = atof( argv[4] );
+  vector[0] = std::stod( argv[3] );
+  vector[1] = std::stod( argv[4] );
 
   TransformType::Pointer translation = TransformType::New();
   translation->Translate( vector );

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/Code.cxx
@@ -44,8 +44,8 @@ int main( int argc, char* argv[] )
   using OutputImageType = itk::Image< OutputPixelType, Dimension >;
 
   const int numberOfIterations     = std::stoi( argv[3] );
-  const InputPixelType timeStep    = atof( argv[4] );
-  const InputPixelType conductance = atof( argv[5] );
+  const InputPixelType timeStep    = std::stod( argv[4] );
+  const InputPixelType conductance = std::stod( argv[5] );
 
   using ReaderType = itk::ImageFileReader< InputImageType >;
   ReaderType::Pointer reader = ReaderType::New();

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/Code.cxx
@@ -44,7 +44,7 @@ int main( int argc, char* argv[] )
   using OutputImageType = itk::Image< OutputPixelType, Dimension >;
 
   const int numberOfIterations     = std::stoi( argv[3] );
-  const InputPixelType timeStep    = atof( argv[4] );
+  const InputPixelType timeStep    = std::stod( argv[4] );
 
   using ReaderType = itk::ImageFileReader< InputImageType >;
   ReaderType::Pointer reader = ReaderType::New();

--- a/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/Code.cxx
@@ -44,8 +44,8 @@ int main( int argc, char* argv[] )
   using OutputImageType = itk::Image< OutputPixelType, Dimension >;
 
   const int numberOfIterations     = std::stoi( argv[3] );
-  const InputPixelType timeStep    = atof( argv[4] );
-  const InputPixelType conductance = atof( argv[5] );
+  const InputPixelType timeStep    = std::stod( argv[4] );
+  const InputPixelType conductance = std::stod( argv[5] );
 
   using ReaderType = itk::ImageFileReader< InputImageType >;
   ReaderType::Pointer reader = ReaderType::New();

--- a/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx
@@ -51,7 +51,7 @@ int main( int argc, char* argv[] )
   filter->SetInput( reader->GetOutput() );
   filter->SetNumberOfIterations( std::stoi( argv[3] ) );
   filter->SetTimeStep( 0.125 );
-  filter->SetConductanceParameter( atof( argv[4] ) );
+  filter->SetConductanceParameter( std::stod( argv[4] ) );
 
   using WriterType = itk::ImageFileWriter< OutputImageType >;
   WriterType::Pointer writer = WriterType::New();

--- a/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/Code.cxx
+++ b/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/Code.cxx
@@ -37,7 +37,7 @@ int main( int argc, char* argv[] )
   double maximumRMSError = 0.001;
   if( argc > 3 )
     {
-    maximumRMSError = atof( argv[3] );
+    maximumRMSError = std::stod( argv[3] );
     }
   int numberOfIterations = 50;
   if( argc > 4 )

--- a/src/Filtering/FFT/FilterImageInFourierDomain/Code.cxx
+++ b/src/Filtering/FFT/FilterImageInFourierDomain/Code.cxx
@@ -42,7 +42,7 @@ int main( int argc, char* argv[] )
   double sigmaValue = 0.5;
   if( argc > 3 )
     {
-    sigmaValue = atof( argv[3] );
+    sigmaValue = std::stod( argv[3] );
     }
 
   constexpr unsigned int Dimension = 3;

--- a/src/Filtering/ImageFeature/DetectEdgesWithCannyFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/DetectEdgesWithCannyFilter/Code.cxx
@@ -40,9 +40,9 @@ int main( int argc, char* argv[] )
 
   const char * inputImage = argv[1];
   const char * outputImage = argv[2];
-  const InputPixelType variance = atof( argv[3] );
-  const InputPixelType lowerThreshold = atof( argv[4] );
-  const InputPixelType upperThreshold = atof( argv[5] );
+  const InputPixelType variance = std::stod( argv[3] );
+  const InputPixelType lowerThreshold = std::stod( argv[4] );
+  const InputPixelType upperThreshold = std::stod( argv[5] );
 
   using InputImageType = itk::Image<InputPixelType, Dimension>;
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/Code.cxx
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/Code.cxx
@@ -33,7 +33,7 @@ int main( int argc, char* argv[] )
     }
   const char * inputImage = argv[1];
   const char * outputImage = argv[2];
-  const double sigma = atof( argv[3] );
+  const double sigma = std::stod( argv[3] );
 
   constexpr unsigned int Dimension = 2;
   using PixelType = float;

--- a/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/Code.cxx
+++ b/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/Code.cxx
@@ -37,27 +37,27 @@ int main( int argc, char* argv[] )
   double scalingFactor = 1.0;
   if( argc > 3 )
     {
-    scalingFactor = atof( argv[3] );
+    scalingFactor = std::stod( argv[3] );
     }
   double translationX = 0.0;
   if( argc > 3 )
     {
-    translationX = atof( argv[3] );
+    translationX = std::stod( argv[3] );
     }
   double translationY = 0.0;
   if( argc > 4 )
     {
-    translationY = atof( argv[4] );
+    translationY = std::stod( argv[4] );
     }
   double translationZ = 0.0;
   if( argc > 5 )
     {
-    translationZ = atof( argv[5] );
+    translationZ = std::stod( argv[5] );
     }
   double rotationZ = 0.0;
   if( argc > 6 )
     {
-    rotationZ = atof( argv[6] );
+    rotationZ = std::stod( argv[6] );
     }
 
   constexpr unsigned int Dimension = 3;

--- a/src/Filtering/ImageGrid/ResampleAnImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ResampleAnImage/Code.cxx
@@ -36,7 +36,7 @@ int main( int argc, char* argv[] )
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const float scale = atof( argv[3] );
+  const float scale = std::stod( argv[3] );
 
   constexpr unsigned int Dimension = 2;
 

--- a/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/Code.cxx
@@ -33,7 +33,7 @@ int main( int argc, char* argv[] )
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const double k = atof( argv[3] );
+  const double k = std::stod( argv[3] );
 
   constexpr unsigned int Dimension = 2;
   using PixelType = float;

--- a/src/Filtering/ImageIntensity/ComputeSigmoid/Code.cxx
+++ b/src/Filtering/ImageIntensity/ComputeSigmoid/Code.cxx
@@ -43,8 +43,8 @@ int main( int argc, char* argv[] )
 
   const auto outputMinimum = static_cast<PixelType>(atoi( argv[3] ) );
   const auto outputMaximum = static_cast<PixelType>(atoi( argv[4] ) );
-  const ScalarType alpha = atof( argv[5] );
-  const ScalarType beta  = atof( argv[6] );
+  const ScalarType alpha = std::stod( argv[5] );
+  const ScalarType beta  = std::stod( argv[6] );
 
   using ReaderType = itk::ImageFileReader< ImageType >;
   ReaderType::Pointer reader = ReaderType::New();

--- a/src/Filtering/ImageIntensity/MultiplyImageByScalar/Code.cxx
+++ b/src/Filtering/ImageIntensity/MultiplyImageByScalar/Code.cxx
@@ -32,7 +32,7 @@ int main( int argc, char* argv[] )
     }
 
   const char * inputFileName = argv[1];
-  const double factor = atof( argv[2] );
+  const double factor = std::stod( argv[2] );
   const char * outputFileName = argv[3];
   constexpr unsigned int Dimension = 2;
 

--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Code.cxx
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Code.cxx
@@ -42,10 +42,10 @@ int main( int argc, char *argv[] )
   using AdaptiveHistogramEqualizationImageFilterType = itk::AdaptiveHistogramEqualizationImageFilter< ImageType >;
   AdaptiveHistogramEqualizationImageFilterType::Pointer adaptiveHistogramEqualizationImageFilter = AdaptiveHistogramEqualizationImageFilterType::New();
 
-  float alpha = atof( argv[3] );
+  float alpha = std::stod( argv[3] );
   adaptiveHistogramEqualizationImageFilter->SetAlpha( alpha );
 
-  float beta = atof( argv[4] );
+  float beta = std::stod( argv[4] );
   adaptiveHistogramEqualizationImageFilter->SetBeta( beta );
 
   int radiusSize = std::stoi( argv[5] );

--- a/src/Filtering/Smoothing/SmoothWithRecursiveGaussian/Code.cxx
+++ b/src/Filtering/Smoothing/SmoothWithRecursiveGaussian/Code.cxx
@@ -35,7 +35,7 @@ int main(int argc, char * argv[])
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const float sigmaValue = atof( argv[3] );
+  const float sigmaValue = std::stod( argv[3] );
 
   using PixelType = unsigned char;
   using ImageType = itk::Image< PixelType, Dimension >;

--- a/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.cxx
+++ b/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.cxx
@@ -40,12 +40,12 @@ int main( int argc, char* argv[] )
   double sigmaMinimum = 1.0;
   if( argc > 3 )
     {
-    sigmaMinimum = atof( argv[3] );
+    sigmaMinimum = std::stod( argv[3] );
     }
   double sigmaMaximum = 10.0;
   if( argc > 4 )
     {
-    sigmaMaximum = atof( argv[4] );
+    sigmaMaximum = std::stod( argv[4] );
     }
   unsigned int numberOfSigmaSteps = 10;
   if( argc > 5 )

--- a/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.cxx
+++ b/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.cxx
@@ -43,11 +43,11 @@ int main( int argc, char* argv[] )
   const int seedPosX =              std::stoi( argv[3] );
   const int seedPosY =              std::stoi( argv[4] );
 
-  const double initialDistance =    atof( argv[5] );
-  const double sigma =              atof( argv[6] );
-  const double alpha =              atof( argv[7] );
-  const double beta  =              atof( argv[8] );
-  const double propagationScaling = atof( argv[9] );
+  const double initialDistance =    std::stod( argv[5] );
+  const double sigma =              std::stod( argv[6] );
+  const double alpha =              std::stod( argv[7] );
+  const double beta  =              std::stod( argv[8] );
+  const double propagationScaling = std::stod( argv[9] );
   const double numberOfIterations = std::stoi( argv[10] );
   const double seedValue =          - initialDistance;
 

--- a/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/Code.cxx
+++ b/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/Code.cxx
@@ -64,8 +64,8 @@ int main( int argc, char *argv[] )
   using WatershedFilterType = itk::WatershedImageFilter< FloatImageType >;
   WatershedFilterType::Pointer watershed = WatershedFilterType::New();
 
-  float threshold = atof( argv[3] );
-  float level = atof( argv[4] );
+  float threshold = std::stod( argv[3] );
+  float level = std::stod( argv[4] );
 
   watershed->SetThreshold( threshold );
   watershed->SetLevel( level );


### PR DESCRIPTION
The ato[if] functions do not provide mechanisms for distinguishing
between '0' and the error condion where the input can not be converted.

std::sto[id] provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

ato[if]()
   Con: No error handling.
   Con: Handle neither hexadecimal nor octal.

The use of ato[if] in code can cause it to be subtly broken.
ato[if] makes two very big assumptions indeed:
   The string represents an integer/floating point value.
   The integer can fit into an int.