### PR TITLE
STYLE: Enforce ITK style defined by .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,151 @@
+## This config file is only relevant for clang-format version 8.0.0
+##
+## Examples of each format style can be found on the in the clang-format documentation
+## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
+##
+## The clang-format binaries can be downloaded as part of the clang binary distributions
+## from http://releases.llvm.org/download.html
+##
+## Use the script Utilities/Maintenance/clang-format.bash to faciliate
+## maintaining a consistent code style.
+##
+## EXAMPLE apply code style enforcement before commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --modified
+## EXAMPLE apply code style enforcement after commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --last
+---
+# This configuration requires clang-format version 8.0.0 exactly.
+BasedOnStyle: Mozilla
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+# clang 9.0 AllowAllArgumentsOnNextLine: true
+# clang 9.0 AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+# clang 9.0 AllowShortLambdasOnASingleLine: All
+# clang 9.0 features AllowShortIfStatementsOnASingleLine: Never
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  # clang 9.0 feature AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+## This is the big change from historical ITK formatting!
+# Historically ITK used a style similar to https://en.wikipedia.org/wiki/Indentation_style#Whitesmiths_style
+# with indented braces, and not indented code.  This style is very difficult to automatically
+# maintain with code beautification tools.  Not indenting braces is more common among
+# formatting tools.
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+#clang 6.0 BreakBeforeInheritanceComma: true
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+#clang 6.0 BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+## The following line allows larger lines in non-documentation code
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+## The following line allows larger lines in non-documentation code
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Middle
+ReflowComments:  true
+# We may want to sort the includes as a separate pass
+SortIncludes:    false
+# We may want to revisit this later
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+# SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        2
+UseTab:          Never
+...

--- a/Utilities/CookieCutter/{{cookiecutter.example_name}}/Code.cxx
+++ b/Utilities/CookieCutter/{{cookiecutter.example_name}}/Code.cxx
@@ -20,11 +20,12 @@
 #include "itkImageFileWriter.h"
 #include "itk{{ cookiecutter.class_name }}.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << " <OutputFileName>";
@@ -37,30 +38,32 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = float;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::{{ cookiecutter.class_name }}< ImageType, ImageType >;
+  // clang-format off
+  using FilterType = itk::{{cookiecutter.class_name}}<ImageType, ImageType>;
+  // clang-format on
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/Code.cxx
@@ -20,42 +20,43 @@
 #include "itkImageToVTKImageFilter.h"
 #include "itkRGBPixel.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
 
   constexpr unsigned int Dimension = 2;
 
   using PixelComponentType = unsigned char;
-  using PixelType = itk::RGBPixel< PixelComponentType >;
-  using ImageType = itk::Image< PixelType, Dimension  >;
+  using PixelType = itk::RGBPixel<PixelComponentType>;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::ImageToVTKImageFilter< ImageType >;
+  using FilterType = itk::ImageToVTKImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-   try
-     {
-     filter->Update();
-     }
-   catch( itk::ExceptionObject & error )
-     {
-     std::cerr << "Error: " << error << std::endl;
-     return EXIT_FAILURE;
-     }
+  try
+  {
+    filter->Update();
+  }
+  catch (itk::ExceptionObject & error)
+  {
+    std::cerr << "Error: " << error << std::endl;
+    return EXIT_FAILURE;
+  }
 
   vtkImageData * myvtkImageData = filter->GetOutput();
   myvtkImageData->Print(std::cout);

--- a/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/Code.cxx
@@ -19,41 +19,42 @@
 #include "itkImageFileReader.h"
 #include "itkImageToVTKImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::ImageToVTKImageFilter< ImageType >;
+  using FilterType = itk::ImageToVTKImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-   try
-     {
-     filter->Update();
-     }
-   catch( itk::ExceptionObject & error )
-     {
-     std::cerr << "Error: " << error << std::endl;
-     return EXIT_FAILURE;
-     }
+  try
+  {
+    filter->Update();
+  }
+  catch (itk::ExceptionObject & error)
+  {
+    std::cerr << "Error: " << error << std::endl;
+    return EXIT_FAILURE;
+  }
 
   vtkImageData * myvtkImageData = filter->GetOutput();
   myvtkImageData->Print(std::cout);

--- a/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/Code.cxx
@@ -21,44 +21,44 @@
 #include "itkVTKImageToImageFilter.h"
 #include "itkRGBPixel.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
 
   constexpr unsigned int Dimension = 2;
 
   using PixelComponentType = unsigned char;
-  using PixelType = itk::RGBPixel< PixelComponentType >;
-  using ImageType = itk::Image< PixelType, Dimension  >;
+  using PixelType = itk::RGBPixel<PixelComponentType>;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  vtkSmartPointer< vtkPNGReader > reader =
-    vtkSmartPointer< vtkPNGReader >::New();
-  reader->SetFileName( inputFileName );
+  vtkSmartPointer<vtkPNGReader> reader = vtkSmartPointer<vtkPNGReader>::New();
+  reader->SetFileName(inputFileName);
   reader->SetDataScalarTypeToUnsignedChar();
 
-  using FilterType = itk::VTKImageToImageFilter< ImageType >;
+  using FilterType = itk::VTKImageToImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-   try
-     {
-     reader->Update();
-     filter->Update();
-     }
-   catch( itk::ExceptionObject & error )
-     {
-     std::cerr << "Error: " << error << std::endl;
-     return EXIT_FAILURE;
-     }
+  try
+  {
+    reader->Update();
+    filter->Update();
+  }
+  catch (itk::ExceptionObject & error)
+  {
+    std::cerr << "Error: " << error << std::endl;
+    return EXIT_FAILURE;
+  }
 
   ImageType::ConstPointer myitkImage = filter->GetOutput();
   myitkImage->Print(std::cout);

--- a/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/Code.cxx
@@ -21,47 +21,46 @@
 #include "vtkImageMagnitude.h"
 #include "itkVTKImageToImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  vtkSmartPointer< vtkPNGReader > reader =
-    vtkSmartPointer< vtkPNGReader >::New();
-  reader->SetFileName( inputFileName );
+  vtkSmartPointer<vtkPNGReader> reader = vtkSmartPointer<vtkPNGReader>::New();
+  reader->SetFileName(inputFileName);
   reader->SetDataScalarTypeToUnsignedChar();
 
-  vtkSmartPointer< vtkImageMagnitude > magnitude =
-    vtkSmartPointer< vtkImageMagnitude >::New();
-  magnitude->SetInputConnection( reader->GetOutputPort() );
+  vtkSmartPointer<vtkImageMagnitude> magnitude = vtkSmartPointer<vtkImageMagnitude>::New();
+  magnitude->SetInputConnection(reader->GetOutputPort());
   magnitude->Update();
 
-  using FilterType = itk::VTKImageToImageFilter< ImageType >;
+  using FilterType = itk::VTKImageToImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( magnitude->GetOutput() );
+  filter->SetInput(magnitude->GetOutput());
 
-   try
-     {
-     filter->Update();
-     }
-   catch( itk::ExceptionObject & error )
-     {
-     std::cerr << "Error: " << error << std::endl;
-     return EXIT_FAILURE;
-     }
+  try
+  {
+    filter->Update();
+  }
+  catch (itk::ExceptionObject & error)
+  {
+    std::cerr << "Error: " << error << std::endl;
+    return EXIT_FAILURE;
+  }
 
   ImageType::ConstPointer myitkImage = filter->GetOutput();
   myitkImage->Print(std::cout);

--- a/src/Bridge/VtkGlue/VTKImageToITKImage/Code.cxx
+++ b/src/Bridge/VtkGlue/VTKImageToITKImage/Code.cxx
@@ -24,27 +24,26 @@
 #include <vtkImageLuminance.h>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-  if(argc < 2)
-    {
+  if (argc < 2)
+  {
     std::cerr << "Required: filename" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  vtkSmartPointer<vtkPNGReader> reader =
-    vtkSmartPointer<vtkPNGReader>::New();
+  vtkSmartPointer<vtkPNGReader> reader = vtkSmartPointer<vtkPNGReader>::New();
   reader->SetFileName(argv[1]);
   // reader->SetNumberOfScalarComponents(1); //doesn't seem to work - use ImageLuminance instead
   reader->Update();
 
 
   // Must convert image to grayscale because itkVTKImageToImageFilter only accepts single channel images
-  vtkSmartPointer<vtkImageLuminance> luminanceFilter =
-    vtkSmartPointer<vtkImageLuminance>::New();
+  vtkSmartPointer<vtkImageLuminance> luminanceFilter = vtkSmartPointer<vtkImageLuminance>::New();
   luminanceFilter->SetInputConnection(reader->GetOutputPort());
   luminanceFilter->Update();
 
@@ -54,7 +53,7 @@ int main(int argc, char*argv[])
 
   VTKImageToImageType::Pointer vtkImageToImageFilter = VTKImageToImageType::New();
   vtkImageToImageFilter->SetInput(luminanceFilter->GetOutput());
-  //vtkImageToImageFilter->SetInput(reader->GetOutput());
+  // vtkImageToImageFilter->SetInput(reader->GetOutput());
   vtkImageToImageFilter->Update();
 
   ImageType::Pointer image = ImageType::New();

--- a/src/Compatibility/Deprecated/ResampleRGBImage/Code.cxx
+++ b/src/Compatibility/Deprecated/ResampleRGBImage/Code.cxx
@@ -23,128 +23,120 @@
 #include "itkRGBPixel.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 typedef itk::Image<itk::RGBPixel<unsigned char>, 2> ImageType;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    double factor = 2.0;
+  double factor = 2.0;
 
-    // Create input image
-    ImageType::Pointer input;
-    if(argc < 2)
+  // Create input image
+  ImageType::Pointer input;
+  if (argc < 2)
+  {
+    input = ImageType::New();
+    CreateImage(input);
+  }
+  else
+  {
+    typedef itk::ImageFileReader<ImageType> ReaderType;
+    ReaderType::Pointer                     reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    input = reader->GetOutput();
+    if (argc > 2)
     {
-        input = ImageType::New();
-        CreateImage(input);
+      factor = std::stod(argv[2]);
     }
-    else
-    {
-        typedef itk::ImageFileReader<ImageType> ReaderType;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-        input = reader->GetOutput();
-        if (argc > 2)
-        {
-            factor = std::stod(argv[2]);
-        }
-    }
+  }
 
-    ImageType::SizeType inputSize = input->GetLargestPossibleRegion().GetSize();
+  ImageType::SizeType inputSize = input->GetLargestPossibleRegion().GetSize();
 
-    std::cout << "Input size: " << inputSize << std::endl;
+  std::cout << "Input size: " << inputSize << std::endl;
 
-    // Resize
-    ImageType::SizeType outputSize;
-    outputSize[0] = inputSize[0] * factor;
-    outputSize[1] = inputSize[1] * factor;
+  // Resize
+  ImageType::SizeType outputSize;
+  outputSize[0] = inputSize[0] * factor;
+  outputSize[1] = inputSize[1] * factor;
 
-    ImageType::SpacingType outputSpacing;
-    outputSpacing[0] = input->GetSpacing()[0] * (static_cast<double>(inputSize[0]) / static_cast<double>(outputSize[0]));
-    outputSpacing[1] = input->GetSpacing()[1] * (static_cast<double>(inputSize[1]) / static_cast<double>(outputSize[1]));
+  ImageType::SpacingType outputSpacing;
+  outputSpacing[0] = input->GetSpacing()[0] * (static_cast<double>(inputSize[0]) / static_cast<double>(outputSize[0]));
+  outputSpacing[1] = input->GetSpacing()[1] * (static_cast<double>(inputSize[1]) / static_cast<double>(outputSize[1]));
 
-    typedef itk::IdentityTransform<double, 2> TransformType;
-    typedef itk::VectorResampleImageFilter<ImageType, ImageType> ResampleImageFilterType;
-    ResampleImageFilterType::Pointer resample = ResampleImageFilterType::New();
-    resample->SetInput(input);
-    resample->SetSize(outputSize);
-    resample->SetOutputSpacing(outputSpacing);
-    resample->SetTransform(TransformType::New());
-    resample->UpdateLargestPossibleRegion();
+  typedef itk::IdentityTransform<double, 2>                    TransformType;
+  typedef itk::VectorResampleImageFilter<ImageType, ImageType> ResampleImageFilterType;
+  ResampleImageFilterType::Pointer                             resample = ResampleImageFilterType::New();
+  resample->SetInput(input);
+  resample->SetSize(outputSize);
+  resample->SetOutputSpacing(outputSpacing);
+  resample->SetTransform(TransformType::New());
+  resample->UpdateLargestPossibleRegion();
 
-    typedef itk::VectorNearestNeighborInterpolateImageFunction<
-            ImageType, double >  NearestInterpolatorType;
-    NearestInterpolatorType::Pointer nnInterpolator =
-            NearestInterpolatorType::New();
+  typedef itk::VectorNearestNeighborInterpolateImageFunction<ImageType, double> NearestInterpolatorType;
+  NearestInterpolatorType::Pointer nnInterpolator = NearestInterpolatorType::New();
 
-    ResampleImageFilterType::Pointer resampleNN =
-            ResampleImageFilterType::New();
-    resampleNN->SetInput(input);
-    resampleNN->SetSize(outputSize);
-    resampleNN->SetOutputSpacing(outputSpacing);
-    resampleNN->SetTransform(TransformType::New());
-    resampleNN->SetInterpolator(nnInterpolator);
-    resampleNN->UpdateLargestPossibleRegion();
+  ResampleImageFilterType::Pointer resampleNN = ResampleImageFilterType::New();
+  resampleNN->SetInput(input);
+  resampleNN->SetSize(outputSize);
+  resampleNN->SetOutputSpacing(outputSpacing);
+  resampleNN->SetTransform(TransformType::New());
+  resampleNN->SetInterpolator(nnInterpolator);
+  resampleNN->UpdateLargestPossibleRegion();
 
-    ImageType::Pointer output = resample->GetOutput();
+  ImageType::Pointer output = resample->GetOutput();
 
-    std::cout << "Output size: " << output->GetLargestPossibleRegion().GetSize() << std::endl;
+  std::cout << "Output size: " << output->GetLargestPossibleRegion().GetSize() << std::endl;
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
+  QuickView viewer;
 
-    viewer.AddRGBImage(input.GetPointer(),
-                       true,
-                       "Original");
-    viewer.AddRGBImage(output.GetPointer(),
-                       true,
-                       "Resampled");
+  viewer.AddRGBImage(input.GetPointer(), true, "Original");
+  viewer.AddRGBImage(output.GetPointer(), true, "Resampled");
 
-    viewer.AddRGBImage(resampleNN->GetOutput(),
-                       true,
-                       "Resampled NN");
+  viewer.AddRGBImage(resampleNN->GetOutput(), true, "Resampled NN");
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with 2 white regions
+  // Create a black image with 2 white regions
 
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(200);
+  ImageType::SizeType size;
+  size.Fill(200);
 
-    ImageType::RegionType region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer( itk::NumericTraits< ImageType::PixelType >::Zero);
+  ImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(itk::NumericTraits<ImageType::PixelType>::Zero);
 
-    ImageType::PixelType pixel;
-    pixel.SetRed(200);
-    pixel.SetGreen(50);
-    pixel.SetBlue(50);
+  ImageType::PixelType pixel;
+  pixel.SetRed(200);
+  pixel.SetGreen(50);
+  pixel.SetBlue(50);
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, pixel);
-
-        }
+      image->SetPixel(pixelIndex, pixel);
     }
-
+  }
 }

--- a/src/Core/Common/AddNoiseToBinaryImage/Code.cxx
+++ b/src/Core/Common/AddNoiseToBinaryImage/Code.cxx
@@ -21,55 +21,52 @@
 #include "itkImageFileWriter.h"
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
-int main (int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if (argc < 3)
+  if (argc < 3)
+  {
+    std::cerr << "Usage: " << argv[0] << " inputFile outputFile [percent]" << std::endl;
+    return EXIT_FAILURE;
+  }
+  double percent = .1;
+  if (argc > 3)
+  {
+    percent = std::stod(argv[3]);
+    if (percent >= 1.0)
     {
-        std::cerr << "Usage: " << argv[0]
-                  << " inputFile outputFile [percent]" << std::endl;
-        return EXIT_FAILURE;
+      percent /= 100.0;
     }
-    double percent = .1;
-    if (argc > 3)
-    {
-        percent = std::stod(argv[3]);
-        if (percent >= 1.0)
-        {
-            percent /= 100.0;
-        }
-    }
-    using ImageType = itk::Image<unsigned char, 2>;
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    using IteratorType = itk::ImageRandomNonRepeatingIteratorWithIndex<ImageType>;
-    using WriterType = itk::ImageFileWriter<ImageType>;
+  }
+  using ImageType = itk::Image<unsigned char, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using IteratorType = itk::ImageRandomNonRepeatingIteratorWithIndex<ImageType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
-    // Read the binary file
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( argv[1] );
-    reader->Update();
+  // Read the binary file
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    // At x% of the pixels, add a uniform random value between 0 and 255
-    IteratorType it(reader->GetOutput(),
-                    reader->GetOutput()->GetLargestPossibleRegion());
-    it.SetNumberOfSamples(reader->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() * percent);
-    std::cout << "Number of random samples: "
-              << it.GetNumberOfSamples() << std::endl;
-    using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
-    GeneratorType::Pointer random = GeneratorType::New();
+  // At x% of the pixels, add a uniform random value between 0 and 255
+  IteratorType it(reader->GetOutput(), reader->GetOutput()->GetLargestPossibleRegion());
+  it.SetNumberOfSamples(reader->GetOutput()->GetLargestPossibleRegion().GetNumberOfPixels() * percent);
+  std::cout << "Number of random samples: " << it.GetNumberOfSamples() << std::endl;
+  using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
+  GeneratorType::Pointer random = GeneratorType::New();
 
-    it.GoToBegin();
-    while(!it.IsAtEnd())
-    {
-        it.Set(random->GetUniformVariate(0, 255));
-        ++it;
-    }
+  it.GoToBegin();
+  while (!it.IsAtEnd())
+  {
+    it.Set(random->GetUniformVariate(0, 255));
+    ++it;
+  }
 
-    // Write the file
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName( argv[2] );
-    writer->SetInput(reader->GetOutput());
-    writer->Update();
+  // Write the file
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(argv[2]);
+  writer->SetInput(reader->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/AddOffsetToIndex/Code.cxx
+++ b/src/Core/Common/AddOffsetToIndex/Code.cxx
@@ -21,25 +21,26 @@
 
 #include <iostream>
 
-int main(int, char * [])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
 
-  itk::Index< Dimension > index;
-  index.Fill( 5 );
+  itk::Index<Dimension> index;
+  index.Fill(5);
 
-  itk::Offset< Dimension > offset;
-  offset.Fill( 1 );
+  itk::Offset<Dimension> offset;
+  offset.Fill(1);
 
-  std::cout << "index: "          << index << std::endl;
-  std::cout << "offset: "         << offset << std::endl;
+  std::cout << "index: " << index << std::endl;
+  std::cout << "offset: " << offset << std::endl;
   std::cout << "index + offset: " << index + offset << std::endl;
   std::cout << std::endl;
 
   offset[0] = -1;
 
-  std::cout << "index: "          << index << std::endl;
-  std::cout << "offset: "         << offset << std::endl;
+  std::cout << "index: " << index << std::endl;
+  std::cout << "offset: " << offset << std::endl;
   std::cout << "index + offset: " << index + offset << std::endl;
   std::cout << std::endl;
 

--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Code.cxx
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Code.cxx
@@ -20,12 +20,13 @@
 #include "itkRandomImageSource.h"
 #include "itkDerivativeImageFilter.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = float;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::SizeType smallSize;
   smallSize.Fill(10);
@@ -46,11 +47,10 @@ int main(int, char *[])
 
   std::cout << "Created random image." << std::endl;
 
-  using DerivativeImageFilterType = itk::DerivativeImageFilter<ImageType, ImageType >;
+  using DerivativeImageFilterType = itk::DerivativeImageFilter<ImageType, ImageType>;
 
-  DerivativeImageFilterType::Pointer derivativeFilter =
-    DerivativeImageFilterType::New();
-  derivativeFilter->SetInput( randomImageSource->GetOutput() );
+  DerivativeImageFilterType::Pointer derivativeFilter = DerivativeImageFilterType::New();
+  derivativeFilter->SetInput(randomImageSource->GetOutput());
   derivativeFilter->SetDirection(0); // "x" axis
   derivativeFilter->GetOutput()->SetRequestedRegion(smallSize);
   derivativeFilter->Update();

--- a/src/Core/Common/BoundingBoxOfAPointSet/Code.cxx
+++ b/src/Core/Common/BoundingBoxOfAPointSet/Code.cxx
@@ -20,32 +20,39 @@
 #include "itkPointSet.h"
 #include "itkBoundingBox.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   using CoordType = float;
   constexpr unsigned int Dimension = 3;
 
-  using PointSetType = itk::PointSet< CoordType, Dimension >;
+  using PointSetType = itk::PointSet<CoordType, Dimension>;
 
   using PointIdentifier = PointSetType::PointIdentifier;
   using PointType = PointSetType::PointType;
   using PointsContainerPointer = PointSetType::PointsContainerPointer;
 
-  PointSetType::Pointer   pointSet = PointSetType::New();
-  PointsContainerPointer  points = pointSet->GetPoints();
+  PointSetType::Pointer  pointSet = PointSetType::New();
+  PointsContainerPointer points = pointSet->GetPoints();
 
   // Create points
   PointType p0, p1, p2;
 
-  p0[0]=  0.0; p0[1]= 0.0; p0[2]= 0.0;
-  p1[0]=  0.1; p1[1]= 0.0; p1[2]= 0.0;
-  p2[0]=  0.0; p2[1]= 0.1; p2[2]= 0.0;
+  p0[0] = 0.0;
+  p0[1] = 0.0;
+  p0[2] = 0.0;
+  p1[0] = 0.1;
+  p1[1] = 0.0;
+  p1[2] = 0.0;
+  p2[0] = 0.0;
+  p2[1] = 0.1;
+  p2[2] = 0.0;
 
   points->InsertElement(0, p0);
   points->InsertElement(1, p1);
   points->InsertElement(2, p2);
 
-  using BoundingBoxType = itk::BoundingBox< PointIdentifier, Dimension, CoordType >;
+  using BoundingBoxType = itk::BoundingBox<PointIdentifier, Dimension, CoordType>;
 
   BoundingBoxType::Pointer boundingBox = BoundingBoxType::New();
   boundingBox->SetPoints(points);
@@ -53,8 +60,7 @@ int main(int, char*[])
 
   std::cout << "bounds: " << boundingBox->GetBounds() << std::endl;
   std::cout << "center: " << boundingBox->GetCenter() << std::endl;
-  std::cout << "diagonal length squared: "
-            << boundingBox->GetDiagonalLength2() << std::endl;
+  std::cout << "diagonal length squared: " << boundingBox->GetDiagonalLength2() << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/BresenhamLine/Code.cxx
+++ b/src/Core/Common/BresenhamLine/Code.cxx
@@ -23,10 +23,13 @@
 
 #include <iostream>
 
-static void Vector();
-static void Line();
+static void
+Vector();
+static void
+Line();
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
   Vector();
   Line();
@@ -34,7 +37,8 @@ int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
   return EXIT_SUCCESS;
 }
 
-void Vector()
+void
+Vector()
 {
 
   itk::BresenhamLine<2> line;
@@ -42,20 +46,20 @@ void Vector()
   itk::Vector<float, 2> v;
   v[0] = 1;
   v[1] = 1;
-  std::vector< itk::Offset<2> > offsets = line.BuildLine(v, 4);
+  std::vector<itk::Offset<2>> offsets = line.BuildLine(v, 4);
 
-  for(auto offset : offsets)
-    {
+  for (auto offset : offsets)
+  {
     std::cout << offset << std::endl;
-    }
-
+  }
 }
 
-void Line()
+void
+Line()
 {
 
   itk::BresenhamLine<2> line;
-  itk::Index<2> pixel0;
+  itk::Index<2>         pixel0;
   pixel0[0] = 0;
   pixel0[1] = 0;
 
@@ -63,12 +67,10 @@ void Line()
   pixel1[0] = 5;
   pixel1[1] = 5;
 
-  std::vector< itk::Index<2> > pixels = line.BuildLine(pixel0, pixel1);
+  std::vector<itk::Index<2>> pixels = line.BuildLine(pixel0, pixel1);
 
-  for(auto pixel : pixels)
-    {
+  for (auto pixel : pixels)
+  {
     std::cout << pixel << std::endl;
-    }
-
+  }
 }
-

--- a/src/Core/Common/BuildAHelloWorldProgram/Code.cxx
+++ b/src/Core/Common/BuildAHelloWorldProgram/Code.cxx
@@ -18,9 +18,10 @@
 
 #include "itkImage.h"
 
-int main( int, char* [] )
+int
+main(int, char *[])
 {
-  using ImageType = itk::Image< unsigned short, 3 >;
+  using ImageType = itk::Image<unsigned short, 3>;
   ImageType::Pointer image = ImageType::New();
 
   std::cout << "ITK Hello World!" << std::endl;

--- a/src/Core/Common/CastVectorImageToAnotherType/Code.cxx
+++ b/src/Core/Common/CastVectorImageToAnotherType/Code.cxx
@@ -18,17 +18,18 @@
 #include "itkVectorImage.h"
 #include "itkCastImageFilter.h"
 
-int main(int  /*argc*/, char * /*argv*/[])
+int
+main(int /*argc*/, char * /*argv*/[])
 {
-    typedef itk::VectorImage<unsigned char, 2>  UnsignedCharVectorImageType;
-    typedef itk::VectorImage<float, 2>  FloatVectorImageType;
+  typedef itk::VectorImage<unsigned char, 2> UnsignedCharVectorImageType;
+  typedef itk::VectorImage<float, 2>         FloatVectorImageType;
 
-    FloatVectorImageType::Pointer image = FloatVectorImageType::New();
+  FloatVectorImageType::Pointer image = FloatVectorImageType::New();
 
-    typedef itk::CastImageFilter< FloatVectorImageType, UnsignedCharVectorImageType > CastImageFilterType;
-    CastImageFilterType::Pointer vectorCastImageFilter = CastImageFilterType::New();
-    vectorCastImageFilter->SetInput(image);
-    vectorCastImageFilter->Update();
+  typedef itk::CastImageFilter<FloatVectorImageType, UnsignedCharVectorImageType> CastImageFilterType;
+  CastImageFilterType::Pointer vectorCastImageFilter = CastImageFilterType::New();
+  vectorCastImageFilter->SetInput(image);
+  vectorCastImageFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/CheckIfModuleIsPresent/Code.cxx
+++ b/src/Core/Common/CheckIfModuleIsPresent/Code.cxx
@@ -19,9 +19,9 @@
 
 #include <iostream>
 
-int main(int  /*argc*/, char * /*argv*/[])
+int
+main(int /*argc*/, char * /*argv*/[])
 {
 
-    return 0;
+  return 0;
 }
-

--- a/src/Core/Common/ComputeTimeBetweenPoints/Code.cxx
+++ b/src/Core/Common/ComputeTimeBetweenPoints/Code.cxx
@@ -22,16 +22,18 @@
 #include <iostream>
 #include <string>
 
-void LongFunction()
+void
+LongFunction()
 {
-  for(int i = 0; i < itk::NumericTraits< int >::max() / 100; i++)
-    {
+  for (int i = 0; i < itk::NumericTraits<int>::max() / 100; i++)
+  {
     double a = 0;
     (void)a;
-    }
+  }
 }
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   itk::TimeProbe clock;
 

--- a/src/Core/Common/ConceptCheckingIsFloatingPoint/Code.cxx
+++ b/src/Core/Common/ConceptCheckingIsFloatingPoint/Code.cxx
@@ -19,22 +19,24 @@
 #include "itkImage.h"
 #include "itkConceptChecking.h"
 
-template< typename TImage >
-void IsPixelTypeFloatingPoint(const TImage* const)
+template <typename TImage>
+void
+IsPixelTypeFloatingPoint(const TImage * const)
 {
-  itkConceptMacro( nameOfCheck, ( itk::Concept::IsFloatingPoint< typename TImage::PixelType > ) );
+  itkConceptMacro(nameOfCheck, (itk::Concept::IsFloatingPoint<typename TImage::PixelType>));
 }
 
-int main( int, char* [] )
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
-  using FloatImageType = itk::Image< float, Dimension >;
+  using FloatImageType = itk::Image<float, Dimension>;
   FloatImageType::Pointer f = FloatImageType::New();
-  IsPixelTypeFloatingPoint( f.GetPointer() );
+  IsPixelTypeFloatingPoint(f.GetPointer());
 
-  using DoubleImageType = itk::Image< double, Dimension >;
+  using DoubleImageType = itk::Image<double, Dimension>;
   DoubleImageType::Pointer d = DoubleImageType::New();
-  IsPixelTypeFloatingPoint( d.GetPointer() );
+  IsPixelTypeFloatingPoint(d.GetPointer());
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ConceptCheckingIsSameDimension/Code.cxx
+++ b/src/Core/Common/ConceptCheckingIsSameDimension/Code.cxx
@@ -19,23 +19,25 @@
 #include "itkImage.h"
 #include "itkConceptChecking.h"
 
-template< typename TImage, unsigned int VDimension >
-void CheckIfDimensionIsTheSame( const TImage* const )
+template <typename TImage, unsigned int VDimension>
+void
+CheckIfDimensionIsTheSame(const TImage * const)
 {
-  itkConceptMacro( nameOfCheck, ( itk::Concept::SameDimension< TImage::ImageDimension, VDimension > ) );
+  itkConceptMacro(nameOfCheck, (itk::Concept::SameDimension<TImage::ImageDimension, VDimension>));
 }
-int main( int, char* [] )
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
   ImageType::Pointer image = ImageType::New();
 
-  CheckIfDimensionIsTheSame< ImageType, 2 >( image.GetPointer() );
+  CheckIfDimensionIsTheSame<ImageType, 2>(image.GetPointer());
 
-  using ImageType2 = itk::Image< PixelType, Dimension >;
+  using ImageType2 = itk::Image<PixelType, Dimension>;
 
-  CheckIfDimensionIsTheSame< ImageType, ImageType2::ImageDimension >( image.GetPointer() );
+  CheckIfDimensionIsTheSame<ImageType, ImageType2::ImageDimension>(image.GetPointer());
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ConceptCheckingIsSameType/Code.cxx
+++ b/src/Core/Common/ConceptCheckingIsSameType/Code.cxx
@@ -19,23 +19,25 @@
 #include "itkImage.h"
 #include "itkConceptChecking.h"
 
-template< typename TImage, class TValue >
-void CheckIfPixelTypeIsTheSameAs( const TImage* const )
+template <typename TImage, class TValue>
+void
+CheckIfPixelTypeIsTheSameAs(const TImage * const)
 {
-  itkConceptMacro( nameOfCheck, ( itk::Concept::SameType< typename TImage::PixelType, TValue > ) );
+  itkConceptMacro(nameOfCheck, (itk::Concept::SameType<typename TImage::PixelType, TValue>));
 }
-int main( int, char* [] )
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
   ImageType::Pointer image = ImageType::New();
 
-  CheckIfPixelTypeIsTheSameAs< ImageType, unsigned char >( image.GetPointer() );
+  CheckIfPixelTypeIsTheSameAs<ImageType, unsigned char>(image.GetPointer());
 
-  using ImageType2 = itk::Image< PixelType, Dimension >;
+  using ImageType2 = itk::Image<PixelType, Dimension>;
 
-  CheckIfPixelTypeIsTheSameAs< ImageType, ImageType2::PixelType >( image.GetPointer() );
+  CheckIfPixelTypeIsTheSameAs<ImageType, ImageType2::PixelType>(image.GetPointer());
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ConvertArrayToImage/Code.cxx
+++ b/src/Core/Common/ConvertArrayToImage/Code.cxx
@@ -20,78 +20,78 @@
 
 #include "itkImageFileWriter.h"
 
-int main(int, char * [])
+int
+main(int, char *[])
 {
-    using PixelType = unsigned char;
-    constexpr unsigned int Dimension = 3;
-    using ImageType = itk::Image< PixelType, Dimension >;
-    using ImportFilterType = itk::ImportImageFilter< PixelType, Dimension >;
+  using PixelType = unsigned char;
+  constexpr unsigned int Dimension = 3;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ImportFilterType = itk::ImportImageFilter<PixelType, Dimension>;
 
-    ImportFilterType::Pointer importFilter = ImportFilterType::New();
+  ImportFilterType::Pointer importFilter = ImportFilterType::New();
 
-    ImportFilterType::SizeType  size;
+  ImportFilterType::SizeType size;
 
-    size[0]  = 200;  // size along X
-    size[1]  = 200;  // size along Y
-    size[2]  = 200;  // size along Z
+  size[0] = 200; // size along X
+  size[1] = 200; // size along Y
+  size[2] = 200; // size along Z
 
-    ImportFilterType::IndexType start;
-    start.Fill( 0 );
+  ImportFilterType::IndexType start;
+  start.Fill(0);
 
-    ImportFilterType::RegionType region;
-    region.SetIndex( start );
-    region.SetSize(  size  );
+  ImportFilterType::RegionType region;
+  region.SetIndex(start);
+  region.SetSize(size);
 
-    importFilter->SetRegion( region );
+  importFilter->SetRegion(region);
 
-    double origin[ Dimension ];
-    origin[0] = 0.0;    // X coordinate
-    origin[1] = 0.0;    // Y coordinate
-    origin[2] = 0.0;    // Z coordinate
+  double origin[Dimension];
+  origin[0] = 0.0; // X coordinate
+  origin[1] = 0.0; // Y coordinate
+  origin[2] = 0.0; // Z coordinate
 
-    importFilter->SetOrigin( origin );
+  importFilter->SetOrigin(origin);
 
-    double spacing[ Dimension ];
-    spacing[0] = 1.0;    // along X direction
-    spacing[1] = 1.0;    // along Y direction
-    spacing[2] = 1.0;    // along Z direction
+  double spacing[Dimension];
+  spacing[0] = 1.0; // along X direction
+  spacing[1] = 1.0; // along Y direction
+  spacing[2] = 1.0; // along Z direction
 
-    importFilter->SetSpacing( spacing );
+  importFilter->SetSpacing(spacing);
 
-    const unsigned int numberOfPixels =  size[0] * size[1] * size[2];
-    auto * localBuffer = new PixelType[ numberOfPixels ];
+  const unsigned int numberOfPixels = size[0] * size[1] * size[2];
+  auto *             localBuffer = new PixelType[numberOfPixels];
 
-    constexpr double radius = 80.0;
+  constexpr double radius = 80.0;
 
-    const double radius2 = radius * radius;
-    PixelType * it = localBuffer;
+  const double radius2 = radius * radius;
+  PixelType *  it = localBuffer;
 
-    for(unsigned int z=0; z < size[2]; z++)
+  for (unsigned int z = 0; z < size[2]; z++)
+  {
+    const double dz = static_cast<double>(z) - static_cast<double>(size[2]) / 2.0;
+    for (unsigned int y = 0; y < size[1]; y++)
     {
-        const double dz = static_cast<double>( z ) - static_cast<double>(size[2])/2.0;
-        for(unsigned int y=0; y < size[1]; y++)
-        {
-            const double dy = static_cast<double>( y ) - static_cast<double>(size[1])/2.0;
-            for(unsigned int x=0; x < size[0]; x++)
-            {
-                const double dx = static_cast<double>( x ) - static_cast<double>(size[0])/2.0;
-                const double d2 = dx*dx + dy*dy + dz*dz;
-                *it++ = ( d2 < radius2 ) ? 255 : 0;
-            }
-        }
+      const double dy = static_cast<double>(y) - static_cast<double>(size[1]) / 2.0;
+      for (unsigned int x = 0; x < size[0]; x++)
+      {
+        const double dx = static_cast<double>(x) - static_cast<double>(size[0]) / 2.0;
+        const double d2 = dx * dx + dy * dy + dz * dz;
+        *it++ = (d2 < radius2) ? 255 : 0;
+      }
     }
+  }
 
-    const bool importImageFilterWillOwnTheBuffer = true;
-    importFilter->SetImportPointer( localBuffer, numberOfPixels,
-                                    importImageFilterWillOwnTheBuffer );
+  const bool importImageFilterWillOwnTheBuffer = true;
+  importFilter->SetImportPointer(localBuffer, numberOfPixels, importImageFilterWillOwnTheBuffer);
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
 
-    writer->SetFileName("test.png");
+  writer->SetFileName("test.png");
 
-    writer->SetInput(  importFilter->GetOutput()  );
-    writer->Update();
+  writer->SetInput(importFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/CovariantVectorDotProduct/Code.cxx
+++ b/src/Core/Common/CovariantVectorDotProduct/Code.cxx
@@ -18,12 +18,13 @@
 
 #include "itkCovariantVector.h"
 
-int main( int, char* [] )
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
 
-  using VectorType = itk::CovariantVector< CoordType, Dimension >;
+  using VectorType = itk::CovariantVector<CoordType, Dimension>;
 
   VectorType u;
   u[0] = -1.;
@@ -38,7 +39,7 @@ int main( int, char* [] )
   std::cout << "u :" << u << std::endl;
   std::cout << "v :" << v << std::endl;
   std::cout << "DotProduct( u, v ) = " << u * v << std::endl;
-  std::cout << "u - ( u * v ) * v = " << u - ( u * v ) * v << std::endl;
+  std::cout << "u - ( u * v ) * v = " << u - (u * v) * v << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/CovariantVectorNorm/Code.cxx
+++ b/src/Core/Common/CovariantVectorNorm/Code.cxx
@@ -18,7 +18,8 @@
 
 #include "itkCovariantVector.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   using VectorType = itk::CovariantVector<double, 3>;
   VectorType v;
@@ -42,20 +43,20 @@ int main(int, char*[])
   std::cout << "v: " << v << std::endl;
 
   // another way to normalize
-  if( vnorm != 0. )
+  if (vnorm != 0.)
+  {
+    for (unsigned int i = 0; i < u.GetNumberOfComponents(); i++)
     {
-    for( unsigned int i = 0; i < u.GetNumberOfComponents(); i++ )
-      {
       u[i] /= vnorm;
-      }
     }
+  }
 
   std::cout << "u: " << u << std::endl;
 
-  if( ( u - v ).GetNorm() != 0. )
-    {
+  if ((u - v).GetNorm() != 0.)
+  {
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
+++ b/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
@@ -18,31 +18,31 @@
 
 #include <itkBackwardDifferenceOperator.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   using PixelType = float;
   constexpr unsigned int Dimension = 2;
 
-  using BackwardDifferenceOperatorType = itk::BackwardDifferenceOperator< PixelType, Dimension >;
+  using BackwardDifferenceOperatorType = itk::BackwardDifferenceOperator<PixelType, Dimension>;
   BackwardDifferenceOperatorType backwardDifferenceOperator;
 
   // Create the operator for the X axis derivative
   backwardDifferenceOperator.SetDirection(0);
 
-  itk::Size< Dimension > radius;
+  itk::Size<Dimension> radius;
   radius.Fill(1);
 
   backwardDifferenceOperator.CreateToRadius(radius);
 
-  std::cout << "Size: " << backwardDifferenceOperator.GetSize()
-            << std::endl;
+  std::cout << "Size: " << backwardDifferenceOperator.GetSize() << std::endl;
 
   std::cout << backwardDifferenceOperator << std::endl;
 
-  for(unsigned int i = 0; i < 9; i++)
-    {
-    std::cout << backwardDifferenceOperator.GetOffset(i) << " "
-              << backwardDifferenceOperator.GetElement(i) << std::endl;
-    }
+  for (unsigned int i = 0; i < 9; i++)
+  {
+    std::cout << backwardDifferenceOperator.GetOffset(i) << " " << backwardDifferenceOperator.GetElement(i)
+              << std::endl;
+  }
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/CreateACovariantVector/Code.cxx
+++ b/src/Core/Common/CreateACovariantVector/Code.cxx
@@ -18,12 +18,13 @@
 
 #include "itkCovariantVector.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
 
-  using VectorType = itk::CovariantVector< CoordType, Dimension >;
+  using VectorType = itk::CovariantVector<CoordType, Dimension>;
   VectorType v;
   v[0] = 1.0;
   v[1] = 2.0;

--- a/src/Core/Common/CreateAFixedArray/Code.cxx
+++ b/src/Core/Common/CreateAFixedArray/Code.cxx
@@ -18,7 +18,8 @@
 
 #include "itkFixedArray.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   itk::FixedArray<double, 2> array;
   array[0] = 0;

--- a/src/Core/Common/CreateAIndex/Code.cxx
+++ b/src/Core/Common/CreateAIndex/Code.cxx
@@ -18,11 +18,12 @@
 
 #include "itkIndex.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
 
-  using IndexType = itk::Index< Dimension >;
+  using IndexType = itk::Index<Dimension>;
 
   IndexType index;
 

--- a/src/Core/Common/CreateAPointSet/Code.cxx
+++ b/src/Core/Common/CreateAPointSet/Code.cxx
@@ -19,24 +19,31 @@
 #include "itkPoint.h"
 #include "itkPointSet.h"
 
-int main(int, char* [])
+int
+main(int, char *[])
 {
   using PixelType = float;
   constexpr unsigned int Dimension = 3;
 
-  using PointSetType = itk::PointSet< PixelType, Dimension >;
-  PointSetType::Pointer  PointSet = PointSetType::New();
+  using PointSetType = itk::PointSet<PixelType, Dimension>;
+  PointSetType::Pointer PointSet = PointSetType::New();
 
   using PointsContainerPointer = PointSetType::PointsContainerPointer;
-  PointsContainerPointer  points = PointSet->GetPoints();
+  PointsContainerPointer points = PointSet->GetPoints();
 
   // Create points
   using PointType = PointSetType::PointType;
   PointType p0, p1, p2;
 
-  p0[0]=  0.0; p0[1]= 0.0; p0[2]= 0.0;
-  p1[0]=  0.1; p1[1]= 0.0; p1[2]= 0.0;
-  p2[0]=  0.0; p2[1]= 0.1; p2[2]= 0.0;
+  p0[0] = 0.0;
+  p0[1] = 0.0;
+  p0[2] = 0.0;
+  p1[0] = 0.1;
+  p1[1] = 0.0;
+  p1[2] = 0.0;
+  p2[0] = 0.0;
+  p2[1] = 0.1;
+  p2[2] = 0.0;
 
   points->InsertElement(0, p0);
   points->InsertElement(1, p1);

--- a/src/Core/Common/CreateASize/Code.cxx
+++ b/src/Core/Common/CreateASize/Code.cxx
@@ -18,10 +18,11 @@
 
 #include "itkSize.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
-  itk::Size< Dimension > size;
+  itk::Size<Dimension>   size;
 
   // Method 1
   // set both components (size[0] and size[1]) to the same value

--- a/src/Core/Common/CreateAVector/Code.cxx
+++ b/src/Core/Common/CreateAVector/Code.cxx
@@ -18,7 +18,8 @@
 
 #include "itkVector.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;

--- a/src/Core/Common/CreateAnImage/Code.cxx
+++ b/src/Core/Common/CreateAnImage/Code.cxx
@@ -18,26 +18,27 @@
 
 #include "itkImage.h"
 
-int main( int , char* [] )
+int
+main(int, char *[])
 {
-  using ImageType = itk::Image< unsigned char, 3 >;
+  using ImageType = itk::Image<unsigned char, 3>;
   ImageType::Pointer image = ImageType::New();
 
   ImageType::IndexType start;
-  start[0] = 0;  // first index on X
-  start[1] = 0;  // first index on Y
-  start[2] = 0;  // first index on Z
+  start[0] = 0; // first index on X
+  start[1] = 0; // first index on Y
+  start[2] = 0; // first index on Z
 
-  ImageType::SizeType  size;
-  size[0] = 200;  // size along X
-  size[1] = 200;  // size along Y
-  size[2] = 200;  // size along Z
+  ImageType::SizeType size;
+  size[0] = 200; // size along X
+  size[1] = 200; // size along Y
+  size[2] = 200; // size along Z
 
   ImageType::RegionType region;
-  region.SetSize( size );
-  region.SetIndex( start );
+  region.SetSize(size);
+  region.SetIndex(start);
 
-  image->SetRegions( region );
+  image->SetRegions(region);
   image->Allocate();
 
   std::cout << image << std::endl;

--- a/src/Core/Common/CreateAnImageOfVectors/Code.cxx
+++ b/src/Core/Common/CreateAnImageOfVectors/Code.cxx
@@ -19,51 +19,51 @@
 #include "itkVector.h"
 #include "itkImage.h"
 
-int main( int , char* [] )
+int
+main(int, char *[])
 {
-  using PixelType = itk::Vector< float, 3 >;
-  using ImageType = itk::Image< PixelType, 3 >;
+  using PixelType = itk::Vector<float, 3>;
+  using ImageType = itk::Image<PixelType, 3>;
 
   // Then the image object can be created
   ImageType::Pointer image = ImageType::New();
 
   // The image region should be initialized
-  const ImageType::IndexType start = {{0,0,0}}; //First index at {X,Y,Z}
-  const ImageType::SizeType  size = {{200,200,200}}; //Size of {X,Y,Z}
+  const ImageType::IndexType start = { { 0, 0, 0 } };      // First index at {X,Y,Z}
+  const ImageType::SizeType  size = { { 200, 200, 200 } }; // Size of {X,Y,Z}
 
   ImageType::RegionType region;
-  region.SetSize( size );
-  region.SetIndex( start );
+  region.SetSize(size);
+  region.SetIndex(start);
 
   // Pixel data is allocated
-  image->SetRegions( region );
+  image->SetRegions(region);
   image->Allocate();
 
   // The image buffer is initialized to a particular value
-  ImageType::PixelType  initialValue;
+  ImageType::PixelType initialValue;
 
   // A vector can initialize all its components to the
   // same value by using the Fill() method.
-  initialValue.Fill( 0.0 );
+  initialValue.Fill(0.0);
 
   // Now the image buffer can be initialized with this
   // vector value.
-  image->FillBuffer( initialValue );
+  image->FillBuffer(initialValue);
 
-  const ImageType::IndexType pixelIndex = {{27,29,37}}; //Position {X,Y,Z}
+  const ImageType::IndexType pixelIndex = { { 27, 29, 37 } }; // Position {X,Y,Z}
 
 
-  ImageType::PixelType   pixelValue;
-  pixelValue[0] =  1.345;   // x component
-  pixelValue[1] =  6.841;   // y component
-  pixelValue[2] =  3.295;   // x component
+  ImageType::PixelType pixelValue;
+  pixelValue[0] = 1.345; // x component
+  pixelValue[1] = 6.841; // y component
+  pixelValue[2] = 3.295; // x component
 
-  image->SetPixel(   pixelIndex,   pixelValue  );
+  image->SetPixel(pixelIndex, pixelValue);
 
-  ImageType::PixelType value = image->GetPixel( pixelIndex );
+  ImageType::PixelType value = image->GetPixel(pixelIndex);
 
   std::cout << value << std::endl;
-
 
 
   return EXIT_SUCCESS;

--- a/src/Core/Common/CreateAnImageRegion/Code.cxx
+++ b/src/Core/Common/CreateAnImageRegion/Code.cxx
@@ -18,18 +18,19 @@
 
 #include "itkImageRegion.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
 
-  using RegionType = itk::ImageRegion< Dimension >;
+  using RegionType = itk::ImageRegion<Dimension>;
   RegionType::SizeType size;
   size.Fill(3);
 
   RegionType::IndexType index;
   index.Fill(1);
 
-  RegionType region( index, size );
+  RegionType region(index, size);
 
   std::cout << region << std::endl;
 

--- a/src/Core/Common/CreateAnRGBImage/Code.cxx
+++ b/src/Core/Common/CreateAnRGBImage/Code.cxx
@@ -19,12 +19,13 @@
 #include "itkImage.h"
 #include "itkRGBPixel.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
-  using RGBPixelType = itk::RGBPixel< unsigned char >;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
 
-  using RGBImageType = itk::Image< RGBPixelType, Dimension >;
+  using RGBImageType = itk::Image<RGBPixelType, Dimension>;
   RGBImageType::Pointer image = RGBImageType::New();
 
   return EXIT_SUCCESS;

--- a/src/Core/Common/CreateAnother/Code.cxx
+++ b/src/Core/Common/CreateAnother/Code.cxx
@@ -19,8 +19,9 @@
 #include "itkAbsImageFilter.h"
 #include "itkImage.h"
 
-template< class TImage >
-void CreateImage(typename TImage::Pointer image)
+template <class TImage>
+void
+CreateImage(typename TImage::Pointer image)
 {
   using ImageType = TImage;
   typename ImageType::IndexType start;
@@ -29,32 +30,32 @@ void CreateImage(typename TImage::Pointer image)
   typename ImageType::SizeType size;
   size.Fill(2);
 
-  typename ImageType::RegionType region(start,size);
+  typename ImageType::RegionType region(start, size);
 
   image->SetRegions(region);
   image->Allocate();
-  image->FillBuffer( -2 );
+  image->FillBuffer(-2);
 }
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = double;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   using FilterType = itk::AbsImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  FilterType::Pointer filter2 =
-    dynamic_cast<FilterType*>(filter->CreateAnother().GetPointer());
+  FilterType::Pointer filter2 = dynamic_cast<FilterType *>(filter->CreateAnother().GetPointer());
 
   ImageType::Pointer image = ImageType::New();
-  CreateImage< ImageType >(image);
+  CreateImage<ImageType>(image);
 
   filter2->SetInput(image);
   filter2->Update();
 
-  itk::Index< Dimension > index;
+  itk::Index<Dimension> index;
   index.Fill(0);
 
   std::cout << filter2->GetOutput()->GetPixel(index) << std::endl;

--- a/src/Core/Common/CreateAnotherInstanceOfAnImage/Code.cxx
+++ b/src/Core/Common/CreateAnotherInstanceOfAnImage/Code.cxx
@@ -17,38 +17,43 @@
  *=========================================================================*/
 #include "itkImage.h"
 
-using FloatScalarImageType = itk::Image<float,2>;
+using FloatScalarImageType = itk::Image<float, 2>;
 
-itk::ImageBase<2>::Pointer CreateImageWithSameType(const itk::ImageBase<2>* input);
-void OutputImageType(const itk::ImageBase<2>* input);
+itk::ImageBase<2>::Pointer
+CreateImageWithSameType(const itk::ImageBase<2> * input);
+void
+OutputImageType(const itk::ImageBase<2> * input);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    FloatScalarImageType::Pointer floatImage = FloatScalarImageType::New();
-    itk::ImageBase<2>::Pointer floatCopy = CreateImageWithSameType(floatImage);
-    OutputImageType(floatCopy);
+  FloatScalarImageType::Pointer floatImage = FloatScalarImageType::New();
+  itk::ImageBase<2>::Pointer    floatCopy = CreateImageWithSameType(floatImage);
+  OutputImageType(floatCopy);
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-itk::ImageBase<2>::Pointer CreateImageWithSameType(const itk::ImageBase<2>* input)
+itk::ImageBase<2>::Pointer
+CreateImageWithSameType(const itk::ImageBase<2> * input)
 {
-    OutputImageType(input);
-    itk::LightObject::Pointer objectCopyLight = input->CreateAnother();
+  OutputImageType(input);
+  itk::LightObject::Pointer objectCopyLight = input->CreateAnother();
 
-    itk::ImageBase<2>::Pointer objectCopy = dynamic_cast<itk::ImageBase<2>*>(objectCopyLight.GetPointer());
-    OutputImageType(objectCopy);
-    return objectCopy;
+  itk::ImageBase<2>::Pointer objectCopy = dynamic_cast<itk::ImageBase<2> *>(objectCopyLight.GetPointer());
+  OutputImageType(objectCopy);
+  return objectCopy;
 }
 
-void OutputImageType(const itk::ImageBase<2>* input)
+void
+OutputImageType(const itk::ImageBase<2> * input)
 {
-    if(dynamic_cast<const FloatScalarImageType*>(input))
-    {
-        std::cout << "Image type FloatScalarImageType" << std::endl;
-    }
-    else
-    {
-        std::cout << "Image is Invalid type!" << std::endl;
-    }
+  if (dynamic_cast<const FloatScalarImageType *>(input))
+  {
+    std::cout << "Image type FloatScalarImageType" << std::endl;
+  }
+  else
+  {
+    std::cout << "Image is Invalid type!" << std::endl;
+  }
 }

--- a/src/Core/Common/CreateDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateDerivativeKernel/Code.cxx
@@ -17,23 +17,23 @@
  *=========================================================================*/
 #include <itkDerivativeOperator.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
-    DerivativeOperatorType derivativeOperator;
-    derivativeOperator.SetDirection(0); // Create the operator for the X axis derivative
-    itk::Size<2> radius;
-    radius.Fill(1);
-    derivativeOperator.CreateToRadius(radius);
+  using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
+  DerivativeOperatorType derivativeOperator;
+  derivativeOperator.SetDirection(0); // Create the operator for the X axis derivative
+  itk::Size<2> radius;
+  radius.Fill(1);
+  derivativeOperator.CreateToRadius(radius);
 
-    std::cout << "Size: " << derivativeOperator.GetSize() << std::endl;
+  std::cout << "Size: " << derivativeOperator.GetSize() << std::endl;
 
-    std::cout << derivativeOperator << std::endl;
+  std::cout << derivativeOperator << std::endl;
 
-    for(unsigned int i = 0; i < 9; i++)
-    {
-        std::cout << derivativeOperator.GetOffset(i) << " " << derivativeOperator.GetElement(i) << std::endl;
-    }
-    return EXIT_SUCCESS;
+  for (unsigned int i = 0; i < 9; i++)
+  {
+    std::cout << derivativeOperator.GetOffset(i) << " " << derivativeOperator.GetElement(i) << std::endl;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
+++ b/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
@@ -17,23 +17,23 @@
  *=========================================================================*/
 #include <itkForwardDifferenceOperator.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using ForwardDifferenceOperatorType = itk::ForwardDifferenceOperator<float, 2>;
-    ForwardDifferenceOperatorType forwardDifferenceOperator;
-    forwardDifferenceOperator.SetDirection(0); // Create the operator for the X axis derivative
-    itk::Size<2> radius;
-    radius.Fill(1);
-    forwardDifferenceOperator.CreateToRadius(radius);
+  using ForwardDifferenceOperatorType = itk::ForwardDifferenceOperator<float, 2>;
+  ForwardDifferenceOperatorType forwardDifferenceOperator;
+  forwardDifferenceOperator.SetDirection(0); // Create the operator for the X axis derivative
+  itk::Size<2> radius;
+  radius.Fill(1);
+  forwardDifferenceOperator.CreateToRadius(radius);
 
-    std::cout << "Size: " << forwardDifferenceOperator.GetSize() << std::endl;
+  std::cout << "Size: " << forwardDifferenceOperator.GetSize() << std::endl;
 
-    std::cout << forwardDifferenceOperator << std::endl;
+  std::cout << forwardDifferenceOperator << std::endl;
 
-    for(unsigned int i = 0; i < 9; i++)
-    {
-        std::cout << forwardDifferenceOperator.GetOffset(i) << " " << forwardDifferenceOperator.GetElement(i) << std::endl;
-    }
-    return EXIT_SUCCESS;
+  for (unsigned int i = 0; i < 9; i++)
+  {
+    std::cout << forwardDifferenceOperator.GetOffset(i) << " " << forwardDifferenceOperator.GetElement(i) << std::endl;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
@@ -17,23 +17,24 @@
  *=========================================================================*/
 #include <itkGaussianDerivativeOperator.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using GaussianDerivativeOperatorType = itk::GaussianDerivativeOperator<float, 2>;
-    GaussianDerivativeOperatorType gaussianDerivativeOperator;
-    gaussianDerivativeOperator.SetDirection(0); // Create the operator for the X axis derivative
-    itk::Size<2> radius;
-    radius.Fill(1);
-    gaussianDerivativeOperator.CreateToRadius(radius);
+  using GaussianDerivativeOperatorType = itk::GaussianDerivativeOperator<float, 2>;
+  GaussianDerivativeOperatorType gaussianDerivativeOperator;
+  gaussianDerivativeOperator.SetDirection(0); // Create the operator for the X axis derivative
+  itk::Size<2> radius;
+  radius.Fill(1);
+  gaussianDerivativeOperator.CreateToRadius(radius);
 
-    std::cout << "Size: " << gaussianDerivativeOperator.GetSize() << std::endl;
+  std::cout << "Size: " << gaussianDerivativeOperator.GetSize() << std::endl;
 
-    std::cout << gaussianDerivativeOperator << std::endl;
+  std::cout << gaussianDerivativeOperator << std::endl;
 
-    for(unsigned int i = 0; i < 9; i++)
-    {
-        std::cout << gaussianDerivativeOperator.GetOffset(i) << " " << gaussianDerivativeOperator.GetElement(i) << std::endl;
-    }
-    return EXIT_SUCCESS;
+  for (unsigned int i = 0; i < 9; i++)
+  {
+    std::cout << gaussianDerivativeOperator.GetOffset(i) << " " << gaussianDerivativeOperator.GetElement(i)
+              << std::endl;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CreateGaussianKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianKernel/Code.cxx
@@ -17,23 +17,23 @@
  *=========================================================================*/
 #include <itkGaussianOperator.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using GaussianOperatorType = itk::GaussianOperator<float, 2>;
-    GaussianOperatorType gaussianOperator;
-    gaussianOperator.SetDirection(0); // Create the operator for the X axis derivative
-    itk::Size<2> radius;
-    radius.Fill(1);
-    gaussianOperator.CreateToRadius(radius);
+  using GaussianOperatorType = itk::GaussianOperator<float, 2>;
+  GaussianOperatorType gaussianOperator;
+  gaussianOperator.SetDirection(0); // Create the operator for the X axis derivative
+  itk::Size<2> radius;
+  radius.Fill(1);
+  gaussianOperator.CreateToRadius(radius);
 
-    std::cout << "Size: " << gaussianOperator.GetSize() << std::endl;
+  std::cout << "Size: " << gaussianOperator.GetSize() << std::endl;
 
-    std::cout << gaussianOperator << std::endl;
+  std::cout << gaussianOperator << std::endl;
 
-    for(unsigned int i = 0; i < 9; i++)
-    {
-        std::cout << gaussianOperator.GetOffset(i) << " " << gaussianOperator.GetElement(i) << std::endl;
-    }
-    return EXIT_SUCCESS;
+  for (unsigned int i = 0; i < 9; i++)
+  {
+    std::cout << gaussianOperator.GetOffset(i) << " " << gaussianOperator.GetElement(i) << std::endl;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CreateLaplacianKernel/Code.cxx
+++ b/src/Core/Common/CreateLaplacianKernel/Code.cxx
@@ -17,22 +17,22 @@
  *=========================================================================*/
 #include <itkLaplacianOperator.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using LaplacianOperatorType = itk::LaplacianOperator<float, 2>;
-    LaplacianOperatorType laplacianOperator;
-    itk::Size<2> radius;
-    radius.Fill(1);
-    laplacianOperator.CreateToRadius(radius);
+  using LaplacianOperatorType = itk::LaplacianOperator<float, 2>;
+  LaplacianOperatorType laplacianOperator;
+  itk::Size<2>          radius;
+  radius.Fill(1);
+  laplacianOperator.CreateToRadius(radius);
 
-    std::cout << "Size: " << laplacianOperator.GetSize() << std::endl;
+  std::cout << "Size: " << laplacianOperator.GetSize() << std::endl;
 
-    std::cout << laplacianOperator << std::endl;
+  std::cout << laplacianOperator << std::endl;
 
-    for(unsigned int i = 0; i < laplacianOperator.GetSize()[0] * laplacianOperator.GetSize()[1]; i++)
-    {
-        std::cout << laplacianOperator.GetOffset(i) << " " << laplacianOperator.GetElement(i) << std::endl;
-    }
-    return EXIT_SUCCESS;
+  for (unsigned int i = 0; i < laplacianOperator.GetSize()[0] * laplacianOperator.GetSize()[1]; i++)
+  {
+    std::cout << laplacianOperator.GetOffset(i) << " " << laplacianOperator.GetElement(i) << std::endl;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CreateSobelKernel/Code.cxx
+++ b/src/Core/Common/CreateSobelKernel/Code.cxx
@@ -17,21 +17,21 @@
  *=========================================================================*/
 #include <itkSobelOperator.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using SobelOperatorType = itk::SobelOperator<float, 2>;
-    SobelOperatorType sobelOperator;
-    sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
-    itk::Size<2> radius;
-    radius.Fill(1);
-    sobelOperator.CreateToRadius(radius);
+  using SobelOperatorType = itk::SobelOperator<float, 2>;
+  SobelOperatorType sobelOperator;
+  sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
+  itk::Size<2> radius;
+  radius.Fill(1);
+  sobelOperator.CreateToRadius(radius);
 
-    std::cout << sobelOperator << std::endl;
+  std::cout << sobelOperator << std::endl;
 
-    for(unsigned int i = 0; i < 9; i++)
-    {
-        std::cout << sobelOperator.GetElement(i) << std::endl;
-    }
-    return EXIT_SUCCESS;
+  for (unsigned int i = 0; i < 9; i++)
+  {
+    std::cout << sobelOperator.GetElement(i) << std::endl;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CreateVectorImage/Code.cxx
+++ b/src/Core/Common/CreateVectorImage/Code.cxx
@@ -17,42 +17,42 @@
  *=========================================================================*/
 #include "itkVectorImage.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    // Create an image
-    using ImageType = itk::VectorImage<float, 2>;
+  // Create an image
+  using ImageType = itk::VectorImage<float, 2>;
 
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(2);
+  ImageType::SizeType size;
+  size.Fill(2);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    ImageType::Pointer image = ImageType::New();
-    image->SetRegions(region);
-    image->SetVectorLength(2);
-    image->Allocate();
+  ImageType::Pointer image = ImageType::New();
+  image->SetRegions(region);
+  image->SetVectorLength(2);
+  image->Allocate();
 
-    ImageType::IndexType pixelIndex;
-    pixelIndex[0] = 1;
-    pixelIndex[1] = 1;
+  ImageType::IndexType pixelIndex;
+  pixelIndex[0] = 1;
+  pixelIndex[1] = 1;
 
-    ImageType::PixelType pixelValue = image->GetPixel(pixelIndex);
+  ImageType::PixelType pixelValue = image->GetPixel(pixelIndex);
 
-    std::cout << "pixel (1,1) = " << pixelValue << std::endl;
+  std::cout << "pixel (1,1) = " << pixelValue << std::endl;
 
-    using VariableVectorType = itk::VariableLengthVector<double>;
-    VariableVectorType variableLengthVector;
-    variableLengthVector.SetSize(2);
-    variableLengthVector[0] = 1.1;
-    variableLengthVector[1] = 2.2;
+  using VariableVectorType = itk::VariableLengthVector<double>;
+  VariableVectorType variableLengthVector;
+  variableLengthVector.SetSize(2);
+  variableLengthVector[0] = 1.1;
+  variableLengthVector[1] = 2.2;
 
-    image->SetPixel(pixelIndex, variableLengthVector);
+  image->SetPixel(pixelIndex, variableLengthVector);
 
-    std::cout << "pixel (1,1) = " << pixelValue << std::endl;
+  std::cout << "pixel (1,1) = " << pixelValue << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
+++ b/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
@@ -21,55 +21,55 @@
 #include <itkImageFileReader.h>
 #include <itkExtractImageFilter.h>
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using ImageType = itk::Image<unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
 
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(10);
+  ImageType::SizeType size;
+  size.Fill(10);
 
-    ImageType::RegionType region(start, size);
+  ImageType::RegionType region(start, size);
 
-    ImageType::Pointer image = ImageType::New();
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(5);
+  ImageType::Pointer image = ImageType::New();
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(5);
 
-    std::cout << "Image largest region: " << image->GetLargestPossibleRegion() << std::endl;
+  std::cout << "Image largest region: " << image->GetLargestPossibleRegion() << std::endl;
 
-    ImageType::IndexType desiredStart;
-    desiredStart.Fill(3);
+  ImageType::IndexType desiredStart;
+  desiredStart.Fill(3);
 
-    ImageType::SizeType desiredSize;
-    desiredSize.Fill(4);
+  ImageType::SizeType desiredSize;
+  desiredSize.Fill(4);
 
-    ImageType::RegionType desiredRegion(desiredStart, desiredSize);
+  ImageType::RegionType desiredRegion(desiredStart, desiredSize);
 
-    std::cout << "desiredRegion: " << desiredRegion << std::endl;
+  std::cout << "desiredRegion: " << desiredRegion << std::endl;
 
-    using FilterType = itk::ExtractImageFilter< ImageType, ImageType >;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetExtractionRegion(desiredRegion);
-    filter->SetInput(image);
+  using FilterType = itk::ExtractImageFilter<ImageType, ImageType>;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetExtractionRegion(desiredRegion);
+  filter->SetInput(image);
 #if ITK_VERSION_MAJOR >= 4
-    filter->SetDirectionCollapseToIdentity(); // This is required.
+  filter->SetDirectionCollapseToIdentity(); // This is required.
 #endif
-    filter->Update();
+  filter->Update();
 
-    ImageType::Pointer output = filter->GetOutput();
-    output->DisconnectPipeline();
-    output->FillBuffer(2);
+  ImageType::Pointer output = filter->GetOutput();
+  output->DisconnectPipeline();
+  output->FillBuffer(2);
 
-    itk::Index<2> index;
-    index.Fill(5);
+  itk::Index<2> index;
+  index.Fill(5);
 
-    std::cout << "new largest region: " << output->GetLargestPossibleRegion() << std::endl;
-    std::cout << "new: " << (int)output->GetPixel(index) << std::endl;
-    std::cout << "Original: " << (int)image->GetPixel(index) << std::endl;
+  std::cout << "new largest region: " << output->GetLargestPossibleRegion() << std::endl;
+  std::cout << "new: " << (int)output->GetPixel(index) << std::endl;
+  std::cout << "Original: " << (int)image->GetPixel(index) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/CustomOperationToEachPixelInImage/Code.cxx
+++ b/src/Core/Common/CustomOperationToEachPixelInImage/Code.cxx
@@ -22,48 +22,54 @@
 #include "itkUnaryFunctorImageFilter.h"
 #include "itkMath.h"
 
-template< class TInput, class TOutput>
+template <class TInput, class TOutput>
 class RotateVectors
 {
 public:
-  RotateVectors() = default;;
-  ~RotateVectors() = default;;
-  bool operator!=( const RotateVectors & ) const
-    {
+  RotateVectors() = default;
+  ;
+  ~RotateVectors() = default;
+  ;
+  bool
+  operator!=(const RotateVectors &) const
+  {
     return false;
-    }
-  bool operator==( const RotateVectors & other ) const
-    {
+  }
+  bool
+  operator==(const RotateVectors & other) const
+  {
     return !(*this != other);
-    }
-  inline TOutput operator()( const TInput & A ) const
-    {
-      using VectorType = itk::Vector<float, 2>;
-      VectorType v;
-      v[0] = A[0];
-      v[1] = A[1];
-            
-      using TransformType = itk::Rigid2DTransform< float >;
+  }
+  inline TOutput
+  operator()(const TInput & A) const
+  {
+    using VectorType = itk::Vector<float, 2>;
+    VectorType v;
+    v[0] = A[0];
+    v[1] = A[1];
 
-      TransformType::Pointer transform = TransformType::New();
-      transform->SetAngle(itk::Math::pi/2.0);
+    using TransformType = itk::Rigid2DTransform<float>;
 
-      VectorType outputV = transform->TransformVector(v);
-      TOutput transformedVector;
-      transformedVector.SetSize(2);
-      transformedVector[0] = outputV[0];
-      transformedVector[1] = outputV[1];
+    TransformType::Pointer transform = TransformType::New();
+    transform->SetAngle(itk::Math::pi / 2.0);
 
-      return transformedVector;
-    }
+    VectorType outputV = transform->TransformVector(v);
+    TOutput    transformedVector;
+    transformedVector.SetSize(2);
+    transformedVector[0] = outputV[0];
+    transformedVector[1] = outputV[1];
+
+    return transformedVector;
+  }
 };
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   using ImageType = itk::VectorImage<float, 2>;
 
   ImageType::RegionType region;
-  ImageType::IndexType start;
+  ImageType::IndexType  start;
   start[0] = 0;
   start[1] = 0;
 
@@ -88,13 +94,11 @@ int main(int, char *[])
   v.SetSize(2);
   v[0] = 1;
   v[1] = 0;
-  
+
   image->SetPixel(pixelIndex, v);
-  
-  using FilterType = itk::UnaryFunctorImageFilter<ImageType,ImageType,
-                                  RotateVectors<
-    ImageType::PixelType,
-    ImageType::PixelType> >;
+
+  using FilterType =
+    itk::UnaryFunctorImageFilter<ImageType, ImageType, RotateVectors<ImageType::PixelType, ImageType::PixelType>>;
 
   FilterType::Pointer filter = FilterType::New();
   filter->SetInput(image);

--- a/src/Core/Common/DeepCopyImage/Code.cxx
+++ b/src/Core/Common/DeepCopyImage/Code.cxx
@@ -18,32 +18,33 @@
 #include "itkImage.h"
 #include "itkImageRegionIterator.h"
 
-template<typename TImage>
-void DeepCopy(typename TImage::Pointer input, typename TImage::Pointer output)
+template <typename TImage>
+void
+DeepCopy(typename TImage::Pointer input, typename TImage::Pointer output)
 {
-    output->SetRegions(input->GetLargestPossibleRegion());
-    output->Allocate();
+  output->SetRegions(input->GetLargestPossibleRegion());
+  output->Allocate();
 
-    itk::ImageRegionConstIterator<TImage> inputIterator(input, input->GetLargestPossibleRegion());
-    itk::ImageRegionIterator<TImage> outputIterator(output, output->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<TImage> inputIterator(input, input->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<TImage>      outputIterator(output, output->GetLargestPossibleRegion());
 
-    while(!inputIterator.IsAtEnd())
-    {
-        outputIterator.Set(inputIterator.Get());
-        ++inputIterator;
-        ++outputIterator;
-    }
+  while (!inputIterator.IsAtEnd())
+  {
+    outputIterator.Set(inputIterator.Get());
+    ++inputIterator;
+    ++outputIterator;
+  }
 }
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using ImageType = itk::Image<unsigned char, 2>;
-    ImageType::Pointer image1 = ImageType::New();
-    ImageType::Pointer image2 = ImageType::New();
+  using ImageType = itk::Image<unsigned char, 2>;
+  ImageType::Pointer image1 = ImageType::New();
+  ImageType::Pointer image2 = ImageType::New();
 
-    DeepCopy<ImageType>(image1, image2);
+  DeepCopy<ImageType>(image1, image2);
 
 
-    return 0;
+  return 0;
 }
-

--- a/src/Core/Common/DemonstrateAllOperators/Code.cxx
+++ b/src/Core/Common/DemonstrateAllOperators/Code.cxx
@@ -29,53 +29,54 @@
 
 #include <vector>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
-    using ForwardDifferenceOperatorType = itk::ForwardDifferenceOperator<float, 2>;
-    using GaussianDerivativeOperatorType = itk::GaussianDerivativeOperator<float, 2>;
-    using GaussianOperatorType = itk::GaussianOperator<float, 2>;
-    using ImageKernelOperatorType = itk::ImageKernelOperator<float, 2>;
-    using LaplacianOperatorType = itk::LaplacianOperator<float, 2>;
-    using SobelOperatorType = itk::SobelOperator<float, 2>;
-    using AnnulusOperatorType = itk::AnnulusOperator<float, 2>;
-    using BackwardDifferenceOperatorType = itk::BackwardDifferenceOperator<float, 2>;
+  using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
+  using ForwardDifferenceOperatorType = itk::ForwardDifferenceOperator<float, 2>;
+  using GaussianDerivativeOperatorType = itk::GaussianDerivativeOperator<float, 2>;
+  using GaussianOperatorType = itk::GaussianOperator<float, 2>;
+  using ImageKernelOperatorType = itk::ImageKernelOperator<float, 2>;
+  using LaplacianOperatorType = itk::LaplacianOperator<float, 2>;
+  using SobelOperatorType = itk::SobelOperator<float, 2>;
+  using AnnulusOperatorType = itk::AnnulusOperator<float, 2>;
+  using BackwardDifferenceOperatorType = itk::BackwardDifferenceOperator<float, 2>;
 
-    std::vector<itk::NeighborhoodOperator<float, 2>*> operators;
-    operators.push_back(new DerivativeOperatorType);
-    operators.push_back(new ForwardDifferenceOperatorType);
-    operators.push_back(new GaussianDerivativeOperatorType);
-    operators.push_back(new GaussianOperatorType);
-    operators.push_back(new ImageKernelOperatorType);
-    operators.push_back(new LaplacianOperatorType);
-    operators.push_back(new SobelOperatorType);
-    operators.push_back(new AnnulusOperatorType);
-    operators.push_back(new BackwardDifferenceOperatorType);
+  std::vector<itk::NeighborhoodOperator<float, 2> *> operators;
+  operators.push_back(new DerivativeOperatorType);
+  operators.push_back(new ForwardDifferenceOperatorType);
+  operators.push_back(new GaussianDerivativeOperatorType);
+  operators.push_back(new GaussianOperatorType);
+  operators.push_back(new ImageKernelOperatorType);
+  operators.push_back(new LaplacianOperatorType);
+  operators.push_back(new SobelOperatorType);
+  operators.push_back(new AnnulusOperatorType);
+  operators.push_back(new BackwardDifferenceOperatorType);
 
-    itk::Size<2> radius;
-    radius.Fill(1);
+  itk::Size<2> radius;
+  radius.Fill(1);
 
-    for(auto & operatorId : operators)
+  for (auto & operatorId : operators)
+  {
+    operatorId->SetDirection(0); // Create the operator for the X axis derivative
+    operatorId->CreateToRadius(radius);
+    // std::cout << *(operators[operatorId]) << std::endl;
+    // operators[operatorId]->Print(std::cout);
+    // std::cout << operators[operatorId]->GetNameOfClass() << std::endl;
+
+    for (auto i = -operatorId->GetSize()[0] / 2; i <= operatorId->GetSize()[0] / 2; i++)
     {
-        operatorId->SetDirection(0); // Create the operator for the X axis derivative
-        operatorId->CreateToRadius(radius);
-        //std::cout << *(operators[operatorId]) << std::endl;
-        //operators[operatorId]->Print(std::cout);
-        //std::cout << operators[operatorId]->GetNameOfClass() << std::endl;
+      for (auto j = -operatorId->GetSize()[1] / 2; j <= operatorId->GetSize()[1] / 2; j++)
+      {
+        itk::Offset<2> offset;
+        offset[0] = i;
+        offset[1] = j;
 
-        for(auto i = -operatorId->GetSize()[0]/2; i <= operatorId->GetSize()[0]/2; i++)
-        {
-            for(auto j = -operatorId->GetSize()[1]/2; j <= operatorId->GetSize()[1]/2; j++)
-            {
-                itk::Offset<2> offset;
-                offset[0] = i;
-                offset[1] = j;
-
-                unsigned int neighborhoodIndex = operatorId->GetNeighborhoodIndex(offset);
-                std::cout << operatorId->GetElement(neighborhoodIndex) << " ";
-            }
-            std::cout << std::endl;
-        }
+        unsigned int neighborhoodIndex = operatorId->GetNeighborhoodIndex(offset);
+        std::cout << operatorId->GetElement(neighborhoodIndex) << " ";
+      }
+      std::cout << std::endl;
     }
-    return EXIT_SUCCESS;
+  }
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/DirectWarningToFile/Code.cxx
+++ b/src/Core/Common/DirectWarningToFile/Code.cxx
@@ -18,29 +18,29 @@
 #include <itkFileOutputWindow.h>
 #include <itkScaleTransform.h>
 
-int main(int argc, char* argv[])
+int
+main(int argc, char * argv[])
 {
-    using myFileOutputWindow = itk::FileOutputWindow;
-    myFileOutputWindow::Pointer window = myFileOutputWindow::New();
+  using myFileOutputWindow = itk::FileOutputWindow;
+  myFileOutputWindow::Pointer window = myFileOutputWindow::New();
 
-    if (argc > 1)
-    {
-        window->SetFileName(argv[1]);
-    }
-    window->FlushOn();
+  if (argc > 1)
+  {
+    window->SetFileName(argv[1]);
+  }
+  window->FlushOn();
 
-    // Set the singelton instance
-    itk::OutputWindow::SetInstance(window);
+  // Set the singelton instance
+  itk::OutputWindow::SetInstance(window);
 
-    // Generic output
-    itkGenericOutputMacro("This should be in the file: " << window->GetFileName());
-    // Warning
-    using TransformType = itk::ScaleTransform<float,2>;
-    TransformType::Pointer transform = TransformType::New();
-    TransformType::FixedParametersType parameters(3);
-    transform->SetFixedParameters(parameters);
+  // Generic output
+  itkGenericOutputMacro("This should be in the file: " << window->GetFileName());
+  // Warning
+  using TransformType = itk::ScaleTransform<float, 2>;
+  TransformType::Pointer             transform = TransformType::New();
+  TransformType::FixedParametersType parameters(3);
+  transform->SetFixedParameters(parameters);
 
-    std::cout << "Look in " << window->GetFileName() << " for the output" << std::endl;
-    return EXIT_SUCCESS;
+  std::cout << "Look in " << window->GetFileName() << " for the output" << std::endl;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/DisplayImage/Code.cxx
+++ b/src/Core/Common/DisplayImage/Code.cxx
@@ -20,75 +20,78 @@
 #include "itkRescaleIntensityImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType* const image);
+static void
+CreateImage(ImageType * const image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image;
+  ImageType::Pointer image;
 
-    if(argc < 2)
-    {
-        //std::cerr << "Required: filename" << std::endl;
-        //return EXIT_FAILURE;
-        image = ImageType::New();
-        CreateImage(image);
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        image = reader->GetOutput();
-    }
+  if (argc < 2)
+  {
+    // std::cerr << "Required: filename" << std::endl;
+    // return EXIT_FAILURE;
+    image = ImageType::New();
+    CreateImage(image);
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    image = reader->GetOutput();
+  }
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< ImageType, ImageType >;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(image);
-    rescaleFilter->SetOutputMinimum(0);
-    rescaleFilter->SetOutputMaximum(255);
-    rescaleFilter->Update();
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<ImageType, ImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(image);
+  rescaleFilter->SetOutputMinimum(0);
+  rescaleFilter->SetOutputMaximum(255);
+  rescaleFilter->Update();
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(image.GetPointer());
-    viewer.AddImage(rescaleFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage(image.GetPointer());
+  viewer.AddImage(rescaleFilter->GetOutput());
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType* const image)
+void
+CreateImage(ImageType * const image)
 {
-    // Create an image with 2 connected components
-    ImageType::IndexType corner = {{0,0}};
+  // Create an image with 2 connected components
+  ImageType::IndexType corner = { { 0, 0 } };
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    ImageType::RegionType region(corner, size);
+  ImageType::RegionType region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make a square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }

--- a/src/Core/Common/DistanceBetweenIndices/Code.cxx
+++ b/src/Core/Common/DistanceBetweenIndices/Code.cxx
@@ -22,23 +22,23 @@
 
 #include <iostream>
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    itk::Index<2> pixel1;
-    pixel1.Fill(2);
+  itk::Index<2> pixel1;
+  pixel1.Fill(2);
 
-    itk::Index<2> pixel2;
-    pixel2.Fill(4);
+  itk::Index<2> pixel2;
+  pixel2.Fill(4);
 
-    itk::Point<double,2> p1;
-    p1[0] = pixel1[0];
-    p1[1] = pixel1[1];
+  itk::Point<double, 2> p1;
+  p1[0] = pixel1[0];
+  p1[1] = pixel1[1];
 
-    itk::Point<double,2> p2;
-    p2[0] = pixel2[0];
-    p2[1] = pixel2[1];
+  itk::Point<double, 2> p2;
+  p2[0] = pixel2[0];
+  p2[1] = pixel2[1];
 
-    double distance = p2.EuclideanDistanceTo(p1);
-    std::cout << "Distance: " << distance << std::endl;
-
+  double distance = p2.EuclideanDistanceTo(p1);
+  std::cout << "Distance: " << distance << std::endl;
 }

--- a/src/Core/Common/DistanceBetweenPoints/Code.cxx
+++ b/src/Core/Common/DistanceBetweenPoints/Code.cxx
@@ -21,12 +21,13 @@
 
 #include <iostream>
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
 
-  using PointType = itk::Point< CoordType, Dimension >;
+  using PointType = itk::Point<CoordType, Dimension>;
 
   PointType p0;
   p0[0] = 0.0;
@@ -41,28 +42,26 @@ int main(int, char *[])
   PointType::RealType dist = p0.EuclideanDistanceTo(p1);
   std::cout << "Dist: " << dist << std::endl;
 
-  if( dist != p1.EuclideanDistanceTo(p0) )
-    {
-    std::cerr << "p0.EuclideanDistanceTo(p1) != p1.EuclideanDistanceTo(p0)"
-              << std::endl;
+  if (dist != p1.EuclideanDistanceTo(p0))
+  {
+    std::cerr << "p0.EuclideanDistanceTo(p1) != p1.EuclideanDistanceTo(p0)" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  if( p1.EuclideanDistanceTo( p1 ) != 0. )
-    {
-    std::cerr << "p1.EuclideanDistanceTo(p1) != 0."
-              << std::endl;
+  if (p1.EuclideanDistanceTo(p1) != 0.)
+  {
+    std::cerr << "p1.EuclideanDistanceTo(p1) != 0." << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   PointType::RealType dist2 = p0.SquaredEuclideanDistanceTo(p1);
   std::cout << "Dist2: " << dist2 << std::endl;
 
-  if( std::abs( dist2 - dist * dist ) < itk::Math::eps )
-    {
+  if (std::abs(dist2 - dist * dist) < itk::Math::eps)
+  {
     std::cerr << "dist2 != dist * dist" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/DoDataParallelThreading/Code.cxx
+++ b/src/Core/Common/DoDataParallelThreading/Code.cxx
@@ -20,16 +20,17 @@
 #include "itkThreadedIndexedContainerPartitioner.h"
 
 // We have central nervous system cells of different types.
-enum CELL_TYPE {
+enum CELL_TYPE
+{
   NEURON,
   ASTROCYTE,
   OLIGODENDROCYTE
 };
 
 // Type to hold our list of cells to count.
-using CellContainerType = std::vector< CELL_TYPE >;
+using CellContainerType = std::vector<CELL_TYPE>;
 // Type to hold the count for each CELL_TYPE.
-using CellCountType = std::map< CELL_TYPE, unsigned int >;
+using CellCountType = std::map<CELL_TYPE, unsigned int>;
 
 
 // This class performs the multi-threaded cell type counting for the
@@ -62,36 +63,33 @@ using CellCountType = std::map< CELL_TYPE, unsigned int >;
 // ThreadedIteratorRangePartitioner and the ThreadedImageRegionPartitioner,
 // respectively.
 
-template< class TAssociate >
-class ComputeCellCountThreader :
-  public itk::DomainThreader<
-    itk::ThreadedIndexedContainerPartitioner, TAssociate >
+template <class TAssociate>
+class ComputeCellCountThreader : public itk::DomainThreader<itk::ThreadedIndexedContainerPartitioner, TAssociate>
 {
 public:
   // Standard ITK type alias.
   using Self = ComputeCellCountThreader;
-  using Superclass = itk::DomainThreader<
-    itk::ThreadedIndexedContainerPartitioner,
-    TAssociate >;
-  using Pointer = itk::SmartPointer< Self >;
-  using ConstPointer = itk::SmartPointer< const Self >;
+  using Superclass = itk::DomainThreader<itk::ThreadedIndexedContainerPartitioner, TAssociate>;
+  using Pointer = itk::SmartPointer<Self>;
+  using ConstPointer = itk::SmartPointer<const Self>;
 
   // The domain is an index range.
   using DomainType = typename Superclass::DomainType;
 
   // This creates the ::New() method for instantiating the class.
-  itkNewMacro( Self );
+  itkNewMacro(Self);
 
 protected:
   // We need a constructor for the itkNewMacro.
   ComputeCellCountThreader() = default;
 
 private:
-  void BeforeThreadedExecution() override
-    {
+  void
+  BeforeThreadedExecution() override
+  {
     // Reset the counts for all cell types to zero.
-    this->m_Associate->m_CellCount[NEURON]          = 0;
-    this->m_Associate->m_CellCount[ASTROCYTE]       = 0;
+    this->m_Associate->m_CellCount[NEURON] = 0;
+    this->m_Associate->m_CellCount[ASTROCYTE] = 0;
     this->m_Associate->m_CellCount[OLIGODENDROCYTE] = 0;
 
     // Resize our per-thread data structures to the number of threads that we
@@ -102,56 +100,54 @@ private:
     // number of cells in the CellContainer is smaller than the number of cores
     // available.
     const itk::ThreadIdType numberOfThreads = this->GetNumberOfWorkUnitsUsed();
-    this->m_CellCountPerThread.resize( numberOfThreads );
-    for( itk::ThreadIdType ii = 0; ii < numberOfThreads; ++ii )
-      {
-      this->m_CellCountPerThread[ii][NEURON]          = 0;
-      this->m_CellCountPerThread[ii][ASTROCYTE]       = 0;
+    this->m_CellCountPerThread.resize(numberOfThreads);
+    for (itk::ThreadIdType ii = 0; ii < numberOfThreads; ++ii)
+    {
+      this->m_CellCountPerThread[ii][NEURON] = 0;
+      this->m_CellCountPerThread[ii][ASTROCYTE] = 0;
       this->m_CellCountPerThread[ii][OLIGODENDROCYTE] = 0;
-      }
     }
+  }
 
-  void ThreadedExecution( const DomainType & subDomain,
-                                  const itk::ThreadIdType threadId ) override
-    {
+  void
+  ThreadedExecution(const DomainType & subDomain, const itk::ThreadIdType threadId) override
+  {
     // Look only at the range of cells by the set of indices in the subDomain.
-    for( itk::IndexValueType ii = subDomain[0]; ii <= subDomain[1]; ++ii )
+    for (itk::IndexValueType ii = subDomain[0]; ii <= subDomain[1]; ++ii)
+    {
+      switch (this->m_Associate->m_Cells[ii])
       {
-      switch( this->m_Associate->m_Cells[ii] )
-        {
-      case NEURON:
-        // Accumulate in the per thread cell count.
-        ++(this->m_CellCountPerThread[threadId][NEURON]);
-        break;
-      case ASTROCYTE:
-        ++(this->m_CellCountPerThread[threadId][ASTROCYTE]);
-        break;
-      case OLIGODENDROCYTE:
-        ++(this->m_CellCountPerThread[threadId][OLIGODENDROCYTE]);
-        break;
-        }
+        case NEURON:
+          // Accumulate in the per thread cell count.
+          ++(this->m_CellCountPerThread[threadId][NEURON]);
+          break;
+        case ASTROCYTE:
+          ++(this->m_CellCountPerThread[threadId][ASTROCYTE]);
+          break;
+        case OLIGODENDROCYTE:
+          ++(this->m_CellCountPerThread[threadId][OLIGODENDROCYTE]);
+          break;
       }
     }
+  }
 
-  void AfterThreadedExecution() override
-    {
+  void
+  AfterThreadedExecution() override
+  {
     // Accumulate the cell counts per thread in the associate's total cell
     // count.
     const itk::ThreadIdType numberOfThreads = this->GetNumberOfWorkUnitsUsed();
-    for( itk::ThreadIdType ii = 0; ii < numberOfThreads; ++ii )
-      {
-      this->m_Associate->m_CellCount[NEURON] +=
-        this->m_CellCountPerThread[ii][NEURON];
+    for (itk::ThreadIdType ii = 0; ii < numberOfThreads; ++ii)
+    {
+      this->m_Associate->m_CellCount[NEURON] += this->m_CellCountPerThread[ii][NEURON];
 
-      this->m_Associate->m_CellCount[ASTROCYTE] +=
-        this->m_CellCountPerThread[ii][ASTROCYTE];
+      this->m_Associate->m_CellCount[ASTROCYTE] += this->m_CellCountPerThread[ii][ASTROCYTE];
 
-      this->m_Associate->m_CellCount[OLIGODENDROCYTE] +=
-        this->m_CellCountPerThread[ii][OLIGODENDROCYTE];
-      }
+      this->m_Associate->m_CellCount[OLIGODENDROCYTE] += this->m_CellCountPerThread[ii][OLIGODENDROCYTE];
     }
+  }
 
-  std::vector< CellCountType > m_CellCountPerThread;
+  std::vector<CellCountType> m_CellCountPerThread;
 };
 
 
@@ -161,68 +157,63 @@ class CellCounter
 public:
   using Self = CellCounter;
 
-  using ComputeCellCountThreaderType = ComputeCellCountThreader< Self >;
+  using ComputeCellCountThreaderType = ComputeCellCountThreader<Self>;
 
   // Constructor.  Create our Threader class instance.
-  CellCounter()
-    {
-    this->m_ComputeCellCountThreader = ComputeCellCountThreaderType::New();
-    }
+  CellCounter() { this->m_ComputeCellCountThreader = ComputeCellCountThreaderType::New(); }
 
   // Set the cells we want to count.
-  void SetCells( const CellContainerType & cells )
+  void
+  SetCells(const CellContainerType & cells)
+  {
+    this->m_Cells.resize(cells.size());
+    for (size_t ii = 0; ii < cells.size(); ++ii)
     {
-    this->m_Cells.resize( cells.size() );
-    for( size_t ii = 0; ii < cells.size(); ++ii )
-      {
       this->m_Cells[ii] = cells[ii];
-      }
     }
+  }
 
   // Count the cells and return the count of each type.
-  const CellCountType & ComputeCellCount()
-    {
+  const CellCountType &
+  ComputeCellCount()
+  {
     ComputeCellCountThreaderType::DomainType completeDomain;
     completeDomain[0] = 0;
     completeDomain[1] = this->m_Cells.size() - 1;
-    this->m_ComputeCellCountThreader->Execute( this, completeDomain );
+    this->m_ComputeCellCountThreader->Execute(this, completeDomain);
     return this->m_CellCount;
-    }
+  }
 
 private:
   // Stores the count of each type of cell.
-  CellCountType     m_CellCount;
+  CellCountType m_CellCount;
   // Stores the cells to count.
   CellContainerType m_Cells;
 
   // The ComputeCellCountThreader gets to access m_CellCount and m_Cells as
   // needed.
-  friend class ComputeCellCountThreader< Self >;
+  friend class ComputeCellCountThreader<Self>;
   ComputeCellCountThreaderType::Pointer m_ComputeCellCountThreader;
 };
 
 
-int main( int, char* [] )
+int
+main(int, char *[])
 {
   // Our cells.
-  static const CELL_TYPE cellsArr[] =
-    { NEURON, ASTROCYTE, ASTROCYTE, OLIGODENDROCYTE,
-    ASTROCYTE, NEURON, NEURON, ASTROCYTE, ASTROCYTE, OLIGODENDROCYTE };
+  static const CELL_TYPE cellsArr[] = { NEURON, ASTROCYTE, ASTROCYTE, OLIGODENDROCYTE, ASTROCYTE,
+                                        NEURON, NEURON,    ASTROCYTE, ASTROCYTE,       OLIGODENDROCYTE };
 
-  CellContainerType cells( cellsArr,
-                           cellsArr + sizeof(cellsArr) / sizeof(cellsArr[0]) );
+  CellContainerType cells(cellsArr, cellsArr + sizeof(cellsArr) / sizeof(cellsArr[0]));
 
   // Count them in a multi-threader way.
   CellCounter cellCounter;
-  cellCounter.SetCells( cells );
+  cellCounter.SetCells(cells);
   const CellCountType multiThreadedCellCount = cellCounter.ComputeCellCount();
   std::cout << "Result of the multi-threaded cell count:\n";
-  std::cout << "\tNEURON:          " <<
-    (*multiThreadedCellCount.find(NEURON)).second << "\n";
-  std::cout << "\tASTROCYTE:       " <<
-    (*multiThreadedCellCount.find(ASTROCYTE)).second << "\n";
-  std::cout << "\tOLIGODENDROCYTE: " <<
-    (*multiThreadedCellCount.find(OLIGODENDROCYTE)).second << "\n";
+  std::cout << "\tNEURON:          " << (*multiThreadedCellCount.find(NEURON)).second << "\n";
+  std::cout << "\tASTROCYTE:       " << (*multiThreadedCellCount.find(ASTROCYTE)).second << "\n";
+  std::cout << "\tOLIGODENDROCYTE: " << (*multiThreadedCellCount.find(OLIGODENDROCYTE)).second << "\n";
 
 
   // Count them in a single-threaded way.
@@ -230,45 +221,39 @@ int main( int, char* [] )
   singleThreadedCellCount[NEURON] = 0;
   singleThreadedCellCount[ASTROCYTE] = 0;
   singleThreadedCellCount[OLIGODENDROCYTE] = 0;
-  for(auto & cell : cells)
+  for (auto & cell : cells)
+  {
+    switch (cell)
     {
-    switch( cell )
-      {
-    case NEURON:
-      // Accumulate in the per thread cell count.
-      ++(singleThreadedCellCount[NEURON]);
-      break;
-    case ASTROCYTE:
-      ++(singleThreadedCellCount[ASTROCYTE]);
-      break;
-    case OLIGODENDROCYTE:
-      ++(singleThreadedCellCount[OLIGODENDROCYTE]);
-      break;
-      }
+      case NEURON:
+        // Accumulate in the per thread cell count.
+        ++(singleThreadedCellCount[NEURON]);
+        break;
+      case ASTROCYTE:
+        ++(singleThreadedCellCount[ASTROCYTE]);
+        break;
+      case OLIGODENDROCYTE:
+        ++(singleThreadedCellCount[OLIGODENDROCYTE]);
+        break;
     }
+  }
   std::cout << "Result of the single-threaded cell count:\n";
-  std::cout << "\tNEURON:          " <<
-    (*singleThreadedCellCount.find(NEURON)).second << "\n";
-  std::cout << "\tASTROCYTE:       " <<
-    (*singleThreadedCellCount.find(ASTROCYTE)).second << "\n";
-  std::cout << "\tOLIGODENDROCYTE: " <<
-    (*singleThreadedCellCount.find(OLIGODENDROCYTE)).second << "\n";
+  std::cout << "\tNEURON:          " << (*singleThreadedCellCount.find(NEURON)).second << "\n";
+  std::cout << "\tASTROCYTE:       " << (*singleThreadedCellCount.find(ASTROCYTE)).second << "\n";
+  std::cout << "\tOLIGODENDROCYTE: " << (*singleThreadedCellCount.find(OLIGODENDROCYTE)).second << "\n";
 
 
   // Did we get what was expected?  It is always good to check a multi-threaded
   // implementation against a single-threaded implementation to ensure that it
   // gets the same results.
-  if( (*multiThreadedCellCount.find(NEURON)).second !=
-        singleThreadedCellCount[NEURON] ||
-      (*multiThreadedCellCount.find(ASTROCYTE)).second !=
-        singleThreadedCellCount[ASTROCYTE] ||
-      (*multiThreadedCellCount.find(OLIGODENDROCYTE)).second !=
-        singleThreadedCellCount[OLIGODENDROCYTE] )
-    {
+  if ((*multiThreadedCellCount.find(NEURON)).second != singleThreadedCellCount[NEURON] ||
+      (*multiThreadedCellCount.find(ASTROCYTE)).second != singleThreadedCellCount[ASTROCYTE] ||
+      (*multiThreadedCellCount.find(OLIGODENDROCYTE)).second != singleThreadedCellCount[OLIGODENDROCYTE])
+  {
     std::cerr << "Error: did not get the same results"
-      << "for a single-threaded and multi-threaded calculation." << std::endl;
+              << "for a single-threaded and multi-threaded calculation." << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/DuplicateAnImage/Code.cxx
+++ b/src/Core/Common/DuplicateAnImage/Code.cxx
@@ -20,21 +20,22 @@
 #include "itkImageDuplicator.h"
 #include "itkRandomImageSource.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using RandomSourceType = itk::RandomImageSource< ImageType >;
+  using RandomSourceType = itk::RandomImageSource<ImageType>;
 
   RandomSourceType::Pointer randomImageSource = RandomSourceType::New();
   randomImageSource->SetNumberOfWorkUnits(1); // to produce non-random results
 
   ImageType::Pointer image = randomImageSource->GetOutput();
 
-  using DuplicatorType = itk::ImageDuplicator< ImageType >;
+  using DuplicatorType = itk::ImageDuplicator<ImageType>;
   DuplicatorType::Pointer duplicator = DuplicatorType::New();
   duplicator->SetInputImage(image);
   duplicator->Update();

--- a/src/Core/Common/FilterAndParallelizeImageRegion/Code.cxx
+++ b/src/Core/Common/FilterAndParallelizeImageRegion/Code.cxx
@@ -24,21 +24,22 @@
 
 constexpr unsigned int Dimension = 2;
 using PixelType = unsigned int;
-using ImageType = itk::Image< PixelType, Dimension >;
+using ImageType = itk::Image<PixelType, Dimension>;
 
 // calculate log(1+x), where x is pixel value, using LogImageFilter
-void log1xViaLogImageFilter(ImageType::Pointer& image)
+void
+log1xViaLogImageFilter(ImageType::Pointer & image)
 {
   // LogImageFilter calculates log(x), so we have to modify the image first
   // by increase its every pixel value by 1, and then apply log filter to it
-  itk::ImageRegionIterator< ImageType > it(image, image->GetBufferedRegion());
+  itk::ImageRegionIterator<ImageType> it(image, image->GetBufferedRegion());
   for (; !it.IsAtEnd(); ++it)
-    {
+  {
     it.Set(1 + it.Get());
-    }
+  }
 
   // classic filter declaration and invocation
-  using LogType = itk::LogImageFilter< ImageType, ImageType >;
+  using LogType = itk::LogImageFilter<ImageType, ImageType>;
   LogType::Pointer logF = LogType::New();
   logF->SetInput(image);
   logF->SetInPlace(true);
@@ -48,37 +49,39 @@ void log1xViaLogImageFilter(ImageType::Pointer& image)
 }
 
 // calculate log(1+x), where x is pixel value, using ParallelizeImageRegion
-void log1xViaParallelizeImageRegion(ImageType::Pointer& image)
+void
+log1xViaParallelizeImageRegion(ImageType::Pointer & image)
 {
   itk::MultiThreaderBase::Pointer mt = itk::MultiThreaderBase::New();
   // ParallelizeImageRegion invokes the provided lambda function in parallel
   // each invocation will contain a piece of the overall region
-  mt->ParallelizeImageRegion<Dimension>(image->GetBufferedRegion(),
-      // here we creat an ad-hoc lambda function to process the region pieces
-      // the lambda will have access to variable 'image' from the outer function
-      // it will have parameter 'region', which needs to be processed
-      [image](const ImageType::RegionType & region)
+  mt->ParallelizeImageRegion<Dimension>(
+    image->GetBufferedRegion(),
+    // here we creat an ad-hoc lambda function to process the region pieces
+    // the lambda will have access to variable 'image' from the outer function
+    // it will have parameter 'region', which needs to be processed
+    [image](const ImageType::RegionType & region) {
+      itk::ImageRegionIterator<ImageType> it(image, region);
+      for (; !it.IsAtEnd(); ++it)
       {
-        itk::ImageRegionIterator< ImageType > it(image, region);
-        for (; !it.IsAtEnd(); ++it)
-          {
-          it.Set(std::log(1 + it.Get()));
-          }
-      },
-      nullptr); // we don't have a filter whose progress needs to be updated
+        it.Set(std::log(1 + it.Get()));
+      }
+    },
+    nullptr); // we don't have a filter whose progress needs to be updated
 }
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   int result = EXIT_SUCCESS;
 
   // create an image
-  ImageType::RegionType region = { {0,0}, {50,20} }; // indices zero, size 50x20
-  using RandomSourceType = itk::RandomImageSource< ImageType >;
+  ImageType::RegionType region = { { 0, 0 }, { 50, 20 } }; // indices zero, size 50x20
+  using RandomSourceType = itk::RandomImageSource<ImageType>;
   RandomSourceType::Pointer randomImageSource = RandomSourceType::New();
   randomImageSource->SetSize(region.GetSize());
   // we don't want overflow on 1+x operation, so set max pixel value
-  randomImageSource->SetMax(itk::NumericTraits< PixelType >::max() - 1);
+  randomImageSource->SetMax(itk::NumericTraits<PixelType>::max() - 1);
   randomImageSource->SetNumberOfWorkUnits(1); // to produce deterministic results
   randomImageSource->Update();
 
@@ -86,7 +89,7 @@ int main(int, char *[])
   image->DisconnectPipeline();
 
   // create another image, to be passed to the alternative method
-  using DuplicatorType = itk::ImageDuplicator< ImageType >;
+  using DuplicatorType = itk::ImageDuplicator<ImageType>;
   DuplicatorType::Pointer duplicator = DuplicatorType::New();
   duplicator->SetInputImage(image);
   duplicator->Update();
@@ -99,30 +102,30 @@ int main(int, char *[])
   log1xViaParallelizeImageRegion(clonedImage);
 
   // compare to make sure the results are the same
-  unsigned diffCount = 0;
-  itk::ImageRegionConstIterator< ImageType > it1(image, region);
-  itk::ImageRegionConstIterator< ImageType > it2(clonedImage, region);
+  unsigned                                 diffCount = 0;
+  itk::ImageRegionConstIterator<ImageType> it1(image, region);
+  itk::ImageRegionConstIterator<ImageType> it2(clonedImage, region);
   for (; !it1.IsAtEnd(); ++it1, ++it2)
+  {
+    if (it1.Get() != it2.Get())
     {
-    if ( it1.Get() != it2.Get() )
-      {
-      std::cerr << "Pixel values are different at index " << it1.GetIndex()
-          << it1.Get() << " vs. " << it2.Get() << std::endl;
-          //<< "\n\tlog1xViaLogImageFilter's value: " << it1.Get()
-          //<< "\n\tlog1xViaParallelizeImageRegion: " << it2.Get() << std::endl;
+      std::cerr << "Pixel values are different at index " << it1.GetIndex() << it1.Get() << " vs. " << it2.Get()
+                << std::endl;
+      //<< "\n\tlog1xViaLogImageFilter's value: " << it1.Get()
+      //<< "\n\tlog1xViaParallelizeImageRegion: " << it2.Get() << std::endl;
       diffCount++;
       result = EXIT_FAILURE;
-      }
     }
+  }
 
-  if ( diffCount == 0 )
-    {
+  if (diffCount == 0)
+  {
     std::cout << "LogImageFilter and ParallelizeImageRegion generate the same result." << std::endl;
-    }
+  }
   else
-    {
-    std::cout << "Discrepancy! " << diffCount << " pixels out of "
-        << region.GetNumberOfPixels() << " are different." << std::endl;
-    }
+  {
+    std::cout << "Discrepancy! " << diffCount << " pixels out of " << region.GetNumberOfPixels() << " are different."
+              << std::endl;
+  }
   return result;
 }

--- a/src/Core/Common/FilterImage/Code.cxx
+++ b/src/Core/Common/FilterImage/Code.cxx
@@ -22,50 +22,52 @@
 #include "ImageFilter.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using ImageType = itk::Image<int, 2>;
-    using FilterType = itk::ImageFilter<ImageType>;
+  // Setup types
+  using ImageType = itk::Image<int, 2>;
+  using FilterType = itk::ImageFilter<ImageType>;
 
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image.GetPointer());
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image.GetPointer());
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(image);
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(image);
+  filter->Update();
 
-    itk::Index<2> cornerPixel = image->GetLargestPossibleRegion().GetIndex();
+  itk::Index<2> cornerPixel = image->GetLargestPossibleRegion().GetIndex();
 
-    // The output here is:
-    // 0
-    // 3
-    // That is, the filter changed the pixel, but the input remained unchagned.
-    std::cout << image->GetPixel(cornerPixel) << std::endl;
-    std::cout << filter->GetOutput()->GetPixel(cornerPixel) << std::endl;
+  // The output here is:
+  // 0
+  // 3
+  // That is, the filter changed the pixel, but the input remained unchagned.
+  std::cout << image->GetPixel(cornerPixel) << std::endl;
+  std::cout << filter->GetOutput()->GetPixel(cornerPixel) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
-    // Create an image with 2 connected components
-    typename TImage::IndexType corner = {{0,0}};
+  // Create an image with 2 connected components
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
-    typename TImage::RegionType region(corner, size);
+  typename TImage::RegionType region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    image->FillBuffer(0);
+  image->FillBuffer(0);
 }
-

--- a/src/Core/Common/FilterImageUsingMultipleThreads/Code.cxx
+++ b/src/Core/Common/FilterImageUsingMultipleThreads/Code.cxx
@@ -22,67 +22,71 @@
 #include "MultiThreadedImageFilter.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
 template <typename TImage>
-static void OutputImage(TImage* const image);
+static void
+OutputImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using ImageType = itk::Image<int, 2>;
-    using FilterType = itk::MultiThreadedImageFilter<ImageType>;
+  // Setup types
+  using ImageType = itk::Image<int, 2>;
+  using FilterType = itk::MultiThreadedImageFilter<ImageType>;
 
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image.GetPointer());
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image.GetPointer());
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(image);
-    // filter->SetNumberOfThreads(3); // There is no need to specify this, it is automatically determined
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(image);
+  // filter->SetNumberOfThreads(3); // There is no need to specify this, it is automatically determined
+  filter->Update();
 
-    std::cout << "Image after filter: " << std::endl;
-    OutputImage(image.GetPointer());
+  std::cout << "Image after filter: " << std::endl;
+  OutputImage(image.GetPointer());
 
-    std::cout << "Output: " << std::endl;
-    OutputImage(filter->GetOutput());
+  std::cout << "Output: " << std::endl;
+  OutputImage(filter->GetOutput());
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
-    // Create an image with 2 connected components
-    typename TImage::IndexType corner = {{0,0}};
+  // Create an image with 2 connected components
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-//   unsigned int NumRows = 200;
-//   unsigned int NumCols = 300;
+  //   unsigned int NumRows = 200;
+  //   unsigned int NumCols = 300;
 
-    unsigned int NumRows = 3;
-    unsigned int NumCols = 2;
-    typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 3;
+  unsigned int              NumCols = 2;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
-    typename TImage::RegionType region(corner, size);
+  typename TImage::RegionType region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    image->FillBuffer(0);
+  image->FillBuffer(0);
 }
 
 template <typename TImage>
-void OutputImage(TImage* const image)
+void
+OutputImage(TImage * const image)
 {
-    itk::ImageRegionConstIterator<TImage> imageIterator(image, image->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<TImage> imageIterator(image, image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        std::cout << imageIterator.Get() << std::endl;
+  while (!imageIterator.IsAtEnd())
+  {
+    std::cout << imageIterator.Get() << std::endl;
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 }
-

--- a/src/Core/Common/FilterImageWithoutCopying/Code.cxx
+++ b/src/Core/Common/FilterImageWithoutCopying/Code.cxx
@@ -22,53 +22,55 @@
 #include "MyInPlaceImageFilter.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using ImageType = itk::Image<int, 2>;
-    using FilterType = itk::MyInPlaceImageFilter<ImageType>;
+  // Setup types
+  using ImageType = itk::Image<int, 2>;
+  using FilterType = itk::MyInPlaceImageFilter<ImageType>;
 
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image.GetPointer());
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image.GetPointer());
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(image);
-    filter->SetInPlace(true);
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetInPlace(true);
+  filter->Update();
 
-    itk::Index<2> cornerPixel = image->GetLargestPossibleRegion().GetIndex();
+  itk::Index<2> cornerPixel = image->GetLargestPossibleRegion().GetIndex();
 
-    // The output here should be "3"
-    std::cout << "Filter output:" << std::endl;
-    std::cout << filter->GetOutput()->GetPixel(cornerPixel) << std::endl;
+  // The output here should be "3"
+  std::cout << "Filter output:" << std::endl;
+  std::cout << filter->GetOutput()->GetPixel(cornerPixel) << std::endl;
 
-    // The follow calls fail. This is because the output has stolen the input's
-    // buffer and the input has no image buffer.
-//   std::cout << "Image output:" << std::endl;
-//   std::cout << image->GetPixel(cornerPixel) << std::endl;
+  // The follow calls fail. This is because the output has stolen the input's
+  // buffer and the input has no image buffer.
+  //   std::cout << "Image output:" << std::endl;
+  //   std::cout << image->GetPixel(cornerPixel) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
-    // Create an image with 2 connected components
-    typename TImage::IndexType corner = {{0,0}};
+  // Create an image with 2 connected components
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
-    typename TImage::RegionType region(corner, size);
+  typename TImage::RegionType region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    image->FillBuffer(0);
+  image->FillBuffer(0);
 }
-

--- a/src/Core/Common/FindMaxAndMinInImage/Code.cxx
+++ b/src/Core/Common/FindMaxAndMinInImage/Code.cxx
@@ -37,99 +37,87 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
 
-        return EXIT_FAILURE;
-    }
-    std::string inputFilename = argv[1];
+    return EXIT_FAILURE;
+  }
+  std::string inputFilename = argv[1];
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
 
-    reader->SetFileName(inputFilename.c_str());
-    reader->Update();
+  reader->SetFileName(inputFilename.c_str());
+  reader->Update();
 
-    using ImageCalculatorFilterType = itk::MinimumMaximumImageCalculator <ImageType>;
+  using ImageCalculatorFilterType = itk::MinimumMaximumImageCalculator<ImageType>;
 
-    ImageCalculatorFilterType::Pointer imageCalculatorFilter
-            = ImageCalculatorFilterType::New ();
-    imageCalculatorFilter->SetImage(reader->GetOutput());
-    imageCalculatorFilter->Compute();
+  ImageCalculatorFilterType::Pointer imageCalculatorFilter = ImageCalculatorFilterType::New();
+  imageCalculatorFilter->SetImage(reader->GetOutput());
+  imageCalculatorFilter->Compute();
 
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer originalConnector = ConnectorType::New();
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer originalConnector = ConnectorType::New();
 
-    originalConnector->SetInput(reader->GetOutput());
+  originalConnector->SetInput(reader->GetOutput());
 
-    vtkSmartPointer<vtkImageActor> originalActor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> originalActor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    originalActor->SetInput(originalConnector->GetOutput());
+  originalActor->SetInput(originalConnector->GetOutput());
 #else
-    originalConnector->Update();
+  originalConnector->Update();
   originalActor->GetMapper()->SetInputData(originalConnector->GetOutput());
 #endif
 
-    vtkSmartPointer<vtkSphereSource> minimumSphereSource =
-            vtkSmartPointer<vtkSphereSource>::New();
-    ImageType::IndexType minimumLocation = imageCalculatorFilter->GetIndexOfMinimum();
-    minimumSphereSource->SetCenter(minimumLocation[0], minimumLocation[1], 0);
-    minimumSphereSource->SetRadius(10);
+  vtkSmartPointer<vtkSphereSource> minimumSphereSource = vtkSmartPointer<vtkSphereSource>::New();
+  ImageType::IndexType             minimumLocation = imageCalculatorFilter->GetIndexOfMinimum();
+  minimumSphereSource->SetCenter(minimumLocation[0], minimumLocation[1], 0);
+  minimumSphereSource->SetRadius(10);
 
-    vtkSmartPointer<vtkPolyDataMapper> minimumMapper =
-            vtkSmartPointer<vtkPolyDataMapper>::New();
-    minimumMapper->SetInputConnection(minimumSphereSource->GetOutputPort());
-    vtkSmartPointer<vtkActor> minimumActor =
-            vtkSmartPointer<vtkActor>::New();
-    minimumActor->SetMapper(minimumMapper);
-    minimumActor->GetProperty()->SetColor(0,1,0);
+  vtkSmartPointer<vtkPolyDataMapper> minimumMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  minimumMapper->SetInputConnection(minimumSphereSource->GetOutputPort());
+  vtkSmartPointer<vtkActor> minimumActor = vtkSmartPointer<vtkActor>::New();
+  minimumActor->SetMapper(minimumMapper);
+  minimumActor->GetProperty()->SetColor(0, 1, 0);
 
-    vtkSmartPointer<vtkSphereSource> maximumSphereSource =
-            vtkSmartPointer<vtkSphereSource>::New();
-    maximumSphereSource->SetRadius(10);
-    ImageType::IndexType maximumLocation = imageCalculatorFilter->GetIndexOfMaximum();
-    maximumSphereSource->SetCenter(maximumLocation[0], maximumLocation[1], 0);
+  vtkSmartPointer<vtkSphereSource> maximumSphereSource = vtkSmartPointer<vtkSphereSource>::New();
+  maximumSphereSource->SetRadius(10);
+  ImageType::IndexType maximumLocation = imageCalculatorFilter->GetIndexOfMaximum();
+  maximumSphereSource->SetCenter(maximumLocation[0], maximumLocation[1], 0);
 
-    vtkSmartPointer<vtkPolyDataMapper> maximumMapper =
-            vtkSmartPointer<vtkPolyDataMapper>::New();
-    maximumMapper->SetInputConnection(maximumSphereSource->GetOutputPort());
-    vtkSmartPointer<vtkActor> maximumActor =
-            vtkSmartPointer<vtkActor>::New();
-    maximumActor->SetMapper(maximumMapper);
-    maximumActor->GetProperty()->SetColor(1,0,0);
+  vtkSmartPointer<vtkPolyDataMapper> maximumMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+  maximumMapper->SetInputConnection(maximumSphereSource->GetOutputPort());
+  vtkSmartPointer<vtkActor> maximumActor = vtkSmartPointer<vtkActor>::New();
+  maximumActor->SetMapper(maximumMapper);
+  maximumActor->GetProperty()->SetColor(1, 0, 0);
 
 
-    // Visualize
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
+  // Visualize
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    vtkSmartPointer<vtkRenderer> renderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(renderer);
+  vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(renderer);
 
-    // Add the sphere to the left and the cube to the right
-    renderer->AddActor(originalActor);
-    renderer->AddActor(minimumActor);
-    renderer->AddActor(maximumActor);
+  // Add the sphere to the left and the cube to the right
+  renderer->AddActor(originalActor);
+  renderer->AddActor(minimumActor);
+  renderer->AddActor(maximumActor);
 
-    renderer->ResetCamera();
+  renderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
-    interactor->SetInteractorStyle(style);
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/GetImageSize/Code.cxx
+++ b/src/Core/Common/GetImageSize/Code.cxx
@@ -19,23 +19,24 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
   // Verify command line arguments
-  if( argc < 2 )
-    {
+  if (argc < 2)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " inputImageFile" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, 2 >;
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ImageType = itk::Image<PixelType, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
 
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
   ImageType::Pointer image = reader->GetOutput();

--- a/src/Core/Common/GetNameOfClass/Code.cxx
+++ b/src/Core/Common/GetNameOfClass/Code.cxx
@@ -18,12 +18,13 @@
 
 #include "itkImage.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
   ImageType::Pointer image = ImageType::New();
 
   std::cout << "image is type: " << image->GetNameOfClass() << std::endl;

--- a/src/Core/Common/GetOrSetMemberVariableOfITKClass/Code.cxx
+++ b/src/Core/Common/GetOrSetMemberVariableOfITKClass/Code.cxx
@@ -21,15 +21,16 @@
 
 #include "ImageFilterX.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using ImageType = itk::Image<unsigned char, 2>;
-    using FilterType = itk::ImageFilter<ImageType>;
+  // Setup types
+  using ImageType = itk::Image<unsigned char, 2>;
+  using FilterType = itk::ImageFilter<ImageType>;
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/GetTypeBasicInformation/Code.cxx
+++ b/src/Core/Common/GetTypeBasicInformation/Code.cxx
@@ -18,42 +18,34 @@
 
 #include "itkNumericTraits.h"
 
-int main(int, char* [] )
+int
+main(int, char *[])
 {
   using MyType = float;
 
-  std::cout << "Min: " << itk::NumericTraits< MyType >::min() << std::endl;
-  std::cout << "Max: " << itk::NumericTraits< MyType >::max() << std::endl;
-  std::cout << "Zero: " << itk::NumericTraits< MyType >::Zero << std::endl;
-  std::cout << "ZeroValue: " << itk::NumericTraits< MyType >::ZeroValue()
-            << std::endl;
+  std::cout << "Min: " << itk::NumericTraits<MyType>::min() << std::endl;
+  std::cout << "Max: " << itk::NumericTraits<MyType>::max() << std::endl;
+  std::cout << "Zero: " << itk::NumericTraits<MyType>::Zero << std::endl;
+  std::cout << "ZeroValue: " << itk::NumericTraits<MyType>::ZeroValue() << std::endl;
 
-  std::cout << "Is -1 negative? "
-            << itk::NumericTraits< MyType >::IsNegative(-1) << std::endl;
+  std::cout << "Is -1 negative? " << itk::NumericTraits<MyType>::IsNegative(-1) << std::endl;
 
-  std::cout << "Is 1 negative? "
-            << itk::NumericTraits< MyType >::IsNegative(1)
-            << std::endl;
+  std::cout << "Is 1 negative? " << itk::NumericTraits<MyType>::IsNegative(1) << std::endl;
 
-  std::cout << "One: "
-            << itk::NumericTraits< MyType >::One
-            << std::endl;
+  std::cout << "One: " << itk::NumericTraits<MyType>::One << std::endl;
 
-  std::cout << "Epsilon: "
-            << itk::NumericTraits< MyType >::epsilon()
-            << std::endl;
+  std::cout << "Epsilon: " << itk::NumericTraits<MyType>::epsilon() << std::endl;
 
-  std::cout << "Infinity: "
-            << itk::NumericTraits< MyType >::infinity() << std::endl;
+  std::cout << "Infinity: " << itk::NumericTraits<MyType>::infinity() << std::endl;
 
-  if(0 == itk::NumericTraits< MyType >::infinity())
-    {
+  if (0 == itk::NumericTraits<MyType>::infinity())
+  {
     std::cout << " 0 == inf!" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   else
-    {
+  {
     std::cout << "Good" << std::endl;
     return EXIT_SUCCESS;
-    }
+  }
 }

--- a/src/Core/Common/ImageRegionIntersection/Code.cxx
+++ b/src/Core/Common/ImageRegionIntersection/Code.cxx
@@ -18,12 +18,13 @@
 
 #include "itkImage.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // Big region
   ImageType::RegionType bigRegion;
@@ -53,8 +54,7 @@ int main(int, char*[])
   smallInsideRegion.SetSize(smallInsideSize);
   smallInsideRegion.SetIndex(smallInsideStart);
 
-  std::cout << "Small inside region is "
-            << bigRegion.IsInside( smallInsideRegion ) << std::endl;
+  std::cout << "Small inside region is " << bigRegion.IsInside(smallInsideRegion) << std::endl;
 
   // Small outside region
   ImageType::RegionType smallOutsideRegion;
@@ -70,8 +70,7 @@ int main(int, char*[])
   smallOutsideRegion.SetSize(smallOutsideSize);
   smallOutsideRegion.SetIndex(smallOutsideStart);
 
-  std::cout << "Small outside region is "
-            << bigRegion.IsInside( smallOutsideRegion ) << std::endl;
+  std::cout << "Small outside region is " << bigRegion.IsInside(smallOutsideRegion) << std::endl;
 
   // Small overlap region
   ImageType::RegionType smallOverlapRegion;
@@ -87,8 +86,7 @@ int main(int, char*[])
   smallOverlapRegion.SetSize(smallOverlapSize);
   smallOverlapRegion.SetIndex(smallOverlapStart);
 
-  std::cout << "Small overlap region is "
-            << bigRegion.IsInside( smallOverlapRegion ) << std::endl;
+  std::cout << "Small overlap region is " << bigRegion.IsInside(smallOverlapRegion) << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ImageRegionOverlap/Code.cxx
+++ b/src/Core/Common/ImageRegionOverlap/Code.cxx
@@ -24,25 +24,26 @@
 #include "itkImageFileWriter.h"
 
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: " <<std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << " <OutputFileName>" << std::endl;
 
     return EXIT_FAILURE;
-    }
+  }
   const char * out_file_name = argv[1];
 
   constexpr unsigned int Dimension = 2;
-  using RGBPixelType = itk::RGBPixel< unsigned char >;
-  using RGBImageType = itk::Image< RGBPixelType, Dimension >;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType, Dimension>;
   using RegionType = RGBImageType::RegionType;
   using IndexType = RGBImageType::IndexType;
   using SizeType = RGBImageType::SizeType;
-  using IteratorType = itk::ImageRegionIterator< RGBImageType >;
+  using IteratorType = itk::ImageRegionIterator<RGBImageType>;
 
 
   IndexType index;
@@ -54,8 +55,8 @@ int main( int argc, char *argv[] )
   size[1] = 100;
 
   RegionType region;
-  region.SetIndex( index );
-  region.SetSize( size );
+  region.SetIndex(index);
+  region.SetSize(size);
 
   IndexType indexA;
   indexA[0] = 9;
@@ -66,8 +67,8 @@ int main( int argc, char *argv[] )
   sizeA[1] = 50;
 
   RegionType regionA;
-  regionA.SetIndex( indexA );
-  regionA.SetSize( sizeA );
+  regionA.SetIndex(indexA);
+  regionA.SetSize(sizeA);
 
   IndexType indexB;
   indexB[0] = 39;
@@ -78,78 +79,78 @@ int main( int argc, char *argv[] )
   sizeB[1] = 50;
 
   RegionType regionB;
-  regionB.SetIndex( indexB );
-  regionB.SetSize( sizeB );
+  regionB.SetIndex(indexB);
+  regionB.SetSize(sizeB);
 
   // Region C is the intersection of A and B
   // padded by 10 pixels.
   RegionType regionC = regionA;
-  regionC.Crop( regionB );
-  regionC.PadByRadius( 10 );
+  regionC.Crop(regionB);
+  regionC.PadByRadius(10);
 
   RGBPixelType pix_black;
-  pix_black.Fill( 0 );
+  pix_black.Fill(0);
 
   RGBPixelType pix_red;
-  pix_red.Fill( 0 );
+  pix_red.Fill(0);
   pix_red[0] = 255;
 
   RGBPixelType pix_green;
-  pix_green.Fill( 0 );
+  pix_green.Fill(0);
   pix_green[1] = 255;
 
   RGBPixelType pix_blue;
-  pix_blue.Fill( 0 );
+  pix_blue.Fill(0);
   pix_blue[2] = 255;
 
   // A black canvas
   RGBImageType::Pointer image = RGBImageType::New();
-  image->SetRegions( region );
+  image->SetRegions(region);
   image->Allocate();
-  image->FillBuffer( pix_black );
+  image->FillBuffer(pix_black);
 
   // Paint region A red.
-  IteratorType itA( image, regionA );
+  IteratorType itA(image, regionA);
   itA.GoToBegin();
-  while ( !itA.IsAtEnd() )
-    {
-    itA.Set( itA.Get() + pix_red );
+  while (!itA.IsAtEnd())
+  {
+    itA.Set(itA.Get() + pix_red);
     ++itA;
-    }
+  }
 
   // Paint region B green.
-  IteratorType itB( image, regionB );
+  IteratorType itB(image, regionB);
   itB.GoToBegin();
-  while ( !itB.IsAtEnd() )
-    {
-    itB.Set( itB.Get() + pix_green );
+  while (!itB.IsAtEnd())
+  {
+    itB.Set(itB.Get() + pix_green);
     ++itB;
-    }
+  }
 
   // Paint region C blue.
-  IteratorType itC( image, regionC );
+  IteratorType itC(image, regionC);
   itC.GoToBegin();
-  while ( !itC.IsAtEnd() )
-    {
-    itC.Set( itC.Get() + pix_blue );
+  while (!itC.IsAtEnd())
+  {
+    itC.Set(itC.Get() + pix_blue);
     ++itC;
-    }
+  }
 
   // Writer
-  using FileWriterType = itk::ImageFileWriter< RGBImageType >;
+  using FileWriterType = itk::ImageFileWriter<RGBImageType>;
   FileWriterType::Pointer writer = FileWriterType::New();
-  writer->SetFileName( out_file_name );
-  writer->SetInput( image );
+  writer->SetFileName(out_file_name);
+  writer->SetInput(image);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ImportPixelBufferIntoAnImage/Code.cxx
+++ b/src/Core/Common/ImportPixelBufferIntoAnImage/Code.cxx
@@ -20,14 +20,15 @@
 #include "itkImportImageFilter.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << "  outputImageFile" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // We select the data type used to represent the image pixels. We
   // assume that the external block of memory uses the same data type to
@@ -35,55 +36,53 @@ int main( int argc, char* argv[] )
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
-  using ImportFilterType = itk::ImportImageFilter< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ImportFilterType = itk::ImportImageFilter<PixelType, Dimension>;
   ImportFilterType::Pointer importFilter = ImportFilterType::New();
   // This filter requires the user to specify the size of the image to be
   // produced as output.  The `SetRegion()` method is used to this end.
   // The image size should exactly match the number of pixels available in the
   // locally allocated buffer.
-  ImportFilterType::SizeType  size;
+  ImportFilterType::SizeType size;
 
-  size[0]  = 200;  // size along X
-  size[1]  = 200;  // size along Y
+  size[0] = 200; // size along X
+  size[1] = 200; // size along Y
 
   ImportFilterType::IndexType start;
-  start.Fill( 0 );
+  start.Fill(0);
 
   ImportFilterType::RegionType region;
-  region.SetIndex( start );
-  region.SetSize(  size  );
+  region.SetIndex(start);
+  region.SetSize(size);
 
-  importFilter->SetRegion( region );
+  importFilter->SetRegion(region);
 
-  const itk::SpacePrecisionType origin[ Dimension ] = { 0.0, 0.0};
-  importFilter->SetOrigin( origin );
-  const itk::SpacePrecisionType  spacing[ Dimension ] =  { 1.0, 1.0};
-  importFilter->SetSpacing( spacing );
+  const itk::SpacePrecisionType origin[Dimension] = { 0.0, 0.0 };
+  importFilter->SetOrigin(origin);
+  const itk::SpacePrecisionType spacing[Dimension] = { 1.0, 1.0 };
+  importFilter->SetSpacing(spacing);
   // Next we allocate the memory block containing the pixel data to be
   // passed to the `ImportImageFilter`. Note that we use exactly the
   // same size that was specified with the `SetRegion()` method. In a
   // practical application, you may get this buffer from some other library
   // using a different data structure to represent the images.
-  const unsigned int numberOfPixels =  size[0] * size[1];
-  auto * localBuffer = new PixelType[ numberOfPixels ];
-  constexpr double radius = 80.0;
+  const unsigned int numberOfPixels = size[0] * size[1];
+  auto *             localBuffer = new PixelType[numberOfPixels];
+  constexpr double   radius = 80.0;
   // Here we fill up the buffer with a binary sphere.
   const double radius2 = radius * radius;
-  PixelType * it = localBuffer;
+  PixelType *  it = localBuffer;
 
-  for(unsigned int y=0; y < size[1]; y++)
+  for (unsigned int y = 0; y < size[1]; y++)
+  {
+    const double dy = static_cast<double>(y) - static_cast<double>(size[1]) / 2.0;
+    for (unsigned int x = 0; x < size[0]; x++)
     {
-    const double dy = static_cast<double>( y )
-      - static_cast<double>(size[1])/2.0;
-    for(unsigned int x=0; x < size[0]; x++)
-      {
-      const double dx = static_cast<double>( x )
-        - static_cast<double>(size[0])/2.0;
-      const double d2 = dx*dx + dy*dy;
-      *it++ = ( d2 < radius2 ) ? 255 : 0;
-      }
+      const double dx = static_cast<double>(x) - static_cast<double>(size[0]) / 2.0;
+      const double d2 = dx * dx + dy * dy;
+      *it++ = (d2 < radius2) ? 255 : 0;
     }
+  }
   // The buffer is passed to the ImportImageFilter with the
   // `SetImportPointer()` method. Note that the last argument of this method
   // specifies who will be responsible for deleting the memory block once it
@@ -99,25 +98,24 @@ int main( int argc, char* argv[] )
   // to ensure that `ImportImageFilter` is only given
   // permission to delete the C++ `new` operator-allocated memory.
   const bool importImageFilterWillOwnTheBuffer = true;
-  importFilter->SetImportPointer( localBuffer, numberOfPixels,
-                                  importImageFilterWillOwnTheBuffer );
+  importFilter->SetImportPointer(localBuffer, numberOfPixels, importImageFilterWillOwnTheBuffer);
   // Finally, we can connect the output of this filter to a pipeline.
   // For simplicity we just use a writer here, but it could be any other filter.
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
 
-  writer->SetFileName( argv[1] );
-  writer->SetInput(  importFilter->GetOutput()  );
+  writer->SetFileName(argv[1]);
+  writer->SetInput(importFilter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & exp )
-    {
+  }
+  catch (itk::ExceptionObject & exp)
+  {
     std::cerr << "Exception caught !" << std::endl;
     std::cerr << exp << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Note that we do not call `delete` on the buffer since we pass
   // `true` as the last argument of `SetImportPointer()`. Now the

--- a/src/Core/Common/InPlaceFilterOfImage/Code.cxx
+++ b/src/Core/Common/InPlaceFilterOfImage/Code.cxx
@@ -32,84 +32,80 @@
 #include "vtkImageMapper3D.h"
 #include "vtkImageViewer.h"
 
-using ImageType = itk::Image< unsigned char, 2 >;
+using ImageType = itk::Image<unsigned char, 2>;
 
-static void ApplyThresholding(ImageType::Pointer image);
+static void
+ApplyThresholding(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::string inputFilename = argv[1];
+  std::string inputFilename = argv[1];
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
 
-    reader->SetFileName(inputFilename.c_str());
-    reader->Update();
+  reader->SetFileName(inputFilename.c_str());
+  reader->Update();
 
-    ImageType::Pointer image = reader->GetOutput();
+  ImageType::Pointer image = reader->GetOutput();
 
-    ApplyThresholding(image);
+  ApplyThresholding(image);
 
-    // Visualize
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector = ConnectorType::New();
-    connector->SetInput(image);
+  // Visualize
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector = ConnectorType::New();
+  connector->SetInput(image);
 
-    vtkSmartPointer<vtkImageActor> actor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor->SetInput(connector->GetOutput());
+  actor->SetInput(connector->GetOutput());
 #else
-    connector->Update();
-    actor->GetMapper()->SetInputData(connector->GetOutput());
+  connector->Update();
+  actor->GetMapper()->SetInputData(connector->GetOutput());
 #endif
 
-    // There will be one render window
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
+  // There will be one render window
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    vtkSmartPointer<vtkRenderer> renderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(renderer);
+  vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(renderer);
 
-    renderer->AddActor(actor);
-    renderer->ResetCamera();
+  renderer->AddActor(actor);
+  renderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
 
-    interactor->SetInteractorStyle(style);
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void ApplyThresholding(ImageType::Pointer image)
+void
+ApplyThresholding(ImageType::Pointer image)
 {
 
-    using BinaryThresholdImageFilterType = itk::BinaryThresholdImageFilter <ImageType, ImageType>;
+  using BinaryThresholdImageFilterType = itk::BinaryThresholdImageFilter<ImageType, ImageType>;
 
-    BinaryThresholdImageFilterType::Pointer thresholdFilter
-            = BinaryThresholdImageFilterType::New();
-    thresholdFilter->SetInput(image);
-    thresholdFilter->SetLowerThreshold(10);
-    thresholdFilter->SetUpperThreshold(50);
-    thresholdFilter->SetInsideValue(255);
-    thresholdFilter->SetOutsideValue(0);
-    thresholdFilter->InPlaceOn();
-    thresholdFilter->Update();
+  BinaryThresholdImageFilterType::Pointer thresholdFilter = BinaryThresholdImageFilterType::New();
+  thresholdFilter->SetInput(image);
+  thresholdFilter->SetLowerThreshold(10);
+  thresholdFilter->SetUpperThreshold(50);
+  thresholdFilter->SetInsideValue(255);
+  thresholdFilter->SetOutsideValue(0);
+  thresholdFilter->InPlaceOn();
+  thresholdFilter->Update();
 }
-

--- a/src/Core/Common/IsPixelInsideRegion/Code.cxx
+++ b/src/Core/Common/IsPixelInsideRegion/Code.cxx
@@ -20,11 +20,12 @@
 #include "itkIndex.h"
 #include "itkSize.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
 
-  using RegionType = itk::ImageRegion< Dimension >;
+  using RegionType = itk::ImageRegion<Dimension>;
   using SizeType = RegionType::SizeType;
   using IndexType = RegionType::IndexType;
 
@@ -34,7 +35,7 @@ int main(int, char *[])
   IndexType start;
   start.Fill(0);
 
-  RegionType region(start,size);
+  RegionType region(start, size);
 
   IndexType testPixel1;
   testPixel1[0] = 1;
@@ -46,27 +47,27 @@ int main(int, char *[])
 
   std::cout << testPixel1 << " ";
 
-  if( region.IsInside(testPixel1) )
-    {
+  if (region.IsInside(testPixel1))
+  {
     std::cout << "Inside";
-    }
+  }
   else
-    {
+  {
     std::cout << "Outside";
     return EXIT_FAILURE;
-    }
+  }
   std::cout << std::endl;
 
   std::cout << testPixel2 << " ";
-  if( region.IsInside(testPixel2) )
-    {
+  if (region.IsInside(testPixel2))
+  {
     std::cout << "Inside";
     return EXIT_FAILURE;
-    }
+  }
   else
-    {
+  {
     std::cout << "Outside";
-    }
+  }
   std::cout << std::endl;
 
   return EXIT_SUCCESS;

--- a/src/Core/Common/IterateImageStartingAtSeed/Code.cxx
+++ b/src/Core/Common/IterateImageStartingAtSeed/Code.cxx
@@ -21,76 +21,78 @@
 #include "itkBinaryThresholdImageFunction.h"
 #include "itkImageFileWriter.h"
 
-using ImageType = itk::Image< unsigned char, 2 >;
+using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main( int  /*argc*/, char * /*argv*/[])
+int
+main(int /*argc*/, char * /*argv*/[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using FunctionType = itk::BinaryThresholdImageFunction< ImageType, double >;
-    FunctionType::Pointer function = FunctionType::New();
-    function->SetInputImage(image);
-    function->ThresholdAbove(100); // we are looking to capture 255
+  using FunctionType = itk::BinaryThresholdImageFunction<ImageType, double>;
+  FunctionType::Pointer function = FunctionType::New();
+  function->SetInputImage(image);
+  function->ThresholdAbove(100); // we are looking to capture 255
 
-    using IteratorType = itk::FloodFilledImageFunctionConditionalIterator< ImageType, FunctionType >;
+  using IteratorType = itk::FloodFilledImageFunctionConditionalIterator<ImageType, FunctionType>;
 
-    itk::Index<2> seed;
-    seed[0] = 25;
-    seed[1] = 25;
+  itk::Index<2> seed;
+  seed[0] = 25;
+  seed[1] = 25;
 
-    std::vector<itk::Index<2> > seeds;
-    seeds.push_back(seed);
+  std::vector<itk::Index<2>> seeds;
+  seeds.push_back(seed);
 
-    IteratorType it (image, function, seeds);
-    it.GoToBegin();
+  IteratorType it(image, function, seeds);
+  it.GoToBegin();
 
-    while ( !it.IsAtEnd() )
-    {
-        std::cout << it.GetIndex() << std::endl;
-        ++it;
-    }
+  while (!it.IsAtEnd())
+  {
+    std::cout << it.GetIndex() << std::endl;
+    ++it;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    itk::Index<2> start;
-    start.Fill(0);
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  itk::ImageRegion<2> region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // The line doesn't work at the moment, because it needs 8-connectivity.
+  // The line doesn't work at the moment, because it needs 8-connectivity.
 
-    // Make a line
-    for(unsigned int i = 20; i < 50; ++i)
-    {
-        itk::Index<2> pixelIndex;
-        pixelIndex.Fill(i);
+  // Make a line
+  for (unsigned int i = 20; i < 50; ++i)
+  {
+    itk::Index<2> pixelIndex;
+    pixelIndex.Fill(i);
 
-        image->SetPixel(pixelIndex, 255);
-    }
+    image->SetPixel(pixelIndex, 255);
+  }
 
-    // Make a square
-//   for(unsigned int r = 20; r < 50; r++)
-//     {
-//     for(unsigned int c = 20; c < 50; c++)
-//       {
-//       itk::Index<2> pixelIndex;
-//       pixelIndex[0] = r;
-//       pixelIndex[1] = c;
-//
-//       image->SetPixel(pixelIndex, 255);
-//       }
-//     }
+  // Make a square
+  //   for(unsigned int r = 20; r < 50; r++)
+  //     {
+  //     for(unsigned int c = 20; c < 50; c++)
+  //       {
+  //       itk::Index<2> pixelIndex;
+  //       pixelIndex[0] = r;
+  //       pixelIndex[1] = c;
+  //
+  //       image->SetPixel(pixelIndex, 255);
+  //       }
+  //     }
 }
-

--- a/src/Core/Common/IterateLineThroughImage/Code.cxx
+++ b/src/Core/Common/IterateLineThroughImage/Code.cxx
@@ -24,94 +24,90 @@
 #include "itksys/SystemTools.hxx"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using PixelType = itk::RGBPixel<unsigned char>;
 using ImageType = itk::Image<PixelType, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image = ImageType::New();
-    std::string inputFilename;
-    if (argc < 2)
-    {
-        CreateImage(image);
-        inputFilename = "Synthetic";
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName (argv[1]);
-        reader->Update();
-        image = reader->GetOutput();
-        inputFilename = argv[1];
-    }
+  ImageType::Pointer image = ImageType::New();
+  std::string        inputFilename;
+  if (argc < 2)
+  {
+    CreateImage(image);
+    inputFilename = "Synthetic";
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+    inputFilename = argv[1];
+  }
 
-    PixelType pixel;
-    pixel.SetRed(255);
-    pixel.SetGreen(127);
-    pixel.SetBlue(50);
+  PixelType pixel;
+  pixel.SetRed(255);
+  pixel.SetGreen(127);
+  pixel.SetBlue(50);
 
-    ImageType::RegionType region = image->GetLargestPossibleRegion();
-    ImageType::IndexType corner1 = region.GetIndex();
-    ImageType::IndexType corner2;
+  ImageType::RegionType region = image->GetLargestPossibleRegion();
+  ImageType::IndexType  corner1 = region.GetIndex();
+  ImageType::IndexType  corner2;
 
-    corner2[0] = corner1[0] + region.GetSize()[0] - 1;
-    corner2[1] = corner1[1] + region.GetSize()[1] - 1;
+  corner2[0] = corner1[0] + region.GetSize()[0] - 1;
+  corner2[1] = corner1[1] + region.GetSize()[1] - 1;
 
-    itk::LineIterator<ImageType> it1(image, corner1, corner2);
-    it1.GoToBegin();
-    while (!it1.IsAtEnd())
-    {
+  itk::LineIterator<ImageType> it1(image, corner1, corner2);
+  it1.GoToBegin();
+  while (!it1.IsAtEnd())
+  {
 
-        it1.Set(pixel);
-        ++it1;
-    }
+    it1.Set(pixel);
+    ++it1;
+  }
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    if (argc > 1)
-    {
-        viewer.AddImage<ImageType>(
-                image,
-                true,
-                itksys::SystemTools::GetFilenameName(argv[1]));
-    }
-    else
-    {
-        viewer.AddImage<ImageType>(
-                image,
-                true,
-                "Synthetic");
-    }
-    viewer.Visualize();
+  QuickView viewer;
+  if (argc > 1)
+  {
+    viewer.AddImage<ImageType>(image, true, itksys::SystemTools::GetFilenameName(argv[1]));
+  }
+  else
+  {
+    viewer.AddImage<ImageType>(image, true, "Synthetic");
+  }
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::SizeType regionSize;
-    regionSize.Fill(100);
+  ImageType::SizeType regionSize;
+  regionSize.Fill(100);
 
-    ImageType::IndexType regionIndex;
-    regionIndex.Fill(0);
+  ImageType::IndexType regionIndex;
+  regionIndex.Fill(0);
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    PixelType pixel;
-    pixel.SetRed(0);
-    pixel.SetGreen(127);
-    pixel.SetBlue(200);
+  PixelType pixel;
+  pixel.SetRed(0);
+  pixel.SetGreen(127);
+  pixel.SetBlue(200);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(pixel);
-
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(pixel);
 }

--- a/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/Code.cxx
@@ -22,51 +22,53 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    ImageType::RegionType region = image->GetLargestPossibleRegion();
-    ImageType::IndexType corner1 = region.GetIndex();
-    ImageType::IndexType corner2;
-    corner2[0] = corner1[0] + region.GetSize()[0] - 1;
-    corner2[1] = corner1[1] + region.GetSize()[1] - 1;
+  ImageType::RegionType region = image->GetLargestPossibleRegion();
+  ImageType::IndexType  corner1 = region.GetIndex();
+  ImageType::IndexType  corner2;
+  corner2[0] = corner1[0] + region.GetSize()[0] - 1;
+  corner2[1] = corner1[1] + region.GetSize()[1] - 1;
 
-    itk::LineConstIterator<ImageType> it(image, corner1, corner2);
-    it.GoToBegin();
-    while (!it.IsAtEnd())
-    {
-        std::cout << (int)it.Get() << std::endl;
-        ++it;
-    }
+  itk::LineConstIterator<ImageType> it(image, corner1, corner2);
+  it.GoToBegin();
+  while (!it.IsAtEnd())
+  {
+    std::cout << (int)it.Get() << std::endl;
+    ++it;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::SizeType regionSize;
-    regionSize.Fill(3);
+  ImageType::SizeType regionSize;
+  regionSize.Fill(3);
 
-    ImageType::IndexType regionIndex;
-    regionIndex.Fill(0);
+  ImageType::IndexType regionIndex;
+  regionIndex.Fill(0);
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(255);
-        ++imageIterator;
-    }
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(255);
+    ++imageIterator;
+  }
 }
-

--- a/src/Core/Common/IterateOnAVectorContainer/Code.cxx
+++ b/src/Core/Common/IterateOnAVectorContainer/Code.cxx
@@ -19,12 +19,13 @@
 #include "itkVectorContainer.h"
 #include "itkPoint.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using CoordType = double;
 
-  using PointType = itk::Point< CoordType, Dimension >;
+  using PointType = itk::Point<CoordType, Dimension>;
   using VectorContainerType = itk::VectorContainer<int, PointType>;
 
   PointType p0;
@@ -45,11 +46,11 @@ int main(int, char*[])
   point->Value() = p1;
 
   point = points->Begin();
-  while(point != points->End())
-    {
+  while (point != points->End())
+  {
     std::cout << point->Value() << std::endl;
     ++point;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Code.cxx
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Code.cxx
@@ -21,7 +21,8 @@
 #include "itkImageRegionIterator.h"
 #include "itkNeighborhoodAlgorithm.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
 
@@ -30,10 +31,10 @@ int main(int, char*[])
   // demonstration purposes it is best to use the int
   // type, however in real applications iterators have
   // no problems with char type images.
-  //using ImageType = itk::Image<unsigned char, 2>;
+  // using ImageType = itk::Image<unsigned char, 2>;
   using PixelType = unsigned int;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::Pointer image = ImageType::New();
 
@@ -43,7 +44,7 @@ int main(int, char*[])
   ImageType::SizeType size;
   size.Fill(10);
 
-  ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
   image->SetRegions(region);
   image->Allocate();
@@ -54,47 +55,41 @@ int main(int, char*[])
   radius.Fill(1);
 
   IteratorType iterator(radius, image, image->GetLargestPossibleRegion());
-  std::cout << "By default there are " << iterator.GetActiveIndexListSize()
-            << " active indices." << std::endl;
+  std::cout << "By default there are " << iterator.GetActiveIndexListSize() << " active indices." << std::endl;
 
-  IteratorType::OffsetType top = {{0,-1}};
+  IteratorType::OffsetType top = { { 0, -1 } };
   iterator.ActivateOffset(top);
-  IteratorType::OffsetType bottom = {{0,1}};
+  IteratorType::OffsetType bottom = { { 0, 1 } };
   iterator.ActivateOffset(bottom);
 
-  std::cout << "Now there are " << iterator.GetActiveIndexListSize()
-            << " active indices." << std::endl;
+  std::cout << "Now there are " << iterator.GetActiveIndexListSize() << " active indices." << std::endl;
 
-  IteratorType::IndexListType indexList = iterator.GetActiveIndexList();
-  IteratorType::IndexListType::const_iterator
-    listIterator = indexList.begin();
+  IteratorType::IndexListType                 indexList = iterator.GetActiveIndexList();
+  IteratorType::IndexListType::const_iterator listIterator = indexList.begin();
   while (listIterator != indexList.end())
-    {
+  {
     std::cout << *listIterator << " ";
     ++listIterator;
-    }
+  }
   std::cout << std::endl;
 
   // Note that ZeroFluxNeumannBoundaryCondition is used by default so even
   // pixels outside of the image will have valid values (equivalent to
   // their neighbors just inside the image)
-  for( iterator.GoToBegin(); !iterator.IsAtEnd(); ++iterator )
-    {
+  for (iterator.GoToBegin(); !iterator.IsAtEnd(); ++iterator)
+  {
     std::cout << "New position: " << std::endl;
     IteratorType::ConstIterator ci = iterator.Begin();
 
-    while( !ci.IsAtEnd() )
-      {
+    while (!ci.IsAtEnd())
+    {
       std::cout << "Centered at " << iterator.GetIndex() << std::endl;
-      std::cout << "Neighborhood index " << ci.GetNeighborhoodIndex()
-                << " is offset " << ci.GetNeighborhoodOffset()
-                << " and has value " << ci.Get()
-                << " The real index is "
-                << iterator.GetIndex() + ci.GetNeighborhoodOffset()
-                << std::endl;
+      std::cout << "Neighborhood index " << ci.GetNeighborhoodIndex() << " is offset " << ci.GetNeighborhoodOffset()
+                << " and has value " << ci.Get() << " The real index is "
+                << iterator.GetIndex() + ci.GetNeighborhoodOffset() << std::endl;
       ++ci;
-      }
     }
+  }
 
   std::cout << std::endl;
 

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Code.cxx
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Code.cxx
@@ -25,75 +25,75 @@
 // demonstration purposes it is best to use the int
 // type, however in real applications iterators have
 // no problems with char type images.
-//using ImageType = itk::Image<unsigned char, 2>;
+// using ImageType = itk::Image<unsigned char, 2>;
 using ImageType = itk::Image<unsigned int, 2>;
 
-void CreateImage(ImageType::Pointer image);
+void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using IteratorType = itk::ShapedNeighborhoodIterator<ImageType>;
+  using IteratorType = itk::ShapedNeighborhoodIterator<ImageType>;
 
-    itk::Size<2> radius;
-    radius.Fill(1);
-    IteratorType iterator(radius, image, image->GetLargestPossibleRegion());
-    std::cout << "By default there are " << iterator.GetActiveIndexListSize() << " active indices." << std::endl;
+  itk::Size<2> radius;
+  radius.Fill(1);
+  IteratorType iterator(radius, image, image->GetLargestPossibleRegion());
+  std::cout << "By default there are " << iterator.GetActiveIndexListSize() << " active indices." << std::endl;
 
-    IteratorType::OffsetType top = {{0,-1}};
-    iterator.ActivateOffset(top);
-    IteratorType::OffsetType bottom = {{0,1}};
-    iterator.ActivateOffset(bottom);
+  IteratorType::OffsetType top = { { 0, -1 } };
+  iterator.ActivateOffset(top);
+  IteratorType::OffsetType bottom = { { 0, 1 } };
+  iterator.ActivateOffset(bottom);
 
-    std::cout << "Now there are " << iterator.GetActiveIndexListSize() << " active indices." << std::endl;
+  std::cout << "Now there are " << iterator.GetActiveIndexListSize() << " active indices." << std::endl;
 
-    IteratorType::IndexListType indexList = iterator.GetActiveIndexList();
-    IteratorType::IndexListType::const_iterator listIterator = indexList.begin();
-    while (listIterator != indexList.end())
+  IteratorType::IndexListType                 indexList = iterator.GetActiveIndexList();
+  IteratorType::IndexListType::const_iterator listIterator = indexList.begin();
+  while (listIterator != indexList.end())
+  {
+    std::cout << *listIterator << " ";
+    ++listIterator;
+  }
+  std::cout << std::endl;
+
+  // Note that ZeroFluxNeumannBoundaryCondition is used by default so even
+  // pixels outside of the image will have valid values (equivalent to their neighbors just inside the image)
+  for (iterator.GoToBegin(); !iterator.IsAtEnd(); ++iterator)
+  {
+    std::cout << "New position: " << std::endl;
+    IteratorType::ConstIterator ci = iterator.Begin();
+
+    while (!ci.IsAtEnd())
     {
-        std::cout << *listIterator << " ";
-        ++listIterator;
+      std::cout << "Centered at " << iterator.GetIndex() << std::endl;
+      std::cout << "Neighborhood index " << ci.GetNeighborhoodIndex() << " is offset " << ci.GetNeighborhoodOffset()
+                << " and has value " << ci.Get() << " The real index is "
+                << iterator.GetIndex() + ci.GetNeighborhoodOffset() << std::endl;
+      ci++;
     }
-    std::cout << std::endl;
+  }
 
-    // Note that ZeroFluxNeumannBoundaryCondition is used by default so even
-    // pixels outside of the image will have valid values (equivalent to their neighbors just inside the image)
-    for(iterator.GoToBegin(); !iterator.IsAtEnd(); ++iterator)
-    {
-        std::cout << "New position: " << std::endl;
-        IteratorType::ConstIterator ci = iterator.Begin();
+  std::cout << std::endl;
 
-        while (! ci.IsAtEnd())
-        {
-            std::cout << "Centered at " << iterator.GetIndex() << std::endl;
-            std::cout << "Neighborhood index " << ci.GetNeighborhoodIndex()
-                      << " is offset " << ci.GetNeighborhoodOffset()
-                      << " and has value " << ci.Get()
-                      << " The real index is " << iterator.GetIndex() + ci.GetNeighborhoodOffset() << std::endl;
-            ci++;
-        }
-    }
-
-    std::cout << std::endl;
-
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(10);
+  ImageType::SizeType size;
+  size.Fill(10);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
-
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 }
-

--- a/src/Core/Common/IterateOverSpecificRegion/Code.cxx
+++ b/src/Core/Common/IterateOverSpecificRegion/Code.cxx
@@ -21,53 +21,54 @@
 
 namespace
 {
-    using ImageType = itk::Image<int, 2>;
+using ImageType = itk::Image<int, 2>;
 }
 
 static void CreateImage(ImageType::Pointer);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
 
-    ImageType::SizeType exclusionRegionSize;
-    exclusionRegionSize.Fill(2);
+  ImageType::SizeType exclusionRegionSize;
+  exclusionRegionSize.Fill(2);
 
-    ImageType::IndexType exclusionRegionIndex;
-    exclusionRegionIndex.Fill(0);
+  ImageType::IndexType exclusionRegionIndex;
+  exclusionRegionIndex.Fill(0);
 
-    ImageType::RegionType exclusionRegion(exclusionRegionIndex, exclusionRegionSize);
+  ImageType::RegionType exclusionRegion(exclusionRegionIndex, exclusionRegionSize);
 
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    itk::ImageRegionExclusionConstIteratorWithIndex<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
-    imageIterator.SetExclusionRegion(exclusionRegion);
+  itk::ImageRegionExclusionConstIteratorWithIndex<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  imageIterator.SetExclusionRegion(exclusionRegion);
 
-    unsigned int numberVisited = 0;
-    while(!imageIterator.IsAtEnd())
-    {
-        std::cout << imageIterator.Get() << std::endl;
-        ++imageIterator;
-        ++numberVisited;
-    }
+  unsigned int numberVisited = 0;
+  while (!imageIterator.IsAtEnd())
+  {
+    std::cout << imageIterator.Get() << std::endl;
+    ++imageIterator;
+    ++numberVisited;
+  }
 
-    std::cout << "Visited " << numberVisited << std::endl;
+  std::cout << "Visited " << numberVisited << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::SizeType regionSize;
-    regionSize.Fill(3);
+  ImageType::SizeType regionSize;
+  regionSize.Fill(3);
 
-    ImageType::IndexType regionIndex;
-    regionIndex.Fill(0);
+  ImageType::IndexType regionIndex;
+  regionIndex.Fill(0);
 
-    ImageType::RegionType region(regionIndex,regionSize);
+  ImageType::RegionType region(regionIndex, regionSize);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
-
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 }

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/Code.cxx
@@ -20,57 +20,57 @@
 #include "itkImageRegionIteratorWithIndex.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using ImageType = itk::Image<unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    ImageType::Pointer image = reader->GetOutput();
+  ImageType::Pointer image = reader->GetOutput();
 
-    ImageType::SizeType regionSize;
-    regionSize[0] = 5;
-    regionSize[1] = 4;
+  ImageType::SizeType regionSize;
+  regionSize[0] = 5;
+  regionSize[1] = 4;
 
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    itk::ImageRegionIteratorWithIndex<ImageType> imageIterator(image,region);
+  itk::ImageRegionIteratorWithIndex<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        std::cout << "Index: " << imageIterator.GetIndex() << " value: " << imageIterator.Get() << std::endl;
+  while (!imageIterator.IsAtEnd())
+  {
+    std::cout << "Index: " << imageIterator.GetIndex() << " value: " << imageIterator.Get() << std::endl;
 
-        // Set the current pixel to white
-        imageIterator.Set(255);
+    // Set the current pixel to white
+    imageIterator.Set(255);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
 #ifdef ENABLE_QUICKVIEW
-    // Visualize
-    QuickView viewer;
-    viewer.AddImage<ImageType>( image );
-    viewer.Visualize();
+  // Visualize
+  QuickView viewer;
+  viewer.AddImage<ImageType>(image);
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/Code.cxx
@@ -20,52 +20,53 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using ImageType = itk::Image<unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    ImageType::Pointer image = reader->GetOutput();
+  ImageType::Pointer image = reader->GetOutput();
 
-    ImageType::SizeType regionSize;
-    regionSize[0] = 5;
-    regionSize[1] = 4;
+  ImageType::SizeType regionSize;
+  regionSize[0] = 5;
+  regionSize[1] = 4;
 
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    itk::ImageRegionConstIteratorWithIndex<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionConstIteratorWithIndex<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        std::cout << "Index: " << imageIterator.GetIndex() << " value: " << imageIterator.Get() << std::endl;
+  while (!imageIterator.IsAtEnd())
+  {
+    std::cout << "Index: " << imageIterator.GetIndex() << " value: " << imageIterator.Get() << std::endl;
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
 #ifdef ENABLE_QUICKVIEW
-    // Visualize
-    QuickView viewer;
-    viewer.AddImage<ImageType>( image  );
-    viewer.Visualize();
+  // Visualize
+  QuickView viewer;
+  viewer.AddImage<ImageType>(image);
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/IterateRegionWithNeighborhood/Code.cxx
+++ b/src/Core/Common/IterateRegionWithNeighborhood/Code.cxx
@@ -30,99 +30,94 @@
 #include "vtkInteractorStyleImage.h"
 #include "vtkRenderer.h"
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  using ImageType = itk::Image<unsigned char, 2>;
+
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
+
+  ImageType::Pointer image = reader->GetOutput();
+
+  ImageType::SizeType regionSize;
+  regionSize[0] = 50;
+  regionSize[1] = 1;
+
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
+
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
+
+  ImageType::SizeType radius;
+  radius[0] = 1;
+  radius[1] = 1;
+
+  itk::NeighborhoodIterator<ImageType> iterator(radius, image, region);
+
+
+  while (!iterator.IsAtEnd())
+  {
+    // Set the current pixel to white
+    iterator.SetCenterPixel(255);
+
+    for (unsigned int i = 0; i < 9; i++)
     {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
+      ImageType::IndexType index = iterator.GetIndex(i);
+      std::cout << index[0] << " " << index[1] << std::endl;
+
+      bool IsInBounds;
+      iterator.GetPixel(i, IsInBounds);
+      if (IsInBounds)
+      {
+        iterator.SetPixel(i, 255);
+      }
     }
+    ++iterator;
+  }
 
-    using ImageType = itk::Image<unsigned char, 2>;
+  // Visualize
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector = ConnectorType::New();
+  connector->SetInput(image);
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
-
-    ImageType::Pointer image = reader->GetOutput();
-
-    ImageType::SizeType regionSize;
-    regionSize[0] = 50;
-    regionSize[1] = 1;
-
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
-
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
-
-    ImageType::SizeType radius;
-    radius[0] = 1;
-    radius[1] = 1;
-
-    itk::NeighborhoodIterator<ImageType> iterator(radius, image,region);
-
-
-    while(!iterator.IsAtEnd())
-    {
-        // Set the current pixel to white
-        iterator.SetCenterPixel(255);
-
-        for(unsigned int i = 0; i < 9; i++)
-        {
-            ImageType::IndexType index = iterator.GetIndex(i);
-            std::cout << index[0] << " " << index[1] << std::endl;
-
-            bool IsInBounds;
-            iterator.GetPixel(i, IsInBounds);
-            if(IsInBounds)
-            {
-                iterator.SetPixel(i,255);
-            }
-        }
-        ++iterator;
-    }
-
-    // Visualize
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector = ConnectorType::New();
-    connector->SetInput(image);
-
-    vtkSmartPointer<vtkImageActor> actor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor->SetInput(connector->GetOutput());
+  actor->SetInput(connector->GetOutput());
 #else
-    connector->Update();
+  connector->Update();
   actor->GetMapper()->SetInputData(connector->GetOutput());
 #endif
 
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    vtkSmartPointer<vtkRenderer> renderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(renderer);
+  vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(renderer);
 
-    renderer->AddActor(actor);
-    renderer->ResetCamera();
+  renderer->AddActor(actor);
+  renderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
 
-    interactor->SetInteractorStyle(style);
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/IterateRegionWithWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateRegionWithWriteAccess/Code.cxx
@@ -30,86 +30,81 @@
 #include "vtkInteractorStyleImage.h"
 #include "vtkRenderer.h"
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using ImageType = itk::Image<unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    ImageType::Pointer image = reader->GetOutput();
+  ImageType::Pointer image = reader->GetOutput();
 
-    ImageType::SizeType regionSize;
-    regionSize[0] = 5;
-    regionSize[1] = 4;
+  ImageType::SizeType regionSize;
+  regionSize[0] = 5;
+  regionSize[1] = 4;
 
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        // Get the value of the current pixel
-        //unsigned char val = imageIterator.Get();
-        //std::cout << (int)val << std::endl;
+  while (!imageIterator.IsAtEnd())
+  {
+    // Get the value of the current pixel
+    // unsigned char val = imageIterator.Get();
+    // std::cout << (int)val << std::endl;
 
-        // Set the current pixel to white
-        imageIterator.Set(255);
+    // Set the current pixel to white
+    imageIterator.Set(255);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
-    // Visualize
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector = ConnectorType::New();
-    connector->SetInput(image);
+  // Visualize
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector = ConnectorType::New();
+  connector->SetInput(image);
 
-    vtkSmartPointer<vtkImageActor> actor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor->SetInput(connector->GetOutput());
+  actor->SetInput(connector->GetOutput());
 #else
-    connector->Update();
+  connector->Update();
   actor->GetMapper()->SetInputData(connector->GetOutput());
 #endif
 
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    vtkSmartPointer<vtkRenderer> renderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(renderer);
+  vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(renderer);
 
-    renderer->AddActor(actor);
-    renderer->ResetCamera();
+  renderer->AddActor(actor);
+  renderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
 
-    interactor->SetInteractorStyle(style);
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/IterateRegionWithoutWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateRegionWithoutWriteAccess/Code.cxx
@@ -19,47 +19,47 @@
 #include "itkImageFileReader.h"
 #include "itkImageRegionConstIterator.h"
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using ImageType = itk::Image<unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    ImageType::Pointer image = reader->GetOutput();
+  ImageType::Pointer image = reader->GetOutput();
 
-    ImageType::SizeType regionSize;
-    regionSize[0] = 5;
-    regionSize[1] = 4;
+  ImageType::SizeType regionSize;
+  regionSize[0] = 5;
+  regionSize[1] = 4;
 
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    itk::ImageRegionConstIterator<ImageType> imageIterator(image,region);
-    //itk::ImageRegionConstIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<ImageType> imageIterator(image, region);
+  // itk::ImageRegionConstIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        // Get the value of the current pixel
-        unsigned char val = imageIterator.Get();
-        std::cout << (int)val << std::endl;
+  while (!imageIterator.IsAtEnd())
+  {
+    // Get the value of the current pixel
+    unsigned char val = imageIterator.Get();
+    std::cout << (int)val << std::endl;
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/IterateWithNeighborhoodWithoutAccess/Code.cxx
+++ b/src/Core/Common/IterateWithNeighborhoodWithoutAccess/Code.cxx
@@ -19,57 +19,56 @@
 #include "itkImageFileReader.h"
 #include "itkConstNeighborhoodIterator.h"
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  using ImageType = itk::Image<unsigned char, 2>;
+
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
+
+  ImageType::Pointer image = reader->GetOutput();
+
+  ImageType::SizeType regionSize;
+  regionSize[0] = 50;
+  regionSize[1] = 1;
+
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
+
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
+
+  ImageType::SizeType radius;
+  radius[0] = 1;
+  radius[1] = 1;
+
+  itk::ConstNeighborhoodIterator<ImageType> iterator(radius, image, region);
+
+
+  while (!iterator.IsAtEnd())
+  {
+    for (unsigned int i = 0; i < 9; i++)
     {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
+      ImageType::IndexType index = iterator.GetIndex(i);
+      std::cout << index[0] << " " << index[1] << std::endl;
+
+      bool IsInBounds;
+      iterator.GetPixel(i, IsInBounds);
     }
-
-    using ImageType = itk::Image<unsigned char, 2>;
-
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
-
-    ImageType::Pointer image = reader->GetOutput();
-
-    ImageType::SizeType regionSize;
-    regionSize[0] = 50;
-    regionSize[1] = 1;
-
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
-
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
-
-    ImageType::SizeType radius;
-    radius[0] = 1;
-    radius[1] = 1;
-
-    itk::ConstNeighborhoodIterator<ImageType> iterator(radius, image,region);
+    ++iterator;
+  }
 
 
-    while(!iterator.IsAtEnd())
-    {
-        for(unsigned int i = 0; i < 9; i++)
-        {
-            ImageType::IndexType index = iterator.GetIndex(i);
-            std::cout << index[0] << " " << index[1] << std::endl;
-
-            bool IsInBounds;
-            iterator.GetPixel(i, IsInBounds);
-
-        }
-        ++iterator;
-    }
-
-
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/Matrix/Code.cxx
+++ b/src/Core/Common/Matrix/Code.cxx
@@ -20,33 +20,37 @@
 
 #include <iostream>
 
-static void Construct();
-//static void ConstructRunTimeDims();
-static void Multiply();
-//static void Inverse();
+static void
+Construct();
+// static void ConstructRunTimeDims();
+static void
+Multiply();
+// static void Inverse();
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    Construct();
-    Multiply();
-    return EXIT_SUCCESS;
+  Construct();
+  Multiply();
+  return EXIT_SUCCESS;
 }
 
-void Construct()
+void
+Construct()
 {
-    using MatrixType = itk::Matrix<double, 3, 3>;
-    MatrixType M;
-    M(0,0) = 1.0;
-    M(0,1) = 2.0;
-    M(0,2) = 3.0;
-    M(1,0) = 4.0;
-    M(1,1) = 5.0;
-    M(1,2) = 6.0;
-    M(2,0) = 7.0;
-    M(2,1) = 8.0;
-    M(2,2) = 9.0;
+  using MatrixType = itk::Matrix<double, 3, 3>;
+  MatrixType M;
+  M(0, 0) = 1.0;
+  M(0, 1) = 2.0;
+  M(0, 2) = 3.0;
+  M(1, 0) = 4.0;
+  M(1, 1) = 5.0;
+  M(1, 2) = 6.0;
+  M(2, 0) = 7.0;
+  M(2, 1) = 8.0;
+  M(2, 2) = 9.0;
 
-    std::cout << "M: " << M << std::endl;
+  std::cout << "M: " << M << std::endl;
 }
 
 /*
@@ -69,31 +73,32 @@ void ConstructRunTimeDims()
 }
 */
 
-void Multiply()
+void
+Multiply()
 {
-    using MatrixType = itk::Matrix<double, 3, 3>;
-    MatrixType M;
-    M(0,0) = 1.0;
-    M(0,1) = 2.0;
-    M(0,2) = 3.0;
-    M(1,0) = 4.0;
-    M(1,1) = 5.0;
-    M(1,2) = 6.0;
-    M(2,0) = 7.0;
-    M(2,1) = 8.0;
-    M(2,2) = 9.0;
+  using MatrixType = itk::Matrix<double, 3, 3>;
+  MatrixType M;
+  M(0, 0) = 1.0;
+  M(0, 1) = 2.0;
+  M(0, 2) = 3.0;
+  M(1, 0) = 4.0;
+  M(1, 1) = 5.0;
+  M(1, 2) = 6.0;
+  M(2, 0) = 7.0;
+  M(2, 1) = 8.0;
+  M(2, 2) = 9.0;
 
-    std::cout << "M: " << M << std::endl;
+  std::cout << "M: " << M << std::endl;
 
-    using VectorType = itk::Vector<double, 3>;
-    VectorType V;
-    V[0] = 1.0;
-    V[1] = 2.0;
-    V[2] = 3.0;
+  using VectorType = itk::Vector<double, 3>;
+  VectorType V;
+  V[0] = 1.0;
+  V[1] = 2.0;
+  V[2] = 3.0;
 
-    std::cout << "V: " << V << std::endl;
+  std::cout << "V: " << V << std::endl;
 
-    std::cout << "MV: " << M*V << std::endl;
+  std::cout << "MV: " << M * V << std::endl;
 }
 
 /*

--- a/src/Core/Common/MatrixInverse/Code.cxx
+++ b/src/Core/Common/MatrixInverse/Code.cxx
@@ -19,21 +19,21 @@
 
 #include <iostream>
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using MatrixType = itk::Matrix<double, 2, 2>;
-    MatrixType M;
-    M(0,0) = 1.0;
-    M(0,1) = 2.0;
-    M(1,0) = 3.0;
-    M(1,1) = 5.0;
+  using MatrixType = itk::Matrix<double, 2, 2>;
+  MatrixType M;
+  M(0, 0) = 1.0;
+  M(0, 1) = 2.0;
+  M(1, 0) = 3.0;
+  M(1, 1) = 5.0;
 
-    std::cout << "M: " << M << std::endl;
+  std::cout << "M: " << M << std::endl;
 
-    MatrixType Minv( M.GetInverse() );
+  MatrixType Minv(M.GetInverse());
 
-    std::cout << "Inverse: " << Minv << std::endl;
+  std::cout << "Inverse: " << Minv << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/MersenneTwisterRandomIntegerGenerator/Code.cxx
+++ b/src/Core/Common/MersenneTwisterRandomIntegerGenerator/Code.cxx
@@ -18,7 +18,8 @@
 
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   GeneratorType::Pointer generator = GeneratorType::New();

--- a/src/Core/Common/MersenneTwisterRandomNumberGenerator/Code.cxx
+++ b/src/Core/Common/MersenneTwisterRandomNumberGenerator/Code.cxx
@@ -18,7 +18,8 @@
 
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   GeneratorType::Pointer generator = GeneratorType::New();

--- a/src/Core/Common/MiniPipeline/Code.cxx
+++ b/src/Core/Common/MiniPipeline/Code.cxx
@@ -22,62 +22,64 @@
 #include "ImageFilterY.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using ImageType = itk::Image<unsigned char, 2>;
-    using FilterType = itk::ImageFilter<ImageType>;
+  // Setup types
+  using ImageType = itk::Image<unsigned char, 2>;
+  using FilterType = itk::ImageFilter<ImageType>;
 
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image.GetPointer());
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image.GetPointer());
 
-    std::cout << "Input:" << std::endl;
-    std::cout << image->GetLargestPossibleRegion() << std::endl;
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(image);
-    filter->Update();
+  std::cout << "Input:" << std::endl;
+  std::cout << image->GetLargestPossibleRegion() << std::endl;
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(image);
+  filter->Update();
 
-    std::cout << "Input:" << std::endl;
-    std::cout << filter->GetOutput()->GetLargestPossibleRegion() << std::endl;
+  std::cout << "Input:" << std::endl;
+  std::cout << filter->GetOutput()->GetLargestPossibleRegion() << std::endl;
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("Output.png");
-    writer->SetInput(filter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("Output.png");
+  writer->SetInput(filter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
-    // Create an image with 2 connected components
-    typename TImage::IndexType corner = {{0,0}};
+  // Create an image with 2 connected components
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
-    typename TImage::RegionType region(corner, size);
+  typename TImage::RegionType region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make another square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make another square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            typename TImage::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      typename TImage::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }
-

--- a/src/Core/Common/MultiThreadOilPainting/Code.cxx
+++ b/src/Core/Common/MultiThreadOilPainting/Code.cxx
@@ -21,59 +21,53 @@
 #include "itkOilPaintingImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    if (argc < 2)
-    {
-        std::cerr << "Usage: " << argv[0] << " inputFile [bins [radius]]" << std::endl;
-        return EXIT_FAILURE;
-    }
-    unsigned int numberOfBins = 50;
-    if (argc >= 3)
-    {
-        numberOfBins = std::stoi(argv[2]);
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " inputFile [bins [radius]]" << std::endl;
+    return EXIT_FAILURE;
+  }
+  unsigned int numberOfBins = 50;
+  if (argc >= 3)
+  {
+    numberOfBins = std::stoi(argv[2]);
+  }
 
-    unsigned int radius = 2;
-    if (argc >= 4)
-    {
-        radius = std::stoi(argv[3]);
-    }
+  unsigned int radius = 2;
+  if (argc >= 4)
+  {
+    radius = std::stoi(argv[3]);
+  }
 
-    using ImageType = itk::Image<unsigned char, 2>;
-    using FilterType = itk::OilPaintingImageFilter<ImageType>;
+  using ImageType = itk::Image<unsigned char, 2>;
+  using FilterType = itk::OilPaintingImageFilter<ImageType>;
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetNumberOfBins(numberOfBins);
-    filter->SetRadius(radius);
-    filter->Update();
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(reader->GetOutput());
+  filter->SetNumberOfBins(numberOfBins);
+  filter->SetRadius(radius);
+  filter->Update();
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),
-            true,
-            itksys::SystemTools::GetFilenameName(reader->GetFileName()));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(reader->GetFileName()));
 
-    std::stringstream desc;
-    desc << "OilPaintingImageFilter, bins = " << numberOfBins
-         << " radius = " << radius;
-    viewer.AddImage(
-            filter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "OilPaintingImageFilter, bins = " << numberOfBins << " radius = " << radius;
+  viewer.AddImage(filter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/MultipleInputsOfDifferentType/Code.cxx
+++ b/src/Core/Common/MultipleInputsOfDifferentType/Code.cxx
@@ -22,29 +22,29 @@
 
 #include "ImageFilterMultipleInputsDifferentType.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using VectorImageType = itk::Image<itk::CovariantVector<unsigned char, 3>, 2>;
-    using ScalarImageType = itk::Image<unsigned char, 2>;
-    using FilterType = itk::ImageFilterMultipleInputsDifferentType<VectorImageType, ScalarImageType>;
+  // Setup types
+  using VectorImageType = itk::Image<itk::CovariantVector<unsigned char, 3>, 2>;
+  using ScalarImageType = itk::Image<unsigned char, 2>;
+  using FilterType = itk::ImageFilterMultipleInputsDifferentType<VectorImageType, ScalarImageType>;
 
-    using ReaderType = itk::ImageFileReader<VectorImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName("Test.jpg");
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<VectorImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName("Test.jpg");
+  reader->Update();
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(reader->GetOutput());
+  filter->Update();
 
-    using WriterType = itk::ImageFileWriter< VectorImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("TestOutput.jpg");
-    writer->SetInput(filter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<VectorImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("TestOutput.jpg");
+  writer->SetInput(filter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/MultipleInputsOfSameType/Code.cxx
+++ b/src/Core/Common/MultipleInputsOfSameType/Code.cxx
@@ -21,20 +21,21 @@
 
 #include "itkImageFilterMultipleInputs.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using ImageType = itk::Image<unsigned char, 2>;
-    using FilterType = itk::ImageFilterMultipleInputs<ImageType>;
+  // Setup types
+  using ImageType = itk::Image<unsigned char, 2>;
+  using FilterType = itk::ImageFilterMultipleInputs<ImageType>;
 
-    ImageType::Pointer image = ImageType::New();
-    ImageType::Pointer mask = ImageType::New();
+  ImageType::Pointer image = ImageType::New();
+  ImageType::Pointer mask = ImageType::New();
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInputImage(image);
-    filter->SetInputMask(mask);
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInputImage(image);
+  filter->SetInputMask(mask);
+  filter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/MultipleOutputsOfDifferentType/Code.cxx
+++ b/src/Core/Common/MultipleOutputsOfDifferentType/Code.cxx
@@ -21,34 +21,34 @@
 
 #include "ImageFilterMultipleOutputsDifferentType.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using InputImageType = itk::Image<unsigned char, 2>;
-    using OutputImageType1 = itk::Image<float, 2>;
-    using OutputImageType2 = itk::Image<int, 2>;
-    using FilterType = itk::ImageFilterMultipleOutputsDifferentType<InputImageType, OutputImageType1, OutputImageType2>;
+  // Setup types
+  using InputImageType = itk::Image<unsigned char, 2>;
+  using OutputImageType1 = itk::Image<float, 2>;
+  using OutputImageType2 = itk::Image<int, 2>;
+  using FilterType = itk::ImageFilterMultipleOutputsDifferentType<InputImageType, OutputImageType1, OutputImageType2>;
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->Update();
 
-    {
-        using WriterType = itk::ImageFileWriter< OutputImageType1  >;
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetFileName("TestOutput1.jpg");
-        writer->SetInput(filter->GetOutput1());
-        writer->Update();
-    }
+  {
+    using WriterType = itk::ImageFileWriter<OutputImageType1>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput1.jpg");
+    writer->SetInput(filter->GetOutput1());
+    writer->Update();
+  }
 
-    {
-        using WriterType = itk::ImageFileWriter< OutputImageType2  >;
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetFileName("TestOutput2.jpg");
-        writer->SetInput(filter->GetOutput2());
-        writer->Update();
-    }
+  {
+    using WriterType = itk::ImageFileWriter<OutputImageType2>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput2.jpg");
+    writer->SetInput(filter->GetOutput2());
+    writer->Update();
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/MultipleOutputsOfSameType/Code.cxx
+++ b/src/Core/Common/MultipleOutputsOfSameType/Code.cxx
@@ -21,32 +21,32 @@
 
 #include "ImageFilterMultipleOutputs.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Setup types
-    using ImageType = itk::Image<unsigned char, 2>;
-    using FilterType = itk::ImageFilterMultipleOutputs<ImageType>;
+  // Setup types
+  using ImageType = itk::Image<unsigned char, 2>;
+  using FilterType = itk::ImageFilterMultipleOutputs<ImageType>;
 
-    // Create and the filter
-    FilterType::Pointer filter = FilterType::New();
-    filter->Update();
+  // Create and the filter
+  FilterType::Pointer filter = FilterType::New();
+  filter->Update();
 
-    {
-        using WriterType = itk::ImageFileWriter< ImageType  >;
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetFileName("TestOutput1.jpg");
-        writer->SetInput(filter->GetOutput1());
-        writer->Update();
-    }
+  {
+    using WriterType = itk::ImageFileWriter<ImageType>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput1.jpg");
+    writer->SetInput(filter->GetOutput1());
+    writer->Update();
+  }
 
-    {
-        using WriterType = itk::ImageFileWriter< ImageType  >;
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetFileName("TestOutput2.jpg");
-        writer->SetInput(filter->GetOutput2());
-        writer->Update();
-    }
+  {
+    using WriterType = itk::ImageFileWriter<ImageType>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput2.jpg");
+    writer->SetInput(filter->GetOutput2());
+    writer->Update();
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/NeighborhoodIteratorOnVectorImage/Code.cxx
+++ b/src/Core/Common/NeighborhoodIteratorOnVectorImage/Code.cxx
@@ -20,37 +20,38 @@
 
 using VectorImageType = itk::VectorImage<unsigned char, 2>;
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Create an image
-    VectorImageType::Pointer image = VectorImageType::New();
+  // Create an image
+  VectorImageType::Pointer image = VectorImageType::New();
 
-    itk::Index<2> start;
-    start.Fill(0);
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(10);
+  itk::Size<2> size;
+  size.Fill(10);
 
-    itk::ImageRegion<2> region(start,size);
+  itk::ImageRegion<2> region(start, size);
 
-    image->SetRegions(region);
-    image->SetNumberOfComponentsPerPixel(3);
-    image->Allocate();
+  image->SetRegions(region);
+  image->SetNumberOfComponentsPerPixel(3);
+  image->Allocate();
 
-    // Create the neighborhood iterator
-    VectorImageType::SizeType radius;
-    radius[0] = 1;
-    radius[1] = 1;
+  // Create the neighborhood iterator
+  VectorImageType::SizeType radius;
+  radius[0] = 1;
+  radius[1] = 1;
 
-    itk::NeighborhoodIterator<VectorImageType> iterator(radius, image, image->GetLargestPossibleRegion());
+  itk::NeighborhoodIterator<VectorImageType> iterator(radius, image, image->GetLargestPossibleRegion());
 
-    while(!iterator.IsAtEnd())
-    {
-        iterator.GetCenterPixel();
+  while (!iterator.IsAtEnd())
+  {
+    iterator.GetCenterPixel();
 
-        ++iterator;
-    }
+    ++iterator;
+  }
 
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ObserveAnEvent/Code.cxx
+++ b/src/Core/Common/ObserveAnEvent/Code.cxx
@@ -20,49 +20,51 @@
 #include "itkGaussianImageSource.h"
 #include "itkCommand.h"
 
-class MyCommand: public itk::Command
+class MyCommand : public itk::Command
 {
-  public:
-    itkNewMacro( MyCommand );
+public:
+  itkNewMacro(MyCommand);
 
-    void Execute(itk::Object * caller, const itk::EventObject & event) override
-      {
-      Execute( (const itk::Object *)caller, event);
-      }
+  void
+  Execute(itk::Object * caller, const itk::EventObject & event) override
+  {
+    Execute((const itk::Object *)caller, event);
+  }
 
-    void Execute(const itk::Object * caller, const itk::EventObject & event) override
-      {
-      if( ! itk::ProgressEvent().CheckEvent( &event ) )
-        {
-        return;
-        }
-      const auto * processObject =
-        dynamic_cast< const itk::ProcessObject * >( caller );
-      if( ! processObject )
-        {
-        return;
-        }
-      std::cout << "Progress: " << processObject->GetProgress() << std::endl;
-      }
+  void
+  Execute(const itk::Object * caller, const itk::EventObject & event) override
+  {
+    if (!itk::ProgressEvent().CheckEvent(&event))
+    {
+      return;
+    }
+    const auto * processObject = dynamic_cast<const itk::ProcessObject *>(caller);
+    if (!processObject)
+    {
+      return;
+    }
+    std::cout << "Progress: " << processObject->GetProgress() << std::endl;
+  }
 };
 
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using SourceType = itk::GaussianImageSource< ImageType >;
+  using SourceType = itk::GaussianImageSource<ImageType>;
   SourceType::Pointer source = SourceType::New();
 
   ImageType::SizeType size;
-  size.Fill( 128 );
-  source->SetSize( size );
+  size.Fill(128);
+  source->SetSize(size);
 
   SourceType::ArrayType sigma;
-  sigma.Fill( 45.0 );
-  source->SetSigma( sigma );
+  sigma.Fill(45.0);
+  source->SetSigma(sigma);
 
   MyCommand::Pointer myCommand = MyCommand::New();
   source->AddObserver(itk::ProgressEvent(), myCommand);

--- a/src/Core/Common/OutOfBoundsPixelsReturnConstValue/Code.cxx
+++ b/src/Core/Common/OutOfBoundsPixelsReturnConstValue/Code.cxx
@@ -33,112 +33,107 @@
 #include "vtkRenderer.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    ImageType::SizeType regionSize;
-    regionSize[0] = 50;
-    regionSize[1] = 1;
+  ImageType::SizeType regionSize;
+  regionSize[0] = 50;
+  regionSize[1] = 1;
 
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    ImageType::SizeType radius;
-    radius[0] = 1;
-    radius[1] = 1;
+  ImageType::SizeType radius;
+  radius[0] = 1;
+  radius[1] = 1;
 
-    using BoundaryConditionType = itk::ConstantBoundaryCondition<ImageType>;
-    itk::ConstNeighborhoodIterator<ImageType, BoundaryConditionType> iterator(radius, image,region);
+  using BoundaryConditionType = itk::ConstantBoundaryCondition<ImageType>;
+  itk::ConstNeighborhoodIterator<ImageType, BoundaryConditionType> iterator(radius, image, region);
 
-    while(!iterator.IsAtEnd())
+  while (!iterator.IsAtEnd())
+  {
+    for (unsigned int i = 0; i < 9; i++)
     {
-        for(unsigned int i = 0; i < 9; i++)
-        {
-            ImageType::IndexType index = iterator.GetIndex(i);
+      ImageType::IndexType index = iterator.GetIndex(i);
 
-            std::cout << "Index: " << index
-                      << " Pixel: " << i << " = "
-                      << (int)iterator.GetPixel(i) << std::endl;
-        }
-        ++iterator;
+      std::cout << "Index: " << index << " Pixel: " << i << " = " << (int)iterator.GetPixel(i) << std::endl;
     }
+    ++iterator;
+  }
 
-    // Visualize
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector = ConnectorType::New();
-    connector->SetInput(image);
+  // Visualize
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector = ConnectorType::New();
+  connector->SetInput(image);
 
-    vtkSmartPointer<vtkImageActor> actor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor->SetInput(connector->GetOutput());
+  actor->SetInput(connector->GetOutput());
 #else
-    connector->Update();
+  connector->Update();
   actor->GetMapper()->SetInputData(connector->GetOutput());
 #endif
 
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    vtkSmartPointer<vtkRenderer> renderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(renderer);
+  vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(renderer);
 
-    renderer->AddActor(actor);
-    renderer->ResetCamera();
+  renderer->AddActor(actor);
+  renderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
 
-    interactor->SetInteractorStyle(style);
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 5;
-    unsigned int NumCols = 5;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 5;
+  unsigned int        NumCols = 5;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    // Set all pixels to white
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(255);
-        ++imageIterator;
-    }
+  // Set all pixels to white
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(255);
+    ++imageIterator;
+  }
 }
-

--- a/src/Core/Common/PassImageToFunction/Code.cxx
+++ b/src/Core/Common/PassImageToFunction/Code.cxx
@@ -20,40 +20,41 @@
 #include <iostream>
 
 using ImageType = itk::Image<float, 2>;
-static void myStandardPointer(const ImageType*)
-{
-}
+static void
+myStandardPointer(const ImageType *)
+{}
 
-static void mySmartPointer(const ImageType::Pointer)
-{
-}
-
-template <typename TImage>
-static void TemplateSmartPointer(const typename TImage::Pointer)
-{
-}
+static void
+mySmartPointer(const ImageType::Pointer)
+{}
 
 template <typename TImage>
-static void TemplateStandardPointer(const TImage*)
+static void
+TemplateSmartPointer(const typename TImage::Pointer)
+{}
+
+template <typename TImage>
+static void
+TemplateStandardPointer(const TImage *)
+{}
+
+int
+main(int, char *[])
 {
-}
+  ImageType::Pointer  image = ImageType::New();
+  itk::Index<2>       corner = { { 0, 0 } };
+  itk::Size<2>        size = { { 10, 10 } };
+  itk::ImageRegion<2> region(corner, size);
+  image->SetRegions(region);
+  image->Allocate();
 
-int main(int, char *[])
-{
-    ImageType::Pointer image = ImageType::New();
-    itk::Index<2> corner = {{0,0}};
-    itk::Size<2> size = {{10,10}};
-    itk::ImageRegion<2> region(corner,size);
-    image->SetRegions(region);
-    image->Allocate();
+  // A function that accepts a standard pointer can be passed either a standard or a smart pointer
+  myStandardPointer(image.GetPointer());
+  myStandardPointer(image);
 
-    // A function that accepts a standard pointer can be passed either a standard or a smart pointer
-    myStandardPointer(image.GetPointer());
-    myStandardPointer(image);
+  // A function that accepts a smart pointer can be passed either a standard or a smart pointer
+  mySmartPointer(image.GetPointer());
+  mySmartPointer(image);
 
-    // A function that accepts a smart pointer can be passed either a standard or a smart pointer
-    mySmartPointer(image.GetPointer());
-    mySmartPointer(image);
-
-    return 0;
+  return 0;
 }

--- a/src/Core/Common/PermuteSequenceOfIndices/Code.cxx
+++ b/src/Core/Common/PermuteSequenceOfIndices/Code.cxx
@@ -17,27 +17,27 @@
  *=========================================================================*/
 #include <itkImageRandomNonRepeatingConstIteratorWithIndex.h>
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    itk::RandomPermutation rp(5);
+  itk::RandomPermutation rp(5);
 
-    std::cout << std::endl;
+  std::cout << std::endl;
 
-    for(unsigned int i = 0; i < 5; i++)
-    {
-        std::cout << rp[i] << " ";
-    }
-    std::cout << std::endl << std::endl;
+  for (unsigned int i = 0; i < 5; i++)
+  {
+    std::cout << rp[i] << " ";
+  }
+  std::cout << std::endl << std::endl;
 
-    rp.Shuffle();
-    std::cout << "After shuffle" << std::endl;
-    for(unsigned int i = 0; i < 5; i++)
-    {
-        std::cout << rp[i] << " ";
-    }
-    std::cout << std::endl;
+  rp.Shuffle();
+  std::cout << "After shuffle" << std::endl;
+  for (unsigned int i = 0; i < 5; i++)
+  {
+    std::cout << rp[i] << " ";
+  }
+  std::cout << std::endl;
 
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/PiConstant/Code.cxx
+++ b/src/Core/Common/PiConstant/Code.cxx
@@ -18,8 +18,9 @@
 
 #include "itkMath.h"
 
-int main( int  /*argc*/, char*  /*argv*/[] )
+int
+main(int /*argc*/, char * /*argv*/[])
 {
-    std::cout << itk::Math::pi << std::endl;
-    return EXIT_SUCCESS;
+  std::cout << itk::Math::pi << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ProduceImageProgrammatically/Code.cxx
+++ b/src/Core/Common/ProduceImageProgrammatically/Code.cxx
@@ -26,16 +26,15 @@
 namespace itk
 {
 
-    template< class TImage>
-    void ImageFilter< TImage>
-    ::GenerateData()
-    {
-        double a = 2.1;
-        itkExceptionMacro ("Here is a variable: " << a << " and then more text.");
-    }
+template <class TImage>
+void
+ImageFilter<TImage>::GenerateData()
+{
+  double a = 2.1;
+  itkExceptionMacro("Here is a variable: " << a << " and then more text.");
+}
 
-}// end namespace
+} // namespace itk
 
 
 #endif
-

--- a/src/Core/Common/RandomSelectOfPixelsFromRegion/Code.cxx
+++ b/src/Core/Common/RandomSelectOfPixelsFromRegion/Code.cxx
@@ -19,37 +19,38 @@
 #include "itkImageFileReader.h"
 #include "itkImageRandomConstIteratorWithIndex.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using ImageType = itk::Image<unsigned char, 2>;
-    ImageType::Pointer image = ImageType::New();
+  using ImageType = itk::Image<unsigned char, 2>;
+  ImageType::Pointer image = ImageType::New();
 
-    ImageType::SizeType regionSize;
-    regionSize[0] = 5;
-    regionSize[1] = 4;
+  ImageType::SizeType regionSize;
+  regionSize[0] = 5;
+  regionSize[1] = 4;
 
-    ImageType::IndexType regionIndex;
-    regionIndex[0] = 0;
-    regionIndex[1] = 0;
+  ImageType::IndexType regionIndex;
+  regionIndex[0] = 0;
+  regionIndex[1] = 0;
 
-    ImageType::RegionType region;
-    region.SetSize(regionSize);
-    region.SetIndex(regionIndex);
+  ImageType::RegionType region;
+  region.SetSize(regionSize);
+  region.SetIndex(regionIndex);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRandomConstIteratorWithIndex<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
-    imageIterator.SetNumberOfSamples(200);
-    imageIterator.GoToBegin();
+  itk::ImageRandomConstIteratorWithIndex<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  imageIterator.SetNumberOfSamples(200);
+  imageIterator.GoToBegin();
 
-    while(!imageIterator.IsAtEnd())
-    {
-        std::cout << imageIterator.GetIndex() << std::endl;
+  while (!imageIterator.IsAtEnd())
+  {
+    std::cout << imageIterator.GetIndex() << std::endl;
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/Code.cxx
+++ b/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/Code.cxx
@@ -19,33 +19,34 @@
 #include "itkImageFileReader.h"
 #include "itkImageRandomNonRepeatingConstIteratorWithIndex.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using ImageType = itk::Image<unsigned char, 2>;
-    ImageType::Pointer image = ImageType::New();
+  using ImageType = itk::Image<unsigned char, 2>;
+  ImageType::Pointer image = ImageType::New();
 
-    ImageType::SizeType regionSize;
-    regionSize.Fill(3);
+  ImageType::SizeType regionSize;
+  regionSize.Fill(3);
 
-    ImageType::IndexType regionIndex;
-    regionIndex.Fill(0);
+  ImageType::IndexType regionIndex;
+  regionIndex.Fill(0);
 
-    ImageType::RegionType region(regionIndex, regionSize);
+  ImageType::RegionType region(regionIndex, regionSize);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRandomNonRepeatingConstIteratorWithIndex<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
-    imageIterator.SetNumberOfSamples(region.GetNumberOfPixels());
+  itk::ImageRandomNonRepeatingConstIteratorWithIndex<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  imageIterator.SetNumberOfSamples(region.GetNumberOfPixels());
 
-    imageIterator.GoToBegin();
-    while(!imageIterator.IsAtEnd())
-    {
-        std::cout << imageIterator.GetIndex() << std::endl;
+  imageIterator.GoToBegin();
+  while (!imageIterator.IsAtEnd())
+  {
+    std::cout << imageIterator.GetIndex() << std::endl;
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/Code.cxx
+++ b/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/Code.cxx
@@ -19,86 +19,89 @@
 #include "itkImageSeriesReader.h"
 #include "itkNumericSeriesFileNames.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <seriesFormat> <startIndex> <endIndex>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * seriesFormat = argv[1];
-  unsigned int startIndex = std::stoi( argv[2] );
-  unsigned int endIndex = std::stoi( argv[3] );
+  unsigned int startIndex = std::stoi(argv[2]);
+  unsigned int endIndex = std::stoi(argv[3]);
 
   constexpr unsigned int Dimension = 3;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   using NameGeneratorType = itk::NumericSeriesFileNames;
   NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
-  nameGenerator->SetSeriesFormat( seriesFormat );
-  nameGenerator->SetStartIndex( startIndex );
-  nameGenerator->SetEndIndex( endIndex );
-  std::vector< std::string > fileNames = nameGenerator->GetFileNames();
+  nameGenerator->SetSeriesFormat(seriesFormat);
+  nameGenerator->SetStartIndex(startIndex);
+  nameGenerator->SetEndIndex(endIndex);
+  std::vector<std::string> fileNames = nameGenerator->GetFileNames();
 
-  using ReaderType = itk::ImageSeriesReader< ImageType >;
+  using ReaderType = itk::ImageSeriesReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileNames( fileNames );
+  reader->SetFileNames(fileNames);
 
   try
-    {
+  {
     reader->Update();
 
-    ImageType::ConstPointer output = reader->GetOutput();
-    const ImageType::RegionType largestRegion =
-      output->GetLargestPossibleRegion();
+    ImageType::ConstPointer     output = reader->GetOutput();
+    const ImageType::RegionType largestRegion = output->GetLargestPossibleRegion();
     std::cout << "Initial LargestPossibleRegion: ";
-    std::cout << largestRegion << std::endl;;
-    }
-  catch( itk::ExceptionObject & error )
-    {
+    std::cout << largestRegion << std::endl;
+    ;
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   fileNames.pop_back();
 
   try
-    {
+  {
     std::cout << "\nTrying to call Update() "
-              << "after shrinking the LargestPossibleRegion...\n" << std::endl;
-    reader->SetFileNames( fileNames );
+              << "after shrinking the LargestPossibleRegion...\n"
+              << std::endl;
+    reader->SetFileNames(fileNames);
     reader->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     // Print out the error that occurs
     std::cout << "Error: " << error << std::endl;
-    }
+  }
 
   try
-    {
+  {
     std::cout << "Trying to call UpdateLargestPossibleRegion() "
-              << "after shrinking the LargestPossibleRegion...\n" << std::endl;
-    reader->SetFileNames( fileNames );
+              << "after shrinking the LargestPossibleRegion...\n"
+              << std::endl;
+    reader->SetFileNames(fileNames);
     reader->UpdateLargestPossibleRegion();
 
-    ImageType::ConstPointer output = reader->GetOutput();
-    const ImageType::RegionType largestRegion =
-      output->GetLargestPossibleRegion();
+    ImageType::ConstPointer     output = reader->GetOutput();
+    const ImageType::RegionType largestRegion = output->GetLargestPossibleRegion();
     std::cout << "Shrunk LargestPossibleRegion: ";
-    std::cout << largestRegion << std::endl;;
-    }
-  catch( itk::ExceptionObject & error )
-    {
+    std::cout << largestRegion << std::endl;
+    ;
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ReadAPointSet/Code.cxx
+++ b/src/Core/Common/ReadAPointSet/Code.cxx
@@ -24,82 +24,82 @@
 #include <string>
 #include <iostream>
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
   if (argc < 2)
-    {
-    std::cout << "Usage: " << argv[0]
-              << " Input(.vtk)" << std::endl;
+  {
+    std::cout << "Usage: " << argv[0] << " Input(.vtk)" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   std::string InputFilename = argv[1];
   std::cout << "Input file: " << InputFilename << std::endl;
 
-  //using PointSetType = itk::PointSet<double, 3 >;
-  //PointSetType::Pointer pointsSet = PointSetType::New();
-  //using PointType = PointSetType::PointType;
+  // using PointSetType = itk::PointSet<double, 3 >;
+  // PointSetType::Pointer pointsSet = PointSetType::New();
+  // using PointType = PointSetType::PointType;
 
   constexpr unsigned int Dimension = 3;
 
   using CoordType = float;
-  using MeshType = itk::Mesh< CoordType, Dimension >;
+  using MeshType = itk::Mesh<CoordType, Dimension>;
 
-  using ReaderType = itk::VTKPolyDataReader< MeshType >;
-  ReaderType::Pointer  polyDataReader = ReaderType::New();
+  using ReaderType = itk::VTKPolyDataReader<MeshType>;
+  ReaderType::Pointer polyDataReader = ReaderType::New();
 
   using PointType = ReaderType::PointType;
   using VectorType = ReaderType::VectorType;
 
-  polyDataReader->SetFileName( InputFilename.c_str() );
+  polyDataReader->SetFileName(InputFilename.c_str());
 
   try
-    {
+  {
     polyDataReader->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   std::cout << "polyDataReader:" << std::endl;
   std::cout << polyDataReader << std::endl;
 
   MeshType::Pointer mesh = polyDataReader->GetOutput();
 
-  PointType  point;
+  PointType point;
 
   std::cout << "Testing itk::VTKPolyDataReader" << std::endl;
 
   unsigned int numberOfPoints = mesh->GetNumberOfPoints();
-  unsigned int numberOfCells  = mesh->GetNumberOfCells();
+  unsigned int numberOfCells = mesh->GetNumberOfCells();
 
   std::cout << "numberOfPoints= " << numberOfPoints << std::endl;
   std::cout << "numberOfCells= " << numberOfCells << std::endl;
 
-  if( !numberOfPoints )
-    {
+  if (!numberOfPoints)
+  {
     std::cerr << "ERROR: numberOfPoints= " << numberOfPoints << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  if( !numberOfCells )
-    {
+  if (!numberOfCells)
+  {
     std::cerr << "ERROR: numberOfCells= " << numberOfCells << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Retrieve points
-  for( unsigned int i = 0; i < numberOfPoints; i++ )
-    {
+  for (unsigned int i = 0; i < numberOfPoints; i++)
+  {
     PointType pp;
-    bool pointExists = mesh->GetPoint( i, &pp );
+    bool      pointExists = mesh->GetPoint(i, &pp);
 
-    if( pointExists )
-      {
+    if (pointExists)
+    {
       std::cout << "Point is = " << pp << std::endl;
-      }
     }
+  }
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ReadWriteVectorImage/Code.cxx
+++ b/src/Core/Common/ReadWriteVectorImage/Code.cxx
@@ -20,43 +20,44 @@
 #include "itkImageFileWriter.h"
 #include "itkImage.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
   // Verify the number of parameters in the command line
-  if( argc < 3 )
-    {
+  if (argc < 3)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " inputImageFile  outputImageFile " << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int VectorDimension = 4;
 
-  using PixelType = itk::Vector< float, VectorDimension >;
+  using PixelType = itk::Vector<float, VectorDimension>;
 
   constexpr unsigned int ImageDimension = 3;
 
-  using ImageType = itk::Image< PixelType, ImageDimension >;
+  using ImageType = itk::Image<PixelType, ImageDimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( reader->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(reader->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & err )
-    {
+  }
+  catch (itk::ExceptionObject & err)
+  {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ReturnObjectFromFunction/Code.cxx
+++ b/src/Core/Common/ReturnObjectFromFunction/Code.cxx
@@ -19,65 +19,67 @@
 
 namespace
 {
-    using ImageType = itk::Image<unsigned char, 2>;
+using ImageType = itk::Image<unsigned char, 2>;
 }
 
-ImageType::Pointer ReturnSmartPointer()
+ImageType::Pointer
+ReturnSmartPointer()
 {
-    ImageType::Pointer image = ImageType::New();
-    itk::Index<2> corner = {{0,0}};
-    itk::Size<2> size = {{10,10}};
-    itk::ImageRegion<2> region(corner, size);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::Pointer  image = ImageType::New();
+  itk::Index<2>       corner = { { 0, 0 } };
+  itk::Size<2>        size = { { 10, 10 } };
+  itk::ImageRegion<2> region(corner, size);
+  image->SetRegions(region);
+  image->Allocate();
 
-    return image;
+  return image;
 }
 
-ImageType* ReturnPointer()
+ImageType *
+ReturnPointer()
 {
-    ImageType::Pointer image = ImageType::New();
-    itk::Index<2> corner = {{0,0}};
-    itk::Size<2> size = {{10,10}};
-    itk::ImageRegion<2> region(corner, size);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::Pointer  image = ImageType::New();
+  itk::Index<2>       corner = { { 0, 0 } };
+  itk::Size<2>        size = { { 10, 10 } };
+  itk::ImageRegion<2> region(corner, size);
+  image->SetRegions(region);
+  image->Allocate();
 
-    return image;
+  return image;
 }
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    {
-        // This is how it should be done.
-        ImageType::Pointer smartPointer = ReturnSmartPointer();
-        std::cout << smartPointer->GetLargestPossibleRegion() << std::endl;
-    }
+  {
+    // This is how it should be done.
+    ImageType::Pointer smartPointer = ReturnSmartPointer();
+    std::cout << smartPointer->GetLargestPossibleRegion() << std::endl;
+  }
 
-    {
-        ImageType* pointer = ReturnPointer();
-        // This crashes the program because the smart pointer created in the function goes out of scope and gets deleted
-        // because it is returned as a normal pointer.
-        // std::cout << pointer->GetLargestPossibleRegion() << std::endl;
-        pointer = nullptr; // Here to silence warning
-    }
+  {
+    ImageType * pointer = ReturnPointer();
+    // This crashes the program because the smart pointer created in the function goes out of scope and gets deleted
+    // because it is returned as a normal pointer.
+    // std::cout << pointer->GetLargestPossibleRegion() << std::endl;
+    pointer = nullptr; // Here to silence warning
+  }
 
-    {
-        ImageType* pointer = ReturnSmartPointer();
-        // This crashes the program because though the function returned a ::Pointer, it was not stored
-        // anywhere so the reference count was not increased, so it got deleted.
-        // std::cout << pointer->GetLargestPossibleRegion() << std::endl;
-        pointer = nullptr; // Here to silence warning
-    }
+  {
+    ImageType * pointer = ReturnSmartPointer();
+    // This crashes the program because though the function returned a ::Pointer, it was not stored
+    // anywhere so the reference count was not increased, so it got deleted.
+    // std::cout << pointer->GetLargestPossibleRegion() << std::endl;
+    pointer = nullptr; // Here to silence warning
+  }
 
-    {
-        // I thought this might also work, but it does not (crash).
-        // My reasoning was that even though you don't return a smart pointer, you assign the object to a smart
-        // pointer at return time, so it still has a reference count of 1.
-        //ImageType::Pointer smartPointer = ReturnPointer(); // this line causes a 'glibc error'
-        // std::cout << smartPointer->GetLargestPossibleRegion() << std::endl;
-    }
+  {
+    // I thought this might also work, but it does not (crash).
+    // My reasoning was that even though you don't return a smart pointer, you assign the object to a smart
+    // pointer at return time, so it still has a reference count of 1.
+    // ImageType::Pointer smartPointer = ReturnPointer(); // this line causes a 'glibc error'
+    // std::cout << smartPointer->GetLargestPossibleRegion() << std::endl;
+  }
 
-    return 0;
+  return 0;
 }
-

--- a/src/Core/Common/SetPixelValueInOneImage/Code.cxx
+++ b/src/Core/Common/SetPixelValueInOneImage/Code.cxx
@@ -19,24 +19,25 @@
 #include "itkImage.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char* argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " <OutputFileName>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::RegionType region;
 
   ImageType::IndexType start;
-  start.Fill( 0 );
+  start.Fill(0);
 
   region.SetIndex(start);
 
@@ -49,12 +50,12 @@ int main(int argc, char* argv[])
   ImageType::Pointer image = ImageType::New();
   image->SetRegions(region);
   image->Allocate();
-  image->FillBuffer( itk::NumericTraits< PixelType >::Zero );
+  image->FillBuffer(itk::NumericTraits<PixelType>::Zero);
 
   ImageType::IndexType pixelIndex;
 
-  for(ImageType::IndexValueType r = 0; r < 50; r++)
-    {
+  for (ImageType::IndexValueType r = 0; r < 50; r++)
+  {
     pixelIndex[0] = 4 * r;
     pixelIndex[1] = 4 * r;
 
@@ -64,10 +65,10 @@ int main(int argc, char* argv[])
     pixelIndex[1] = 200 - 4 * r;
 
     image->SetPixel(pixelIndex, 255);
-    }
+  }
 
-  for(ImageType::IndexValueType r = 0; r < 25; r++)
-    {
+  for (ImageType::IndexValueType r = 0; r < 25; r++)
+  {
     pixelIndex[0] = 8 * r;
     pixelIndex[1] = 200 + 4 * r;
 
@@ -76,48 +77,48 @@ int main(int argc, char* argv[])
     pixelIndex[0] = 8 * r;
     pixelIndex[1] = 250;
 
-    image->SetPixel(pixelIndex, 180 );
-    }
+    image->SetPixel(pixelIndex, 180);
+  }
 
   pixelIndex[0] = 95;
   pixelIndex[1] = 150;
 
-  image->SetPixel( pixelIndex, 200 );
+  image->SetPixel(pixelIndex, 200);
 
   pixelIndex[0] = 100;
   pixelIndex[1] = 150;
 
-  image->SetPixel( pixelIndex, 200 );
+  image->SetPixel(pixelIndex, 200);
 
   pixelIndex[0] = 105;
   pixelIndex[1] = 150;
 
-  image->SetPixel( pixelIndex, 200 );
+  image->SetPixel(pixelIndex, 200);
 
   pixelIndex[0] = 100;
   pixelIndex[1] = 155;
 
-  image->SetPixel( pixelIndex, 200 );
+  image->SetPixel(pixelIndex, 200);
 
   pixelIndex[0] = 100;
   pixelIndex[1] = 145;
 
-  image->SetPixel( pixelIndex, 200 );
+  image->SetPixel(pixelIndex, 200);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( image );
-  writer->SetFileName( argv[1] );
+  writer->SetInput(image);
+  writer->SetFileName(argv[1]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/SortITKIndex/Code.cxx
+++ b/src/Core/Common/SortITKIndex/Code.cxx
@@ -18,12 +18,12 @@
 #include "itkIndex.h"
 #include <map>
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   using IndexType = itk::Index<2>;
-  IndexType index = {{ 3, 4 }};
+  IndexType                  index = { { 3, 4 } };
   std::map<IndexType, float> myMap;
   myMap[index] = 42;
   return EXIT_SUCCESS;
 }
-

--- a/src/Core/Common/StoreNonPixelDataInImage/Code.cxx
+++ b/src/Core/Common/StoreNonPixelDataInImage/Code.cxx
@@ -24,74 +24,76 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    // Create an image
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  // Create an image
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    // Store some data in it
-    itk::MetaDataDictionary dictionary;
-    itk::EncapsulateMetaData<float>(dictionary,"ASimpleFloat",1.2);
-    image->SetMetaDataDictionary(dictionary);
+  // Store some data in it
+  itk::MetaDataDictionary dictionary;
+  itk::EncapsulateMetaData<float>(dictionary, "ASimpleFloat", 1.2);
+  image->SetMetaDataDictionary(dictionary);
 
-    // View all of the data
-    dictionary.Print(std::cout);
+  // View all of the data
+  dictionary.Print(std::cout);
 
-    // View the data individually
-    auto itr = dictionary.Begin();
+  // View the data individually
+  auto itr = dictionary.Begin();
 
-    while( itr != dictionary.End() )
-    {
-        std::cout << "Key   = " << itr->first << std::endl;
-        std::cout << "Value = ";
-        itr->second->Print( std::cout );
-        std::cout << std::endl;
-        ++itr;
-    }
+  while (itr != dictionary.End())
+  {
+    std::cout << "Key   = " << itr->first << std::endl;
+    std::cout << "Value = ";
+    itr->second->Print(std::cout);
+    std::cout << std::endl;
+    ++itr;
+  }
 
-    // Write the image (and the data) to a file
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("test.mhd");
-    writer->SetInput(image);
-    writer->Update();
+  // Write the image (and the data) to a file
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("test.mhd");
+  writer->SetInput(image);
+  writer->Update();
 
-    // Read the image (and data) from the file
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName("test.mhd");
+  // Read the image (and data) from the file
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName("test.mhd");
 
-    // Display the data
-    std::cout << "Data read from file:" << std::endl;
-    reader->GetMetaDataDictionary().Print(std::cout);
+  // Display the data
+  std::cout << "Data read from file:" << std::endl;
+  reader->GetMetaDataDictionary().Print(std::cout);
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(10);
+  ImageType::SizeType size;
+  size.Fill(10);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(20);
-        ++imageIterator;
-    }
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(20);
+    ++imageIterator;
+  }
 }
-

--- a/src/Core/Common/StreamAPipeline/Code.cxx
+++ b/src/Core/Common/StreamAPipeline/Code.cxx
@@ -20,58 +20,58 @@
 #include "itkRandomImageSource.h"
 #include "itkStreamingImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage: " << argv[0] << " <NumberOfSplits>" << std::endl;
     return EXIT_FAILURE;
-    }
-  int numberOfSplits = std::stoi( argv[1] );
+  }
+  int numberOfSplits = std::stoi(argv[1]);
 
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using SourceType = itk::RandomImageSource< ImageType >;
+  using SourceType = itk::RandomImageSource<ImageType>;
   SourceType::Pointer source = SourceType::New();
   ImageType::SizeType size;
-  size.Fill( numberOfSplits );
-  source->SetSize( size );
+  size.Fill(numberOfSplits);
+  source->SetSize(size);
 
-  using MonitorFilterType = itk::PipelineMonitorImageFilter< ImageType >;
+  using MonitorFilterType = itk::PipelineMonitorImageFilter<ImageType>;
   MonitorFilterType::Pointer monitorFilter = MonitorFilterType::New();
-  monitorFilter->SetInput( source->GetOutput() );
+  monitorFilter->SetInput(source->GetOutput());
   // If ITK was built with the Debug CMake configuration, the filter
   // automatically outputs status information to the console
   monitorFilter->DebugOn();
 
-  using StreamingFilterType = itk::StreamingImageFilter< ImageType, ImageType >;
+  using StreamingFilterType = itk::StreamingImageFilter<ImageType, ImageType>;
   StreamingFilterType::Pointer streamingFilter = StreamingFilterType::New();
-  streamingFilter->SetInput( monitorFilter->GetOutput() );
-  streamingFilter->SetNumberOfStreamDivisions( numberOfSplits );
+  streamingFilter->SetInput(monitorFilter->GetOutput());
+  streamingFilter->SetNumberOfStreamDivisions(numberOfSplits);
 
   try
-    {
+  {
     streamingFilter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  std::cout << "The output LargestPossibleRegion is: "
-    << streamingFilter->GetOutput()->GetLargestPossibleRegion() << std::endl;
+  std::cout << "The output LargestPossibleRegion is: " << streamingFilter->GetOutput()->GetLargestPossibleRegion()
+            << std::endl;
   std::cout << std::endl;
 
-  const MonitorFilterType::RegionVectorType updatedRequestedRegions =
-    monitorFilter->GetUpdatedRequestedRegions();
+  const MonitorFilterType::RegionVectorType updatedRequestedRegions = monitorFilter->GetUpdatedRequestedRegions();
   std::cout << "Updated RequestedRegions's:" << std::endl;
-  for(const auto & updatedRequestedRegion : updatedRequestedRegions)
-    {
+  for (const auto & updatedRequestedRegion : updatedRequestedRegions)
+  {
     std::cout << "  " << updatedRequestedRegion << std::endl;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/ThrowException/Code.cxx
+++ b/src/Core/Common/ThrowException/Code.cxx
@@ -18,15 +18,16 @@
 #include "itkImage.h"
 #include <itkCastImageFilter.h>
 
-//TODO: Incomplete example
-int main(int, char*[])
+// TODO: Incomplete example
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;
   ImageType::Pointer image = ImageType::New();
 
   // Create and the filter
-  using FilterType = itk::CastImageFilter<ImageType,ImageType>;
+  using FilterType = itk::CastImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
   filter->SetInput(image);
   filter->Update();

--- a/src/Core/Common/TraceMemoryBetweenPoints/Code.cxx
+++ b/src/Core/Common/TraceMemoryBetweenPoints/Code.cxx
@@ -19,22 +19,23 @@
 #include "itkMemoryProbe.h"
 #include <iostream>
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage:" << std::endl;
     std::cerr << argv[0] << " <Size of the array>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const auto N = static_cast< unsigned int >( std::stoi( argv[1] ) );
+  const auto N = static_cast<unsigned int>(std::stoi(argv[1]));
 
-  if( N == 0 )
-    {
+  if (N == 0)
+  {
     std::cerr << "Size of the array should be non null" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   itk::MemoryProbe memoryProbe;
 
@@ -50,12 +51,12 @@ int main( int argc, char* argv[] )
   std::cout << std::endl;
 
   memoryProbe.Start();
-  auto* a = new char[N];
+  auto * a = new char[N];
   // The memory must be used for it to be counted.
-  for(unsigned int i = 0; i < N; ++i)
-    {
-    a[i] = static_cast< char >( i*i );
-    }
+  for (unsigned int i = 0; i < N; ++i)
+  {
+    a[i] = static_cast<char>(i * i);
+  }
   memoryProbe.Stop();
 
   std::cout << "** After allocation **" << std::endl;

--- a/src/Core/Common/Transparency/Code.cxx
+++ b/src/Core/Common/Transparency/Code.cxx
@@ -21,72 +21,73 @@
 #include "itkTIFFImageIO.h"
 #include "itkRGBAPixel.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    std::string outputFilename;
-    if(argc > 1)
+  std::string outputFilename;
+  if (argc > 1)
+  {
+    outputFilename = argv[1];
+  }
+  else
+  {
+    outputFilename = "test.tif";
+  }
+
+  using PixelType = itk::RGBAPixel<unsigned char>;
+  using ImageType = itk::Image<PixelType, 2>;
+
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
+
+  ImageType::SizeType size;
+  size[0] = 200;
+  size[1] = 300;
+
+  region.SetSize(size);
+  region.SetIndex(start);
+
+  ImageType::Pointer image = ImageType::New();
+  image->SetRegions(region);
+  image->Allocate();
+
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
+
+  while (!imageIterator.IsAtEnd())
+  {
+    ImageType::PixelType pixel = imageIterator.Get();
+
+    if (imageIterator.GetIndex()[0] > 100)
     {
-        outputFilename = argv[1];
+      pixel.SetRed(0);
+      pixel.SetGreen(255);
+      pixel.SetBlue(0);
+      // pixel.SetAlpha(255); // invisible
+      pixel.SetAlpha(122);
     }
     else
     {
-        outputFilename = "test.tif";
+      pixel.SetRed(255);
+      pixel.SetGreen(0);
+      pixel.SetBlue(0);
+      pixel.SetAlpha(static_cast<unsigned char>(0.5 * 255));
     }
+    imageIterator.Set(pixel);
 
-    using PixelType = itk::RGBAPixel<unsigned char>;
-    using ImageType = itk::Image< PixelType, 2>;
+    ++imageIterator;
+  }
 
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  using TIFFIOType = itk::TIFFImageIO;
+  WriterType::Pointer writer = WriterType::New();
+  TIFFIOType::Pointer tiffIO = TIFFIOType::New();
+  tiffIO->SetPixelType(itk::ImageIOBase::RGBA);
+  writer->SetFileName(outputFilename);
+  writer->SetInput(image);
+  writer->SetImageIO(tiffIO);
+  writer->Update();
 
-    ImageType::SizeType size;
-    size[0] = 200;
-    size[1] = 300;
-
-    region.SetSize(size);
-    region.SetIndex(start);
-
-    ImageType::Pointer image = ImageType::New();
-    image->SetRegions(region);
-    image->Allocate();
-
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
-
-    while(!imageIterator.IsAtEnd())
-    {
-        ImageType::PixelType pixel = imageIterator.Get();
-
-        if(imageIterator.GetIndex()[0] > 100)
-        {
-            pixel.SetRed(0);
-            pixel.SetGreen(255);
-            pixel.SetBlue(0);
-            //pixel.SetAlpha(255); // invisible
-            pixel.SetAlpha(122);
-        }
-        else
-        {
-            pixel.SetRed(255);
-            pixel.SetGreen(0);
-            pixel.SetBlue(0);
-            pixel.SetAlpha( static_cast<unsigned char>( 0.5 * 255 ) );
-        }
-        imageIterator.Set(pixel);
-
-        ++imageIterator;
-    }
-
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    using TIFFIOType = itk::TIFFImageIO;
-    WriterType::Pointer writer = WriterType::New();
-    TIFFIOType::Pointer tiffIO = TIFFIOType::New();
-    tiffIO->SetPixelType(itk::ImageIOBase::RGBA);
-    writer->SetFileName(outputFilename);
-    writer->SetInput(image);
-    writer->SetImageIO(tiffIO);
-    writer->Update();
-
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Common/TryCatchException/Code.cxx
+++ b/src/Core/Common/TryCatchException/Code.cxx
@@ -19,30 +19,31 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = double;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
 
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( "nofile.png" );
+  reader->SetFileName("nofile.png");
 
   try
-    {
+  {
     reader->Update();
-    }
-  catch( itk::ExceptionObject & err )
-    {
+  }
+  catch (itk::ExceptionObject & err)
+  {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;
 
     // Since the goal of the example is to catch the exception,
     // we declare this a success.
     return EXIT_SUCCESS;
-    }
+  }
 
   // Since the goal of the example is to catch the exception,
   // the example fails if it is not caught.

--- a/src/Core/Common/VariableLengthVector/Code.cxx
+++ b/src/Core/Common/VariableLengthVector/Code.cxx
@@ -18,70 +18,75 @@
 #include <itkVariableLengthVector.h>
 #include <itkVector.h>
 
-void VectorToVariableLengthVector();
-void VariableLengthVectorToVector();
+void
+VectorToVariableLengthVector();
+void
+VariableLengthVectorToVector();
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using VectorType = itk::VariableLengthVector<double>;
-    VectorType v;
-    v.SetSize(2);
-    v[0] = 1;
-    v[1] = 2;
-    std::cout << v << std::endl;
+  using VectorType = itk::VariableLengthVector<double>;
+  VectorType v;
+  v.SetSize(2);
+  v[0] = 1;
+  v[1] = 2;
+  std::cout << v << std::endl;
 
-    for(unsigned int i = 0; i < v.Size(); i++)
-    {
-        std::cout << v[i] << " ";
-    }
-    std::cout << std::endl;
+  for (unsigned int i = 0; i < v.Size(); i++)
+  {
+    std::cout << v[i] << " ";
+  }
+  std::cout << std::endl;
 
-    VectorToVariableLengthVector();
-    VariableLengthVectorToVector();
-    return EXIT_SUCCESS;
+  VectorToVariableLengthVector();
+  VariableLengthVectorToVector();
+  return EXIT_SUCCESS;
 }
 
-void VectorToVariableLengthVector()
+void
+VectorToVariableLengthVector()
 {
-    std::cout << "VectorToVariableLengthVector()" << std::endl;
+  std::cout << "VectorToVariableLengthVector()" << std::endl;
 
-    using FixedVectorType = itk::Vector<double, 2>;
-    FixedVectorType fixedLengthVector;
-    fixedLengthVector[0] = 1;
-    fixedLengthVector[1] = 2;
+  using FixedVectorType = itk::Vector<double, 2>;
+  FixedVectorType fixedLengthVector;
+  fixedLengthVector[0] = 1;
+  fixedLengthVector[1] = 2;
 
-    using VariableVectorType = itk::VariableLengthVector<double>;
-    VariableVectorType variableLengthVector;
+  using VariableVectorType = itk::VariableLengthVector<double>;
+  VariableVectorType variableLengthVector;
 
-    // This works
-    variableLengthVector.SetSize(fixedLengthVector.Size());
-    variableLengthVector.SetData(fixedLengthVector.GetDataPointer());
+  // This works
+  variableLengthVector.SetSize(fixedLengthVector.Size());
+  variableLengthVector.SetData(fixedLengthVector.GetDataPointer());
 
-    // This crashes with both true and false
-    //variableLengthVector.SetData(fixedLengthVector.GetDataPointer(), 2, true);
+  // This crashes with both true and false
+  // variableLengthVector.SetData(fixedLengthVector.GetDataPointer(), 2, true);
 
-    std::cout << "variableLengthVector: " << variableLengthVector << std::endl;
+  std::cout << "variableLengthVector: " << variableLengthVector << std::endl;
 }
 
-void VariableLengthVectorToVector()
+void
+VariableLengthVectorToVector()
 {
-    std::cout << "VariableLengthVectorToVector()" << std::endl;
-    using VariableVectorType = itk::VariableLengthVector<double>;
-    VariableVectorType variableLengthVector;
-    variableLengthVector.SetSize(2);
+  std::cout << "VariableLengthVectorToVector()" << std::endl;
+  using VariableVectorType = itk::VariableLengthVector<double>;
+  VariableVectorType variableLengthVector;
+  variableLengthVector.SetSize(2);
 
-    variableLengthVector[0] = 1;
-    variableLengthVector[1] = 2;
+  variableLengthVector[0] = 1;
+  variableLengthVector[1] = 2;
 
-    using FixedVectorType = itk::Vector<double, 2>;
-    FixedVectorType fixedLengthVector;
+  using FixedVectorType = itk::Vector<double, 2>;
+  FixedVectorType fixedLengthVector;
 
-    for(unsigned int i = 0; i < FixedVectorType::GetVectorDimension(); i++)
-    {
-        fixedLengthVector[i] = variableLengthVector[i];
-    }
+  for (unsigned int i = 0; i < FixedVectorType::GetVectorDimension(); i++)
+  {
+    fixedLengthVector[i] = variableLengthVector[i];
+  }
 
-    // This function doesn't exist!
-    //fixedLengthVector.SetData(variableLengthVector.GetDataPointer());
-    std::cout << "fixedLengthVector: " << fixedLengthVector << std::endl;
+  // This function doesn't exist!
+  // fixedLengthVector.SetData(variableLengthVector.GetDataPointer());
+  std::cout << "fixedLengthVector: " << fixedLengthVector << std::endl;
 }

--- a/src/Core/Common/VectorDotProduct/Code.cxx
+++ b/src/Core/Common/VectorDotProduct/Code.cxx
@@ -18,12 +18,13 @@
 
 #include "itkVector.h"
 
-int main( int, char* [] )
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
 
-  using VectorType = itk::Vector< CoordType, Dimension >;
+  using VectorType = itk::Vector<CoordType, Dimension>;
 
   VectorType u;
   u[0] = -1.;
@@ -38,7 +39,7 @@ int main( int, char* [] )
   std::cout << "u :" << u << std::endl;
   std::cout << "v :" << v << std::endl;
   std::cout << "DotProduct( u, v ) = " << u * v << std::endl;
-  std::cout << "u - ( u * v ) * v = " << u - ( u * v ) * v << std::endl;
+  std::cout << "u - ( u * v ) * v = " << u - (u * v) * v << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Common/WatchAFilter/Code.cxx
+++ b/src/Core/Common/WatchAFilter/Code.cxx
@@ -21,18 +21,19 @@
 #include "itkThresholdImageFilter.h"
 #include "itkImageRegionIterator.h"
 
-template< class TImage >
-void CreateImage(typename TImage::Pointer image)
+template <class TImage>
+void
+CreateImage(typename TImage::Pointer image)
 {
   using ImageType = TImage;
 
   // Create an image with 2 connected components
   typename ImageType::RegionType region;
-  typename ImageType::IndexType start;
-  start.Fill( 0 );
+  typename ImageType::IndexType  start;
+  start.Fill(0);
 
   typename ImageType::SizeType size;
-  size.Fill( 100 );
+  size.Fill(100);
 
   region.SetSize(size);
   region.SetIndex(start);
@@ -40,29 +41,28 @@ void CreateImage(typename TImage::Pointer image)
   image->SetRegions(region);
   image->Allocate();
 
-  itk::ImageRegionIterator< ImageType > imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-  while(!imageIterator.IsAtEnd())
-    {
+  while (!imageIterator.IsAtEnd())
+  {
     imageIterator.Set(255);
     ++imageIterator;
-    }
-
+  }
 }
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::Pointer image = ImageType::New();
-  CreateImage< ImageType >(image);
+  CreateImage<ImageType>(image);
 
-  using ThresholdImageFilterType = itk::ThresholdImageFilter <ImageType>;
+  using ThresholdImageFilterType = itk::ThresholdImageFilter<ImageType>;
 
-  ThresholdImageFilterType::Pointer thresholdFilter
-          = ThresholdImageFilterType::New();
+  ThresholdImageFilterType::Pointer thresholdFilter = ThresholdImageFilterType::New();
   thresholdFilter->SetInput(image);
   thresholdFilter->ThresholdBelow(100);
   thresholdFilter->SetOutsideValue(0);

--- a/src/Core/Common/WriteAPointSet/Code.cxx
+++ b/src/Core/Common/WriteAPointSet/Code.cxx
@@ -18,23 +18,24 @@
 
 #include "itkPointSet.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-    // Verify the number of parameters in the command line
-    if( argc < 1 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " outputFile " << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify the number of parameters in the command line
+  if (argc < 1)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " outputFile " << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::string outputFilename = argv[1];
+  std::string outputFilename = argv[1];
 
-    // Store points
-    typedef itk::PointSet<double, 3 > PointSetType;
-    PointSetType::Pointer pointsSet = PointSetType::New();
-    typedef PointSetType::PointType PointType;
+  // Store points
+  typedef itk::PointSet<double, 3> PointSetType;
+  PointSetType::Pointer            pointsSet = PointSetType::New();
+  typedef PointSetType::PointType  PointType;
 
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/Code.cxx
+++ b/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/Code.cxx
@@ -22,65 +22,64 @@
 
 using ImageType = itk::Image<unsigned int, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using AddPixelAccessorType = itk::Accessor::AddPixelAccessor <ImageType::PixelType>;
-    using ImageAdaptorType = itk::ImageAdaptor<  ImageType, AddPixelAccessorType >;
+  using AddPixelAccessorType = itk::Accessor::AddPixelAccessor<ImageType::PixelType>;
+  using ImageAdaptorType = itk::ImageAdaptor<ImageType, AddPixelAccessorType>;
 
-    ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
-    AddPixelAccessorType addPixelAccessor;
+  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  AddPixelAccessorType      addPixelAccessor;
 
 
-    adaptor->SetImage(image);
+  adaptor->SetImage(image);
 
-    ImageType::IndexType index;
-    index[0] = 0;
-    index[1] = 0;
+  ImageType::IndexType index;
+  index[0] = 0;
+  index[1] = 0;
 
-    addPixelAccessor.SetValue(5);
-    adaptor->SetPixelAccessor(addPixelAccessor);
-    std::cout << "addPixelAccessor.SetValue(5)" << std::endl;
-    std::cout << "\timage->GetPixel" << index << ": " << image->GetPixel(index)
-              << " adaptor->GetPixel" << index << ": " << adaptor->GetPixel(index)
-              << std::endl;
+  addPixelAccessor.SetValue(5);
+  adaptor->SetPixelAccessor(addPixelAccessor);
+  std::cout << "addPixelAccessor.SetValue(5)" << std::endl;
+  std::cout << "\timage->GetPixel" << index << ": " << image->GetPixel(index) << " adaptor->GetPixel" << index << ": "
+            << adaptor->GetPixel(index) << std::endl;
 
-    addPixelAccessor.SetValue(100);
-    adaptor->SetPixelAccessor(addPixelAccessor);
-    std::cout << "addPixelAccessor.SetValue(100)" << std::endl;
-    std::cout << "\timage->GetPixel" << index << ": " << image->GetPixel(index)
-              << " adaptor->GetPixel" << index << ": " << adaptor->GetPixel(index)
-              << std::endl;
+  addPixelAccessor.SetValue(100);
+  adaptor->SetPixelAccessor(addPixelAccessor);
+  std::cout << "addPixelAccessor.SetValue(100)" << std::endl;
+  std::cout << "\timage->GetPixel" << index << ": " << image->GetPixel(index) << " adaptor->GetPixel" << index << ": "
+            << adaptor->GetPixel(index) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(10);
+  ImageType::SizeType size;
+  size.Fill(10);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(20);
-        ++imageIterator;
-    }
-
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(20);
+    ++imageIterator;
+  }
 }
-

--- a/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/Code.cxx
+++ b/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/Code.cxx
@@ -19,55 +19,57 @@
 #include "itkImageRegionIterator.h"
 #include "itkNthElementImageAdaptor.h"
 
-using VectorImageType = itk::Image<itk::CovariantVector< float, 3>, 2>;
+using VectorImageType = itk::Image<itk::CovariantVector<float, 3>, 2>;
 
-static void CreateImage(VectorImageType::Pointer image);
+static void
+CreateImage(VectorImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    VectorImageType::Pointer image = VectorImageType::New();
-    CreateImage(image);
+  VectorImageType::Pointer image = VectorImageType::New();
+  CreateImage(image);
 
-    itk::Index<2> index;
-    index.Fill(0);
+  itk::Index<2> index;
+  index.Fill(0);
 
-    std::cout << image->GetPixel(index) << std::endl;
+  std::cout << image->GetPixel(index) << std::endl;
 
-    using ImageAdaptorType = itk::NthElementImageAdaptor<VectorImageType,
-            float>;
+  using ImageAdaptorType = itk::NthElementImageAdaptor<VectorImageType, float>;
 
-    ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
 
-    adaptor->SelectNthElement(0);
-    adaptor->SetImage(image);
+  adaptor->SelectNthElement(0);
+  adaptor->SetImage(image);
 
-    std::cout << adaptor->GetPixel(index) << std::endl;
+  std::cout << adaptor->GetPixel(index) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(VectorImageType::Pointer image)
+void
+CreateImage(VectorImageType::Pointer image)
 {
-    VectorImageType::IndexType start;
-    start.Fill(0);
+  VectorImageType::IndexType start;
+  start.Fill(0);
 
-    VectorImageType::SizeType size;
-    size.Fill(2);
+  VectorImageType::SizeType size;
+  size.Fill(2);
 
-    VectorImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  VectorImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Create a pixel and fill it with (1,2,3), and set every pixel of the image to this pixel.
+  // Create a pixel and fill it with (1,2,3), and set every pixel of the image to this pixel.
 
-    itk::ImageRegionIterator<VectorImageType> imageIterator(image,image->GetLargestPossibleRegion());
-    itk::CovariantVector<float, 3> vectorPixel;
-    vectorPixel[0] = 1;
-    vectorPixel[1] = 2;
-    vectorPixel[2] = 3;
+  itk::ImageRegionIterator<VectorImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  itk::CovariantVector<float, 3>            vectorPixel;
+  vectorPixel[0] = 1;
+  vectorPixel[1] = 2;
+  vectorPixel[2] = 3;
 
-    image->FillBuffer(vectorPixel);
+  image->FillBuffer(vectorPixel);
 }

--- a/src/Core/ImageAdaptors/PresentImageAfterOperation/Code.cxx
+++ b/src/Core/ImageAdaptors/PresentImageAfterOperation/Code.cxx
@@ -19,83 +19,89 @@
 #include "itkImageRegionIterator.h"
 
 using ScalarImageType = itk::Image<float, 2>;
-using VectorImageType = itk::Image<itk::CovariantVector< float, 3>, 2>;
+using VectorImageType = itk::Image<itk::CovariantVector<float, 3>, 2>;
 
 
-static void CreateImage(VectorImageType::Pointer image);
+static void
+CreateImage(VectorImageType::Pointer image);
 
 class VectorPixelAccessor
 {
 public:
-    using InternalType = itk::CovariantVector<float,3>;
-    using ExternalType = float;
+  using InternalType = itk::CovariantVector<float, 3>;
+  using ExternalType = float;
 
-    void operator=( const VectorPixelAccessor & vpa )
-    {
-        m_Index = vpa.m_Index;
-    }
-    ExternalType Get( const InternalType & input ) const
-    {
-        return static_cast<ExternalType>( input[ m_Index ] );
-    }
-    void SetIndex( unsigned int index )
-    {
-        m_Index = index;
-    }
+  void
+  operator=(const VectorPixelAccessor & vpa)
+  {
+    m_Index = vpa.m_Index;
+  }
+  ExternalType
+  Get(const InternalType & input) const
+  {
+    return static_cast<ExternalType>(input[m_Index]);
+  }
+  void
+  SetIndex(unsigned int index)
+  {
+    m_Index = index;
+  }
+
 private:
-    unsigned int m_Index;
+  unsigned int m_Index;
 };
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    VectorImageType::Pointer image = VectorImageType::New();
-    CreateImage(image);
+  VectorImageType::Pointer image = VectorImageType::New();
+  CreateImage(image);
 
-    itk::Index<2> index;
-    index.Fill(0);
+  itk::Index<2> index;
+  index.Fill(0);
 
-    std::cout << image->GetPixel(index) << std::endl;
+  std::cout << image->GetPixel(index) << std::endl;
 
-    using ImageAdaptorType = itk::ImageAdaptor<  VectorImageType,
-            VectorPixelAccessor >;
+  using ImageAdaptorType = itk::ImageAdaptor<VectorImageType, VectorPixelAccessor>;
 
-    ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
 
-    VectorPixelAccessor  accessor;
-    accessor.SetIndex(0);
-    adaptor->SetPixelAccessor( accessor );
-    adaptor->SetImage(image);
+  VectorPixelAccessor accessor;
+  accessor.SetIndex(0);
+  adaptor->SetPixelAccessor(accessor);
+  adaptor->SetImage(image);
 
-    std::cout << adaptor->GetPixel(index) << std::endl;
+  std::cout << adaptor->GetPixel(index) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(VectorImageType::Pointer image)
+void
+CreateImage(VectorImageType::Pointer image)
 {
-    VectorImageType::IndexType start;
-    start.Fill(0);
+  VectorImageType::IndexType start;
+  start.Fill(0);
 
-    VectorImageType::SizeType size;
-    size.Fill(2);
+  VectorImageType::SizeType size;
+  size.Fill(2);
 
-    VectorImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  VectorImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<VectorImageType> imageIterator(image,image->GetLargestPossibleRegion());
-    itk::CovariantVector<float, 3> vec;
-    vec[0] = 1;
-    vec[1] = 2;
-    vec[2] = 3;
+  itk::ImageRegionIterator<VectorImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  itk::CovariantVector<float, 3>            vec;
+  vec[0] = 1;
+  vec[1] = 2;
+  vec[2] = 3;
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(vec);
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(vec);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 }

--- a/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/Code.cxx
+++ b/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/Code.cxx
@@ -20,32 +20,34 @@
 #include "itkNthElementImageAdaptor.h"
 #include "itkBinomialBlurImageFilter.h"
 
-using VectorImageType = itk::Image<itk::CovariantVector< float, 3>, 2>;
+using VectorImageType = itk::Image<itk::CovariantVector<float, 3>, 2>;
 
-static void CreateImage(VectorImageType::Pointer image);
+static void
+CreateImage(VectorImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   VectorImageType::Pointer image = VectorImageType::New();
   CreateImage(image);
 
-  using ImageAdaptorType = itk::NthElementImageAdaptor<VectorImageType,
-    float>;
+  using ImageAdaptorType = itk::NthElementImageAdaptor<VectorImageType, float>;
 
   ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
 
   adaptor->SelectNthElement(0);
   adaptor->SetImage(image);
 
-  using BlurFilterType = itk::BinomialBlurImageFilter<ImageAdaptorType, itk::Image<float,2> >;
+  using BlurFilterType = itk::BinomialBlurImageFilter<ImageAdaptorType, itk::Image<float, 2>>;
   BlurFilterType::Pointer blurFilter = BlurFilterType::New();
   blurFilter->SetInput(adaptor);
   blurFilter->Update();
-  
+
   return EXIT_SUCCESS;
 }
 
-void CreateImage(VectorImageType::Pointer image)
+void
+CreateImage(VectorImageType::Pointer image)
 {
   VectorImageType::IndexType start;
   start.Fill(0);
@@ -60,17 +62,16 @@ void CreateImage(VectorImageType::Pointer image)
   image->SetRegions(region);
   image->Allocate();
 
-  itk::ImageRegionIterator<VectorImageType> imageIterator(image,image->GetLargestPossibleRegion());
-  itk::CovariantVector<float, 3> vec;
+  itk::ImageRegionIterator<VectorImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  itk::CovariantVector<float, 3>            vec;
   vec[0] = 1;
   vec[1] = 2;
   vec[2] = 3;
 
-  while(!imageIterator.IsAtEnd())
-    {
+  while (!imageIterator.IsAtEnd())
+  {
     imageIterator.Set(vec);
 
     ++imageIterator;
-    }
+  }
 }
-

--- a/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/Code.cxx
+++ b/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/Code.cxx
@@ -23,55 +23,58 @@
 using ScalarImageType = itk::Image<float, 2>;
 using VectorImageType = itk::VectorImage<float, 2>;
 
-void CreateImage(VectorImageType::Pointer image);
+void
+CreateImage(VectorImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    VectorImageType::Pointer image = VectorImageType::New();
-    CreateImage(image);
+  VectorImageType::Pointer image = VectorImageType::New();
+  CreateImage(image);
 
-    using ImageAdaptorType = itk::VectorImageToImageAdaptor<float, 2>;
-    ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
-    adaptor->SetExtractComponentIndex(0);
-    adaptor->SetImage(image);
+  using ImageAdaptorType = itk::VectorImageToImageAdaptor<float, 2>;
+  ImageAdaptorType::Pointer adaptor = ImageAdaptorType::New();
+  adaptor->SetExtractComponentIndex(0);
+  adaptor->SetImage(image);
 
-    itk::Index<2> index;
-    index[0] = 0;
-    index[1] = 0;
+  itk::Index<2> index;
+  index[0] = 0;
+  index[1] = 0;
 
-    std::cout << adaptor->GetPixel(index) << std::endl;
+  std::cout << adaptor->GetPixel(index) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(VectorImageType::Pointer image)
+void
+CreateImage(VectorImageType::Pointer image)
 {
-    VectorImageType::IndexType start;
-    start.Fill(0);
+  VectorImageType::IndexType start;
+  start.Fill(0);
 
-    VectorImageType::SizeType size;
-    size.Fill(2);
+  VectorImageType::SizeType size;
+  size.Fill(2);
 
-    VectorImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  VectorImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->SetNumberOfComponentsPerPixel(2);
-    image->Allocate();
+  image->SetRegions(region);
+  image->SetNumberOfComponentsPerPixel(2);
+  image->Allocate();
 
-    using VariableVectorType = itk::VariableLengthVector<double>;
-    VariableVectorType variableLengthVector;
-    variableLengthVector.SetSize(2);
+  using VariableVectorType = itk::VariableLengthVector<double>;
+  VariableVectorType variableLengthVector;
+  variableLengthVector.SetSize(2);
 
-    itk::ImageRegionIterator<VectorImageType> imageIterator(image,image->GetLargestPossibleRegion());
-    variableLengthVector[0] = 1;
-    variableLengthVector[1] = 2;
+  itk::ImageRegionIterator<VectorImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  variableLengthVector[0] = 1;
+  variableLengthVector[1] = 2;
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(variableLengthVector);
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(variableLengthVector);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 }

--- a/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
+++ b/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
@@ -20,55 +20,59 @@
 #include "itkImageRegionIterator.h"
 #include "itkMedianImageFunction.h"
 
-using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
+using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-void CreateImage(UnsignedCharImageType::Pointer image);
+void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main( int, char *[] )
+int
+main(int, char *[])
 {
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    CreateImage(image);
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  CreateImage(image);
 
-    using MedianImageFunctionType = itk::MedianImageFunction< UnsignedCharImageType >;
-    MedianImageFunctionType::Pointer medianImageFunction = MedianImageFunctionType::New();
-    medianImageFunction->SetInputImage( image );
+  using MedianImageFunctionType = itk::MedianImageFunction<UnsignedCharImageType>;
+  MedianImageFunctionType::Pointer medianImageFunction = MedianImageFunctionType::New();
+  medianImageFunction->SetInputImage(image);
 
-    itk::Index<2> index;
-    index.Fill(10);
-    std::cout << "Median at " << index << " is " << static_cast<int>(medianImageFunction->EvaluateAtIndex(index)) << std::endl;
-    return EXIT_SUCCESS;
+  itk::Index<2> index;
+  index.Fill(10);
+  std::cout << "Median at " << index << " is " << static_cast<int>(medianImageFunction->EvaluateAtIndex(index))
+            << std::endl;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    itk::Index<2> start;
-    start.Fill(0);
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start,size);
+  itk::ImageRegion<2> region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] >= 50 && imageIterator.GetIndex()[1] >= 50 && imageIterator.GetIndex()[0] <= 70 &&
+        imageIterator.GetIndex()[1] <= 70)
     {
-        if(imageIterator.GetIndex()[0] >= 50 && imageIterator.GetIndex()[1] >= 50 &&
-           imageIterator.GetIndex()[0] <= 70 && imageIterator.GetIndex()[1] <= 70)
-        {
-            imageIterator.Set(255);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
     }
 
-    using WriterType = itk::ImageFileWriter < UnsignedCharImageType >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.png");
-    writer->SetInput(image);
-    writer->Update();
+    ++imageIterator;
+  }
+
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/Code.cxx
+++ b/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/Code.cxx
@@ -21,48 +21,50 @@
 
 using ImageType = itk::Image<unsigned char, 1>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    itk::ContinuousIndex<double, 1> pixel;
-    pixel[0] = 1.3;
+  itk::ContinuousIndex<double, 1> pixel;
+  pixel[0] = 1.3;
 
-    itk::LinearInterpolateImageFunction<ImageType, double>::Pointer interpolator =
-            itk::LinearInterpolateImageFunction<ImageType, double>::New();
-    interpolator->SetInputImage(image);
+  itk::LinearInterpolateImageFunction<ImageType, double>::Pointer interpolator =
+    itk::LinearInterpolateImageFunction<ImageType, double>::New();
+  interpolator->SetInputImage(image);
 
-    std::cout << "Value at 1.3: " << interpolator->EvaluateAtContinuousIndex(pixel) << std::endl;
+  std::cout << "Value at 1.3: " << interpolator->EvaluateAtContinuousIndex(pixel) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a 1D image
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
+  // Create a 1D image
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
 
-    ImageType::SizeType size;
-    size[0] = 10;
+  ImageType::SizeType size;
+  size[0] = 10;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    for(unsigned int i = 0; i < 10; i++)
-    {
-        ImageType::IndexType pixelIndex;
-        pixelIndex[0] = i;
+  for (unsigned int i = 0; i < 10; i++)
+  {
+    ImageType::IndexType pixelIndex;
+    pixelIndex[0] = i;
 
-        image->SetPixel(pixelIndex, i*10);
-    }
-
+    image->SetPixel(pixelIndex, i * 10);
+  }
 }

--- a/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
+++ b/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
@@ -21,53 +21,57 @@
 
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
   CreateImage(image);
 
   itk::Neighborhood<float, 2> neighborhood;
   neighborhood.SetRadius(1);
-  for(unsigned int i = 0; i < neighborhood.GetSize()[0] * neighborhood.GetSize()[1]; ++i)
-    {
+  for (unsigned int i = 0; i < neighborhood.GetSize()[0] * neighborhood.GetSize()[1]; ++i)
+  {
     neighborhood[i] = 1;
-    }
+  }
 
   using NeighborhoodOperatorImageFunctionType = itk::NeighborhoodOperatorImageFunction<UnsignedCharImageType, float>;
-  NeighborhoodOperatorImageFunctionType::Pointer neighborhoodOperatorImageFunction = NeighborhoodOperatorImageFunctionType::New();
+  NeighborhoodOperatorImageFunctionType::Pointer neighborhoodOperatorImageFunction =
+    NeighborhoodOperatorImageFunctionType::New();
   neighborhoodOperatorImageFunction->SetOperator(neighborhood);
   neighborhoodOperatorImageFunction->SetInputImage(image);
 
   {
-  itk::Index<2> index;
-  index.Fill(20);
+    itk::Index<2> index;
+    index.Fill(20);
 
-  float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
-  std::cout << "Sum on border: " << output << std::endl;
+    float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
+    std::cout << "Sum on border: " << output << std::endl;
   }
-  
+
   {
-  itk::Index<2> index;
-  index.Fill(35);
+    itk::Index<2> index;
+    index.Fill(35);
 
-  float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
-  std::cout << "Sum in center: " << output << std::endl;
+    float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
+    std::cout << "Sum in center: " << output << std::endl;
   }
-  
+
   {
-  itk::Index<2> index;
-  index.Fill(7);
+    itk::Index<2> index;
+    index.Fill(7);
 
-  float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
-  std::cout << "Sum outside: " << output << std::endl;
+    float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
+    std::cout << "Sum outside: " << output << std::endl;
   }
-  
+
   return EXIT_SUCCESS;
 }
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
   // Create an image with 2 connected components
   UnsignedCharImageType::IndexType start;
@@ -76,23 +80,22 @@ void CreateImage(UnsignedCharImageType::Pointer image)
   UnsignedCharImageType::SizeType size;
   size.Fill(100);
 
-  UnsignedCharImageType::RegionType region(start,size);
+  UnsignedCharImageType::RegionType region(start, size);
 
   image->SetRegions(region);
   image->Allocate();
   image->FillBuffer(0);
 
   // Make a square
-  for(unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 20; c < 80; c++)
     {
-    for(unsigned int c = 20; c < 80; c++)
-      {
       UnsignedCharImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
       pixelIndex[1] = c;
 
       image->SetPixel(pixelIndex, 1);
-      }
     }
+  }
 }
-

--- a/src/Core/ImageFunction/ResampleSegmentedImage/Code.cxx
+++ b/src/Core/ImageFunction/ResampleSegmentedImage/Code.cxx
@@ -28,7 +28,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 #include <iostream>
@@ -38,191 +38,167 @@ using ImageType = itk::Image<InputPixelType, 2>;
 using RGBPixelType = itk::RGBPixel<unsigned char>;
 using RGBImageType = itk::Image<RGBPixelType, 2>;
 
-using ColormapType = itk::Function::CustomColormapFunction<
-        ImageType::PixelType, RGBImageType::PixelType>;
+using ColormapType = itk::Function::CustomColormapFunction<ImageType::PixelType, RGBImageType::PixelType>;
 
-static void CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap);
+static void
+CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap);
 
-int main( int argc, char * argv[] )
+int
+main(int argc, char * argv[])
 {
-    if( argc != 3 )
-    {
-        std::cerr << "Usage: " << argv[0]
-                  << " inputImageFile pixelSize"
-                  << std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << argv[0] << " inputImageFile pixelSize" << std::endl;
 
-        return EXIT_FAILURE;
-    }
-    double spacing = std::stod(argv[2]);
+    return EXIT_FAILURE;
+  }
+  double spacing = std::stod(argv[2]);
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
 
-    // Identity transform.
-    // We don't want any transform on our image except rescaling which is not
-    // specified by a transform but by the input/output spacing as we will see
-    // later.
-    // So no transform will be specified.
-    using TransformType = itk::IdentityTransform<double, 2>;
+  // Identity transform.
+  // We don't want any transform on our image except rescaling which is not
+  // specified by a transform but by the input/output spacing as we will see
+  // later.
+  // So no transform will be specified.
+  using TransformType = itk::IdentityTransform<double, 2>;
 
-    using GaussianInterpolatorType = itk::LabelImageGaussianInterpolateImageFunction<ImageType, double>;
-    using NearestNeighborInterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, double>;
+  using GaussianInterpolatorType = itk::LabelImageGaussianInterpolateImageFunction<ImageType, double>;
+  using NearestNeighborInterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, double>;
 
-    using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
+  using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
-    // Prepare the reader and update it right away to know the sizes beforehand.
-    ReaderType::Pointer reader =
-            ReaderType::New();
-    reader->SetFileName( argv[1] );
-    reader->Update();
+  // Prepare the reader and update it right away to know the sizes beforehand.
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    // Instantiate the transform and specify it should be the identity transform.
-    TransformType::Pointer transform =
-            TransformType::New();
-    transform->SetIdentity();
+  // Instantiate the transform and specify it should be the identity transform.
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    // Instantiate the interpolators
-    GaussianInterpolatorType::Pointer gaussianInterpolator =
-            GaussianInterpolatorType::New();
-    gaussianInterpolator->SetSigma(1.0);
-    gaussianInterpolator->SetAlpha(3.0);
+  // Instantiate the interpolators
+  GaussianInterpolatorType::Pointer gaussianInterpolator = GaussianInterpolatorType::New();
+  gaussianInterpolator->SetSigma(1.0);
+  gaussianInterpolator->SetAlpha(3.0);
 
-    NearestNeighborInterpolatorType::Pointer nearestNeighborInterpolator =
-            NearestNeighborInterpolatorType::New();
+  NearestNeighborInterpolatorType::Pointer nearestNeighborInterpolator = NearestNeighborInterpolatorType::New();
 
-    // Instantiate the resamplers. Wire in the transforms and the interpolators.
-    ResampleFilterType::Pointer resizeFilter1 =
-            ResampleFilterType::New();
-    resizeFilter1->SetTransform(transform);
-    resizeFilter1->SetInterpolator(gaussianInterpolator);
+  // Instantiate the resamplers. Wire in the transforms and the interpolators.
+  ResampleFilterType::Pointer resizeFilter1 = ResampleFilterType::New();
+  resizeFilter1->SetTransform(transform);
+  resizeFilter1->SetInterpolator(gaussianInterpolator);
 
-    ResampleFilterType::Pointer resizeFilter2 =
-            ResampleFilterType::New();
-    resizeFilter2->SetTransform(transform);
-    resizeFilter2->SetInterpolator(nearestNeighborInterpolator);
+  ResampleFilterType::Pointer resizeFilter2 = ResampleFilterType::New();
+  resizeFilter2->SetTransform(transform);
+  resizeFilter2->SetInterpolator(nearestNeighborInterpolator);
 
-    //     Compute and set the output size
-    //
-    //     The computation must be so that the following holds:
-    //
-    //     new width         old x spacing
-    //     ----------   =   ---------------
-    //     old width         new x spacing
-    //
-    //
-    //     new height         old y spacing
-    //    ------------  =   ---------------
-    //     old height         new y spacing
-    //
-    //     So either we specify new height and width and compute new spacings
-    //     or we specify new spacing and compute new height and width
-    //     and computations that follows need to be modified a little (as it is
-    //     done at step 2 there:
-    //       http://itk.org/Wiki/ITK/Examples/DICOM/ResampleDICOM)
-    //
+  //     Compute and set the output size
+  //
+  //     The computation must be so that the following holds:
+  //
+  //     new width         old x spacing
+  //     ----------   =   ---------------
+  //     old width         new x spacing
+  //
+  //
+  //     new height         old y spacing
+  //    ------------  =   ---------------
+  //     old height         new y spacing
+  //
+  //     So either we specify new height and width and compute new spacings
+  //     or we specify new spacing and compute new height and width
+  //     and computations that follows need to be modified a little (as it is
+  //     done at step 2 there:
+  //       http://itk.org/Wiki/ITK/Examples/DICOM/ResampleDICOM)
+  //
 
-    // Fetch original image spacing.
-    const ImageType::SpacingType& inputSpacing =
-            reader->GetOutput()->GetSpacing();
+  // Fetch original image spacing.
+  const ImageType::SpacingType & inputSpacing = reader->GetOutput()->GetSpacing();
 
-    double outputSpacing[2];
-    outputSpacing[0] = spacing;
-    outputSpacing[1] = spacing;
+  double outputSpacing[2];
+  outputSpacing[0] = spacing;
+  outputSpacing[1] = spacing;
 
-    // Fetch original image size
-    const ImageType::RegionType& inputRegion =
-            reader->GetOutput()->GetLargestPossibleRegion();
-    const ImageType::SizeType& inputSize = inputRegion.GetSize();
-    unsigned int oldWidth = inputSize[0];
-    unsigned int oldHeight = inputSize[1];
+  // Fetch original image size
+  const ImageType::RegionType & inputRegion = reader->GetOutput()->GetLargestPossibleRegion();
+  const ImageType::SizeType &   inputSize = inputRegion.GetSize();
+  unsigned int                  oldWidth = inputSize[0];
+  unsigned int                  oldHeight = inputSize[1];
 
-    unsigned int newWidth = (double) oldWidth * inputSpacing[0] / spacing;
-    unsigned int newHeight = (double) oldHeight * inputSpacing[1] / spacing;
+  unsigned int newWidth = (double)oldWidth * inputSpacing[0] / spacing;
+  unsigned int newHeight = (double)oldHeight * inputSpacing[1] / spacing;
 
-    // Set the output spacing as specified on the command line
-    resizeFilter1->SetOutputSpacing(outputSpacing);
-    resizeFilter2->SetOutputSpacing(outputSpacing);
+  // Set the output spacing as specified on the command line
+  resizeFilter1->SetOutputSpacing(outputSpacing);
+  resizeFilter2->SetOutputSpacing(outputSpacing);
 
-    // Set the computed size
-    itk::Size<2> outputSize = { {newWidth, newHeight} };
-    resizeFilter1->SetSize(outputSize);
-    resizeFilter2->SetSize(outputSize);
+  // Set the computed size
+  itk::Size<2> outputSize = { { newWidth, newHeight } };
+  resizeFilter1->SetSize(outputSize);
+  resizeFilter2->SetSize(outputSize);
 
-    // Specify the input for the resamplers
-    resizeFilter1->SetInput(reader->GetOutput());
-    resizeFilter2->SetInput(reader->GetOutput());
+  // Specify the input for the resamplers
+  resizeFilter1->SetInput(reader->GetOutput());
+  resizeFilter2->SetInput(reader->GetOutput());
 
-    // Display the images
-    using ColormapFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
-    ColormapFilterType::Pointer colormapFilter1 =
-            ColormapFilterType::New();
+  // Display the images
+  using ColormapFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
+  ColormapFilterType::Pointer colormapFilter1 = ColormapFilterType::New();
 
-    ColormapType::Pointer colormap
-            = ColormapType::New();
-    CreateRandomColormap(4096, colormap);
+  ColormapType::Pointer colormap = ColormapType::New();
+  CreateRandomColormap(4096, colormap);
 
-    colormapFilter1->SetInput (reader->GetOutput());
-    colormapFilter1->SetColormap(colormap);
+  colormapFilter1->SetInput(reader->GetOutput());
+  colormapFilter1->SetColormap(colormap);
 
-    ColormapFilterType::Pointer colormapFilter2 =
-            ColormapFilterType::New();
-    colormapFilter2->SetInput (resizeFilter1->GetOutput());
-    colormapFilter2->SetColormap(colormap);
+  ColormapFilterType::Pointer colormapFilter2 = ColormapFilterType::New();
+  colormapFilter2->SetInput(resizeFilter1->GetOutput());
+  colormapFilter2->SetColormap(colormap);
 
-    ColormapFilterType::Pointer colormapFilter3 =
-            ColormapFilterType::New();
-    colormapFilter3->SetInput (resizeFilter2->GetOutput());
-    colormapFilter3->SetColormap(colormap);
+  ColormapFilterType::Pointer colormapFilter3 = ColormapFilterType::New();
+  colormapFilter3->SetInput(resizeFilter2->GetOutput());
+  colormapFilter3->SetColormap(colormap);
 
 #ifdef ENABLE_QUICKVIEW
-    std::stringstream desc;
-    desc << itksys::SystemTools::GetFilenameName(argv[1]) << ": " << oldWidth << ", " << oldHeight;
-    QuickView viewer;
-    viewer.AddRGBImage(
-            colormapFilter1->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << itksys::SystemTools::GetFilenameName(argv[1]) << ": " << oldWidth << ", " << oldHeight;
+  QuickView viewer;
+  viewer.AddRGBImage(colormapFilter1->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Gaussian Interpolation: " << newWidth << ", " << newHeight;
-    viewer.AddRGBImage(
-            colormapFilter2->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "Gaussian Interpolation: " << newWidth << ", " << newHeight;
+  viewer.AddRGBImage(colormapFilter2->GetOutput(), true, desc2.str());
 
-    std::stringstream desc3;
-    desc3 << "Nearest Neighbor Interpolation: " << newWidth << ", " << newHeight;
-    viewer.AddRGBImage(
-            colormapFilter3->GetOutput(),
-            true,
-            desc3.str());
-    viewer.Visualize();
+  std::stringstream desc3;
+  desc3 << "Nearest Neighbor Interpolation: " << newWidth << ", " << newHeight;
+  viewer.AddRGBImage(colormapFilter3->GetOutput(), true, desc3.str());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap)
+void
+CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap)
 {
 #define LOW .3
-    ColormapType::ChannelType redChannel;
-    ColormapType::ChannelType greenChannel;
-    ColormapType::ChannelType blueChannel;
-    itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer random =
-            itk::Statistics::MersenneTwisterRandomVariateGenerator::New();
+  ColormapType::ChannelType                                       redChannel;
+  ColormapType::ChannelType                                       greenChannel;
+  ColormapType::ChannelType                                       blueChannel;
+  itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer random =
+    itk::Statistics::MersenneTwisterRandomVariateGenerator::New();
 
-    random->SetSeed ( 8775070 );
-    redChannel.push_back(LOW);
-    greenChannel.push_back(LOW);
-    blueChannel.push_back(LOW);
-    for (unsigned int i = 1; i < size; ++i)
-    {
-        redChannel.push_back(static_cast<ColormapType::RealType>
-                             (random->GetUniformVariate(LOW, 1.0)));
-        greenChannel.push_back(static_cast<ColormapType::RealType>
-                               (random->GetUniformVariate(LOW, 1.0)));
-        blueChannel.push_back(static_cast<ColormapType::RealType>
-                              (random->GetUniformVariate(LOW, 1.0)));
-    }
-    colormap->SetRedChannel(redChannel);
-    colormap->SetGreenChannel(greenChannel);
-    colormap->SetBlueChannel(blueChannel);
+  random->SetSeed(8775070);
+  redChannel.push_back(LOW);
+  greenChannel.push_back(LOW);
+  blueChannel.push_back(LOW);
+  for (unsigned int i = 1; i < size; ++i)
+  {
+    redChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(LOW, 1.0)));
+    greenChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(LOW, 1.0)));
+    blueChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(LOW, 1.0)));
+  }
+  colormap->SetRedChannel(redChannel);
+  colormap->SetGreenChannel(greenChannel);
+  colormap->SetBlueChannel(blueChannel);
 }

--- a/src/Core/Mesh/AddPointsAndEdges/Code.cxx
+++ b/src/Core/Mesh/AddPointsAndEdges/Code.cxx
@@ -19,94 +19,105 @@
 #include "itkLineCell.h"
 
 constexpr unsigned int Dimension = 3;
-using MeshType = itk::Mesh< float, Dimension >;
+using MeshType = itk::Mesh<float, Dimension>;
 
-MeshType::Pointer CreatePointOnlyMesh();
-void CreateMeshWithEdges();
+MeshType::Pointer
+CreatePointOnlyMesh();
+void
+CreateMeshWithEdges();
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    //CreatePointOnlyMesh();
-    CreateMeshWithEdges();
+  // CreatePointOnlyMesh();
+  CreateMeshWithEdges();
 
-    return 0;
+  return 0;
 }
 
 
-MeshType::Pointer CreatePointOnlyMesh()
+MeshType::Pointer
+CreatePointOnlyMesh()
 {
-    MeshType::Pointer  mesh = MeshType::New();
+  MeshType::Pointer mesh = MeshType::New();
 
-    // Create points
-    MeshType::PointType p0,p1,p2,p3;
+  // Create points
+  MeshType::PointType p0, p1, p2, p3;
 
-    p0[0]= -1.0; p0[1]= -1.0; p0[2]= 0.0; // first  point ( -1, -1, 0 )
-    p1[0]=  1.0; p1[1]= -1.0; p1[2]= 0.0; // second point (  1, -1, 0 )
-    p2[0]=  1.0; p2[1]=  1.0; p2[2]= 0.0; // third  point (  1,  1, 0 )
-    p3[0]=  1.0; p3[1]=  1.0; p3[2]= 1.0; // third  point (  1,  1, 1 )
+  p0[0] = -1.0;
+  p0[1] = -1.0;
+  p0[2] = 0.0; // first  point ( -1, -1, 0 )
+  p1[0] = 1.0;
+  p1[1] = -1.0;
+  p1[2] = 0.0; // second point (  1, -1, 0 )
+  p2[0] = 1.0;
+  p2[1] = 1.0;
+  p2[2] = 0.0; // third  point (  1,  1, 0 )
+  p3[0] = 1.0;
+  p3[1] = 1.0;
+  p3[2] = 1.0; // third  point (  1,  1, 1 )
 
-    mesh->SetPoint( 0, p0 );
-    mesh->SetPoint( 1, p1 );
-    mesh->SetPoint( 2, p2 );
-    mesh->SetPoint( 3, p3 );
+  mesh->SetPoint(0, p0);
+  mesh->SetPoint(1, p1);
+  mesh->SetPoint(2, p2);
+  mesh->SetPoint(3, p3);
 
-    std::cout << "Points = " << mesh->GetNumberOfPoints() << std::endl;
+  std::cout << "Points = " << mesh->GetNumberOfPoints() << std::endl;
 
-    // Access points
-    using PointsIterator = MeshType::PointsContainer::Iterator;
+  // Access points
+  using PointsIterator = MeshType::PointsContainer::Iterator;
 
-    PointsIterator  pointIterator = mesh->GetPoints()->Begin();
+  PointsIterator pointIterator = mesh->GetPoints()->Begin();
 
-    PointsIterator end = mesh->GetPoints()->End();
-    while( pointIterator != end )
-    {
-        MeshType::PointType p = pointIterator.Value();  // access the point
-        std::cout << p << std::endl;                    // print the point
-        ++pointIterator;                                // advance to next point
-    }
+  PointsIterator end = mesh->GetPoints()->End();
+  while (pointIterator != end)
+  {
+    MeshType::PointType p = pointIterator.Value(); // access the point
+    std::cout << p << std::endl;                   // print the point
+    ++pointIterator;                               // advance to next point
+  }
 
-    return mesh;
+  return mesh;
 }
 
-void CreateMeshWithEdges()
+void
+CreateMeshWithEdges()
 {
-    MeshType::Pointer mesh = CreatePointOnlyMesh();
+  MeshType::Pointer mesh = CreatePointOnlyMesh();
 
-    using CellAutoPointer = MeshType::CellType::CellAutoPointer;
-    using LineType = itk::LineCell< MeshType::CellType >;
+  using CellAutoPointer = MeshType::CellType::CellAutoPointer;
+  using LineType = itk::LineCell<MeshType::CellType>;
 
-    // Create a link to the previous point in the column (below the current point)
-    CellAutoPointer colline;
-    colline.TakeOwnership(  new LineType  );
+  // Create a link to the previous point in the column (below the current point)
+  CellAutoPointer colline;
+  colline.TakeOwnership(new LineType);
 
-    //unsigned int pointId0 = 0;
-    //unsigned int pointId1 = 1;
+  // unsigned int pointId0 = 0;
+  // unsigned int pointId1 = 1;
 
-    unsigned int pointId0 = 2;
-    unsigned int pointId1 = 3;
+  unsigned int pointId0 = 2;
+  unsigned int pointId1 = 3;
 
-    colline->SetPointId(0, pointId0); // line between points 0 and 1
-    colline->SetPointId(1, pointId1);
-    //std::cout << "Linked point: " << MeshIndex << " and " << MeshIndex - 1 << std::endl;
-    mesh->SetCell( 0, colline );
+  colline->SetPointId(0, pointId0); // line between points 0 and 1
+  colline->SetPointId(1, pointId1);
+  // std::cout << "Linked point: " << MeshIndex << " and " << MeshIndex - 1 << std::endl;
+  mesh->SetCell(0, colline);
 
-    using CellIterator = MeshType::CellsContainer::Iterator;
-    CellIterator  cellIterator = mesh->GetCells()->Begin();
-    CellIterator  CellsEnd          = mesh->GetCells()->End();
+  using CellIterator = MeshType::CellsContainer::Iterator;
+  CellIterator cellIterator = mesh->GetCells()->Begin();
+  CellIterator CellsEnd = mesh->GetCells()->End();
 
-    while( cellIterator != CellsEnd )
-    {
-        MeshType::CellType * cellptr = cellIterator.Value();
-        auto * line = dynamic_cast<LineType *>( cellptr );
+  while (cellIterator != CellsEnd)
+  {
+    MeshType::CellType * cellptr = cellIterator.Value();
+    auto *               line = dynamic_cast<LineType *>(cellptr);
 
-        itk::IdentifierType* linePoint0 = line->PointIdsBegin();
-        //itk::IdentifierType* linePoint1 = line->PointIdsEnd();
-        itk::IdentifierType* linePoint1 = linePoint0+1;
-        std::cout << "line first point id: " << *linePoint0 << std::endl;
-        std::cout << "line second point id: " << *linePoint1 << std::endl;
+    itk::IdentifierType * linePoint0 = line->PointIdsBegin();
+    // itk::IdentifierType* linePoint1 = line->PointIdsEnd();
+    itk::IdentifierType * linePoint1 = linePoint0 + 1;
+    std::cout << "line first point id: " << *linePoint0 << std::endl;
+    std::cout << "line second point id: " << *linePoint1 << std::endl;
 
-        ++cellIterator;
-    }
-
+    ++cellIterator;
+  }
 }
-

--- a/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/Code.cxx
+++ b/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/Code.cxx
@@ -15,60 +15,59 @@
  *  limitations under the License.
  *
  *=========================================================================*/
-#define _USE_MATH_DEFINES //needed for Visual Studio (before #include <cmath>)
+#define _USE_MATH_DEFINES // needed for Visual Studio (before #include <cmath>)
 #include <itkSimplexMesh.h>
 #include <itkRegularSphereMeshSource.h>
 #include <itkTriangleMeshToSimplexMeshFilter.h>
 #include <itkSimplexMeshVolumeCalculator.h>
 
-using TMesh = itk::Mesh< float, 3 >;
-using TSimplex = itk::SimplexMesh< float, 3 >;
-using TSphere = itk::RegularSphereMeshSource< TMesh >;
-using TConvert = itk::TriangleMeshToSimplexMeshFilter< TMesh, TSimplex >;
-using TVolume = itk::SimplexMeshVolumeCalculator< TSimplex >;
+using TMesh = itk::Mesh<float, 3>;
+using TSimplex = itk::SimplexMesh<float, 3>;
+using TSphere = itk::RegularSphereMeshSource<TMesh>;
+using TConvert = itk::TriangleMeshToSimplexMeshFilter<TMesh, TSimplex>;
+using TVolume = itk::SimplexMeshVolumeCalculator<TSimplex>;
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
 
-    // Create a spherical mesh with known radius and resolution.
-    TSphere::Pointer source = TSphere::New();
-    TSphere::VectorType scale;
-    scale.Fill( 5.0 );
-    source->SetScale( scale );
-    source->SetResolution( 5 );
-    source->Update();
+  // Create a spherical mesh with known radius and resolution.
+  TSphere::Pointer    source = TSphere::New();
+  TSphere::VectorType scale;
+  scale.Fill(5.0);
+  source->SetScale(scale);
+  source->SetResolution(5);
+  source->Update();
 
-    // Ensure that all cells of the mesh are triangles.
-    for (TMesh::CellsContainerIterator it = source->GetOutput()->GetCells()->Begin();
-         it != source->GetOutput()->GetCells()->End();
-         ++it)
+  // Ensure that all cells of the mesh are triangles.
+  for (TMesh::CellsContainerIterator it = source->GetOutput()->GetCells()->Begin();
+       it != source->GetOutput()->GetCells()->End();
+       ++it)
+  {
+    TMesh::CellAutoPointer cell;
+    source->GetOutput()->GetCell(it->Index(), cell);
+    if (3 != cell->GetNumberOfPoints())
     {
-        TMesh::CellAutoPointer cell;
-        source->GetOutput()->GetCell(it->Index(), cell);
-        if (3 != cell->GetNumberOfPoints())
-        {
-            std::cerr << "ERROR: All cells must be trianglar." << std::endl;
-            return EXIT_FAILURE;
-        }
+      std::cerr << "ERROR: All cells must be trianglar." << std::endl;
+      return EXIT_FAILURE;
     }
+  }
 
-    // Convert the triangle mesh to a simplex mesh.
-    TConvert::Pointer convert = TConvert::New();
-    convert->SetInput( source->GetOutput() );
-    convert->Update();
+  // Convert the triangle mesh to a simplex mesh.
+  TConvert::Pointer convert = TConvert::New();
+  convert->SetInput(source->GetOutput());
+  convert->Update();
 
-    // Calculate the volume and area of the simplex mesh.
-    TVolume::Pointer volume = TVolume::New();
-    volume->SetSimplexMesh( convert->GetOutput() );
-    volume->Compute();
+  // Calculate the volume and area of the simplex mesh.
+  TVolume::Pointer volume = TVolume::New();
+  volume->SetSimplexMesh(convert->GetOutput());
+  volume->Compute();
 
-    // Compare with the volume and area of an ideal sphere.
-    std::cout << "Ideal Volume: "       << 4.0/3.0*M_PI*pow(5.0,3) << std::endl;
-    std::cout << "Mesh Volume: "        << volume->GetVolume()     << std::endl;
-    std::cout << "Ideal Surface Area: " << 4.0*M_PI*pow(5.0,2)     << std::endl;
-    std::cout << "Mesh Surface Area: "  << volume->GetArea()       << std::endl;
+  // Compare with the volume and area of an ideal sphere.
+  std::cout << "Ideal Volume: " << 4.0 / 3.0 * M_PI * pow(5.0, 3) << std::endl;
+  std::cout << "Mesh Volume: " << volume->GetVolume() << std::endl;
+  std::cout << "Ideal Surface Area: " << 4.0 * M_PI * pow(5.0, 2) << std::endl;
+  std::cout << "Mesh Surface Area: " << volume->GetArea() << std::endl;
 
-    return EXIT_SUCCESS;
-
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Mesh/ConvertMeshToUnstructeredGrid/Code.cxx
+++ b/src/Core/Mesh/ConvertMeshToUnstructeredGrid/Code.cxx
@@ -28,229 +28,245 @@
 #include <vtkUnstructuredGrid.h>
 #include <vtkXMLUnstructuredGridWriter.h>
 
-using MeshType = itk::Mesh< float, 3 >;
+using MeshType = itk::Mesh<float, 3>;
 
 // Functions
-static MeshType::Pointer CreateMeshWithEdges();
-static void ConvertMeshToUnstructuredGrid(MeshType::Pointer, vtkUnstructuredGrid*);
+static MeshType::Pointer
+CreateMeshWithEdges();
+static void
+ConvertMeshToUnstructuredGrid(MeshType::Pointer, vtkUnstructuredGrid *);
 
 class VisitVTKCellsClass
 {
-    vtkCellArray* m_Cells;
-    int* m_LastCell;
-    int* m_TypeArray;
+  vtkCellArray * m_Cells;
+  int *          m_LastCell;
+  int *          m_TypeArray;
+
 public:
-    using CellInterfaceType = itk::CellInterface<
-            MeshType::PixelType,
-            MeshType::CellTraits >;
+  using CellInterfaceType = itk::CellInterface<MeshType::PixelType, MeshType::CellTraits>;
 
-    using floatLineCell = itk::LineCell<CellInterfaceType>;
-    using floatTriangleCell = itk::TriangleCell<CellInterfaceType>;
-    using floatQuadrilateralCell = itk::QuadrilateralCell<CellInterfaceType>;
+  using floatLineCell = itk::LineCell<CellInterfaceType>;
+  using floatTriangleCell = itk::TriangleCell<CellInterfaceType>;
+  using floatQuadrilateralCell = itk::QuadrilateralCell<CellInterfaceType>;
 
-    // Set the vtkCellArray that will be constructed
-    void SetCellArray(vtkCellArray* a)
-    {
-        m_Cells = a;
-    }
+  // Set the vtkCellArray that will be constructed
+  void
+  SetCellArray(vtkCellArray * a)
+  {
+    m_Cells = a;
+  }
 
-    // Set the cell counter pointer
-    void SetCellCounter(int* i)
-    {
-        m_LastCell = i;
-    }
+  // Set the cell counter pointer
+  void
+  SetCellCounter(int * i)
+  {
+    m_LastCell = i;
+  }
 
-    // Set the type array for storing the vtk cell types
-    void SetTypeArray(int* i)
-    {
-        m_TypeArray = i;
-    }
+  // Set the type array for storing the vtk cell types
+  void
+  SetTypeArray(int * i)
+  {
+    m_TypeArray = i;
+  }
 
-    // Visit a triangle and create the VTK_TRIANGLE cell
-    void Visit(unsigned long, floatTriangleCell* t)
-    {
-        m_Cells->InsertNextCell(3,  (vtkIdType*)t->PointIdsBegin());
-        m_TypeArray[*m_LastCell] = VTK_TRIANGLE;
-        (*m_LastCell)++;
-    }
+  // Visit a triangle and create the VTK_TRIANGLE cell
+  void
+  Visit(unsigned long, floatTriangleCell * t)
+  {
+    m_Cells->InsertNextCell(3, (vtkIdType *)t->PointIdsBegin());
+    m_TypeArray[*m_LastCell] = VTK_TRIANGLE;
+    (*m_LastCell)++;
+  }
 
-    // Visit a triangle and create the VTK_QUAD cell
-    void Visit(unsigned long, floatQuadrilateralCell* t)
-    {
-        m_Cells->InsertNextCell(4,  (vtkIdType*)t->PointIdsBegin());
-        m_TypeArray[*m_LastCell] = VTK_QUAD;
-        (*m_LastCell)++;
-    }
+  // Visit a triangle and create the VTK_QUAD cell
+  void
+  Visit(unsigned long, floatQuadrilateralCell * t)
+  {
+    m_Cells->InsertNextCell(4, (vtkIdType *)t->PointIdsBegin());
+    m_TypeArray[*m_LastCell] = VTK_QUAD;
+    (*m_LastCell)++;
+  }
 
-    // Visit a line and create the VTK_LINE cell
-    void Visit(unsigned long, floatLineCell* t)
-    {
-        m_Cells->InsertNextCell(2,  (vtkIdType*)t->PointIdsBegin());
-        m_TypeArray[*m_LastCell] = VTK_LINE;
-        (*m_LastCell)++;
-    }
+  // Visit a line and create the VTK_LINE cell
+  void
+  Visit(unsigned long, floatLineCell * t)
+  {
+    m_Cells->InsertNextCell(2, (vtkIdType *)t->PointIdsBegin());
+    m_TypeArray[*m_LastCell] = VTK_LINE;
+    (*m_LastCell)++;
+  }
 };
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    MeshType::Pointer mesh = CreateMeshWithEdges();
+  MeshType::Pointer mesh = CreateMeshWithEdges();
 
-    vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid = vtkSmartPointer<vtkUnstructuredGrid>::New();
-    ConvertMeshToUnstructuredGrid(mesh, unstructuredGrid);
+  vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid = vtkSmartPointer<vtkUnstructuredGrid>::New();
+  ConvertMeshToUnstructuredGrid(mesh, unstructuredGrid);
 
-    // Write file
-    vtkSmartPointer<vtkXMLUnstructuredGridWriter> writer =
-            vtkSmartPointer<vtkXMLUnstructuredGridWriter>::New();
-    writer->SetFileName("output.vtu");
+  // Write file
+  vtkSmartPointer<vtkXMLUnstructuredGridWriter> writer = vtkSmartPointer<vtkXMLUnstructuredGridWriter>::New();
+  writer->SetFileName("output.vtu");
 #if VTK_MAJOR_VERSION <= 5
-    writer->SetInputConnection(unstructuredGrid->GetProducerPort());
+  writer->SetInputConnection(unstructuredGrid->GetProducerPort());
 #else
-    writer->SetInputData(unstructuredGrid);
+  writer->SetInputData(unstructuredGrid);
 #endif
-    writer->Write();
+  writer->Write();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-MeshType::Pointer CreateMeshWithEdges()
+MeshType::Pointer
+CreateMeshWithEdges()
 {
 
-    MeshType::Pointer  mesh = MeshType::New();
+  MeshType::Pointer mesh = MeshType::New();
 
-    // Create 4 points and add them to the mesh
-    MeshType::PointType p0,p1,p2,p3;
+  // Create 4 points and add them to the mesh
+  MeshType::PointType p0, p1, p2, p3;
 
-    p0[0]= -1.0; p0[1]= -1.0; p0[2]= 0.0;
-    p1[0]=  1.0; p1[1]= -1.0; p1[2]= 0.0;
-    p2[0]=  1.0; p2[1]=  1.0; p2[2]= 0.0;
-    p3[0]=  1.0; p3[1]=  1.0; p3[2]= 1.0;
+  p0[0] = -1.0;
+  p0[1] = -1.0;
+  p0[2] = 0.0;
+  p1[0] = 1.0;
+  p1[1] = -1.0;
+  p1[2] = 0.0;
+  p2[0] = 1.0;
+  p2[1] = 1.0;
+  p2[2] = 0.0;
+  p3[0] = 1.0;
+  p3[1] = 1.0;
+  p3[2] = 1.0;
 
-    mesh->SetPoint( 0, p0 );
-    mesh->SetPoint( 1, p1 );
-    mesh->SetPoint( 2, p2 );
-    mesh->SetPoint( 3, p3 );
+  mesh->SetPoint(0, p0);
+  mesh->SetPoint(1, p1);
+  mesh->SetPoint(2, p2);
+  mesh->SetPoint(3, p3);
 
-    // Create three lines and add them to the mesh
-    using CellAutoPointer = MeshType::CellType::CellAutoPointer;
-    using LineType = itk::LineCell< MeshType::CellType >;
+  // Create three lines and add them to the mesh
+  using CellAutoPointer = MeshType::CellType::CellAutoPointer;
+  using LineType = itk::LineCell<MeshType::CellType>;
 
-    CellAutoPointer line0;
-    line0.TakeOwnership(  new LineType  );
-    line0->SetPointId(0, 0); // line between points 0 and 1
-    line0->SetPointId(1, 1);
-    mesh->SetCell( 0, line0);
+  CellAutoPointer line0;
+  line0.TakeOwnership(new LineType);
+  line0->SetPointId(0, 0); // line between points 0 and 1
+  line0->SetPointId(1, 1);
+  mesh->SetCell(0, line0);
 
-    CellAutoPointer line1;
-    line1.TakeOwnership(  new LineType  );
-    line1->SetPointId(0, 1); // line between points 1 and 2
-    line1->SetPointId(1, 2);
-    mesh->SetCell( 1, line1);
+  CellAutoPointer line1;
+  line1.TakeOwnership(new LineType);
+  line1->SetPointId(0, 1); // line between points 1 and 2
+  line1->SetPointId(1, 2);
+  mesh->SetCell(1, line1);
 
-    CellAutoPointer line2;
-    line2.TakeOwnership(  new LineType  );
-    line2->SetPointId(0, 2); // line between points 2 and 3
-    line2->SetPointId(1, 3);
-    mesh->SetCell( 2, line2);
+  CellAutoPointer line2;
+  line2.TakeOwnership(new LineType);
+  line2->SetPointId(0, 2); // line between points 2 and 3
+  line2->SetPointId(1, 3);
+  mesh->SetCell(2, line2);
 
-    return mesh;
+  return mesh;
 }
 
-void ConvertMeshToUnstructuredGrid(MeshType::Pointer mesh, vtkUnstructuredGrid* unstructuredGrid)
+void
+ConvertMeshToUnstructuredGrid(MeshType::Pointer mesh, vtkUnstructuredGrid * unstructuredGrid)
 {
-    // Get the number of points in the mesh
-    int numPoints = mesh->GetNumberOfPoints();
-    if(numPoints == 0)
-    {
-        mesh->Print(std::cerr);
-        std::cerr << "no points in Grid " << std::endl;
-        exit(-1);
-    }
+  // Get the number of points in the mesh
+  int numPoints = mesh->GetNumberOfPoints();
+  if (numPoints == 0)
+  {
+    mesh->Print(std::cerr);
+    std::cerr << "no points in Grid " << std::endl;
+    exit(-1);
+  }
 
-    // Create the vtkPoints object and set the number of points
-    vtkPoints* vpoints = vtkPoints::New();
-    vpoints->SetNumberOfPoints(numPoints);
-    // Iterate over all the points in the itk mesh filling in
-    // the vtkPoints object as we go
-    MeshType::PointsContainer::Pointer points = mesh->GetPoints();
+  // Create the vtkPoints object and set the number of points
+  vtkPoints * vpoints = vtkPoints::New();
+  vpoints->SetNumberOfPoints(numPoints);
+  // Iterate over all the points in the itk mesh filling in
+  // the vtkPoints object as we go
+  MeshType::PointsContainer::Pointer points = mesh->GetPoints();
 
-    // In ITK the point container is not necessarily a vector, but in VTK it is
-    vtkIdType VTKId = 0;
-    std::map< vtkIdType, int > IndexMap;
+  // In ITK the point container is not necessarily a vector, but in VTK it is
+  vtkIdType                VTKId = 0;
+  std::map<vtkIdType, int> IndexMap;
 
-    for(MeshType::PointsContainer::Iterator i = points->Begin();
-        i != points->End(); ++i, VTKId++)
-    {
-        // Get the point index from the point container iterator
-        IndexMap[ VTKId ] = i->Index();
+  for (MeshType::PointsContainer::Iterator i = points->Begin(); i != points->End(); ++i, VTKId++)
+  {
+    // Get the point index from the point container iterator
+    IndexMap[VTKId] = i->Index();
 
-        // Set the vtk point at the index with the the coord array from itk
-        // itk returns a const pointer, but vtk is not const correct, so
-        // we have to use a const cast to get rid of the const
-        vpoints->SetPoint(VTKId, const_cast<float*>(i->Value().GetDataPointer()));
-    }
+    // Set the vtk point at the index with the the coord array from itk
+    // itk returns a const pointer, but vtk is not const correct, so
+    // we have to use a const cast to get rid of the const
+    vpoints->SetPoint(VTKId, const_cast<float *>(i->Value().GetDataPointer()));
+  }
 
-    // Set the points on the vtk grid
-    unstructuredGrid->SetPoints(vpoints);
+  // Set the points on the vtk grid
+  unstructuredGrid->SetPoints(vpoints);
 
-    // Setup some VTK things
-    int vtkCellCount = 0; // running counter for current cell being inserted into vtk
-    int numCells = mesh->GetNumberOfCells();
-    auto *types = new int[numCells]; // type array for vtk
-    // create vtk cells and estimate the size
-    vtkCellArray* cells = vtkCellArray::New();
-    cells->EstimateSize(numCells, 4);
+  // Setup some VTK things
+  int    vtkCellCount = 0; // running counter for current cell being inserted into vtk
+  int    numCells = mesh->GetNumberOfCells();
+  auto * types = new int[numCells]; // type array for vtk
+  // create vtk cells and estimate the size
+  vtkCellArray * cells = vtkCellArray::New();
+  cells->EstimateSize(numCells, 4);
 
-    // Setup the line visitor
-    using LineVisitor = itk::CellInterfaceVisitorImplementation<
-            float, MeshType::CellTraits,
-            itk::LineCell< itk::CellInterface<MeshType::PixelType, MeshType::CellTraits > >,
-            VisitVTKCellsClass>;
-    LineVisitor::Pointer lv =  LineVisitor::New();
-    lv->SetTypeArray(types);
-    lv->SetCellCounter(&vtkCellCount);
-    lv->SetCellArray(cells);
+  // Setup the line visitor
+  using LineVisitor = itk::CellInterfaceVisitorImplementation<
+    float,
+    MeshType::CellTraits,
+    itk::LineCell<itk::CellInterface<MeshType::PixelType, MeshType::CellTraits>>,
+    VisitVTKCellsClass>;
+  LineVisitor::Pointer lv = LineVisitor::New();
+  lv->SetTypeArray(types);
+  lv->SetCellCounter(&vtkCellCount);
+  lv->SetCellArray(cells);
 
-    // Setup the triangle visitor
-    using TriangleVisitor = itk::CellInterfaceVisitorImplementation<
-            float, MeshType::CellTraits,
-            itk::TriangleCell< itk::CellInterface<MeshType::PixelType, MeshType::CellTraits > >,
-            VisitVTKCellsClass>;
-    TriangleVisitor::Pointer tv = TriangleVisitor::New();
-    tv->SetTypeArray(types);
-    tv->SetCellCounter(&vtkCellCount);
-    tv->SetCellArray(cells);
+  // Setup the triangle visitor
+  using TriangleVisitor = itk::CellInterfaceVisitorImplementation<
+    float,
+    MeshType::CellTraits,
+    itk::TriangleCell<itk::CellInterface<MeshType::PixelType, MeshType::CellTraits>>,
+    VisitVTKCellsClass>;
+  TriangleVisitor::Pointer tv = TriangleVisitor::New();
+  tv->SetTypeArray(types);
+  tv->SetCellCounter(&vtkCellCount);
+  tv->SetCellArray(cells);
 
-    // Setup the quadrilateral visitor
-    using QuadrilateralVisitor = itk::CellInterfaceVisitorImplementation<
-            float, MeshType::CellTraits,
-            itk::QuadrilateralCell< itk::CellInterface<MeshType::PixelType, MeshType::CellTraits > >,
-            VisitVTKCellsClass>;
-    QuadrilateralVisitor::Pointer qv =  QuadrilateralVisitor::New();
-    qv->SetTypeArray(types);
-    qv->SetCellCounter(&vtkCellCount);
-    qv->SetCellArray(cells);
+  // Setup the quadrilateral visitor
+  using QuadrilateralVisitor = itk::CellInterfaceVisitorImplementation<
+    float,
+    MeshType::CellTraits,
+    itk::QuadrilateralCell<itk::CellInterface<MeshType::PixelType, MeshType::CellTraits>>,
+    VisitVTKCellsClass>;
+  QuadrilateralVisitor::Pointer qv = QuadrilateralVisitor::New();
+  qv->SetTypeArray(types);
+  qv->SetCellCounter(&vtkCellCount);
+  qv->SetCellArray(cells);
 
-    // Add the visitors to a multivisitor
+  // Add the visitors to a multivisitor
 
-    MeshType::CellType::MultiVisitor::Pointer mv =
-            MeshType::CellType::MultiVisitor::New();
+  MeshType::CellType::MultiVisitor::Pointer mv = MeshType::CellType::MultiVisitor::New();
 
-    mv->AddVisitor(tv);
-    mv->AddVisitor(qv);
-    mv->AddVisitor(lv);
+  mv->AddVisitor(tv);
+  mv->AddVisitor(qv);
+  mv->AddVisitor(lv);
 
-    // Now ask the mesh to accept the multivisitor which
-    // will Call Visit for each cell in the mesh that matches the
-    // cell types of the visitors added to the MultiVisitor
-    mesh->Accept(mv);
+  // Now ask the mesh to accept the multivisitor which
+  // will Call Visit for each cell in the mesh that matches the
+  // cell types of the visitors added to the MultiVisitor
+  mesh->Accept(mv);
 
-    // Now set the cells on the vtk grid with the type array and cell array
-    unstructuredGrid->SetCells(types, cells);
-    std::cout << "Unstructured grid has " << unstructuredGrid->GetNumberOfCells() << " cells." << std::endl;
+  // Now set the cells on the vtk grid with the type array and cell array
+  unstructuredGrid->SetCells(types, cells);
+  std::cout << "Unstructured grid has " << unstructuredGrid->GetNumberOfCells() << " cells." << std::endl;
 
-    // Clean up vtk objects
-    cells->Delete();
-    vpoints->Delete();
-
+  // Clean up vtk objects
+  cells->Delete();
+  vpoints->Delete();
 }
-

--- a/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/Code.cxx
+++ b/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/Code.cxx
@@ -26,72 +26,73 @@
 #include "itkCastImageFilter.h"
 #include "itkTriangleMeshToBinaryImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputImageName> <InputMeshName> <OutputImageName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const char * inputImageName   = argv[1];
-  const char * inputMeshName    = argv[2];
-  const char * outputImageName  = argv[3];
+  const char * inputImageName = argv[1];
+  const char * inputMeshName = argv[2];
+  const char * outputImageName = argv[3];
 
   constexpr unsigned int Dimension = 3;
   using MeshPixelType = double;
 
-  using MeshType = itk::Mesh< MeshPixelType, Dimension >;
+  using MeshType = itk::Mesh<MeshPixelType, Dimension>;
 
-  using MeshReaderType = itk::MeshFileReader< MeshType >;
+  using MeshReaderType = itk::MeshFileReader<MeshType>;
   MeshReaderType::Pointer meshReader = MeshReaderType::New();
-  meshReader->SetFileName( inputMeshName );
+  meshReader->SetFileName(inputMeshName);
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
-  using ImageReaderType = itk::ImageFileReader< InputImageType >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
+  using ImageReaderType = itk::ImageFileReader<InputImageType>;
 
   ImageReaderType::Pointer imageReader = ImageReaderType::New();
-  imageReader->SetFileName( inputImageName );
+  imageReader->SetFileName(inputImageName);
 
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using CastFilterType = itk::CastImageFilter< InputImageType, OutputImageType >;
+  using CastFilterType = itk::CastImageFilter<InputImageType, OutputImageType>;
   CastFilterType::Pointer cast = CastFilterType::New();
-  cast->SetInput( imageReader->GetOutput() );
+  cast->SetInput(imageReader->GetOutput());
 
-  using FilterType = itk::TriangleMeshToBinaryImageFilter< MeshType, OutputImageType >;
+  using FilterType = itk::TriangleMeshToBinaryImageFilter<MeshType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( meshReader->GetOutput() );
-  filter->SetInfoImage( cast->GetOutput() );
-  filter->SetInsideValue( itk::NumericTraits< OutputPixelType >::max() );
+  filter->SetInput(meshReader->GetOutput());
+  filter->SetInfoImage(cast->GetOutput());
+  filter->SetInsideValue(itk::NumericTraits<OutputPixelType>::max());
   try
-    {
+  {
     filter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputImageName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputImageName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Mesh/ExtractIsoSurface/Code.cxx
+++ b/src/Core/Mesh/ExtractIsoSurface/Code.cxx
@@ -24,16 +24,17 @@
 #include "itkBinaryMask3DMeshSource.h"
 #include "itkMeshFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <Lower Threshold> <Upper Threshold>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -41,42 +42,42 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 3;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  auto lowerThreshold = static_cast< PixelType >( std::stoi( argv[3] ) );
-  auto upperThreshold = static_cast< PixelType >( std::stoi( argv[4] ) );
+  auto lowerThreshold = static_cast<PixelType>(std::stoi(argv[3]));
+  auto upperThreshold = static_cast<PixelType>(std::stoi(argv[4]));
 
-  using BinaryThresholdFilterType = itk::BinaryThresholdImageFilter< ImageType, ImageType >;
+  using BinaryThresholdFilterType = itk::BinaryThresholdImageFilter<ImageType, ImageType>;
   BinaryThresholdFilterType::Pointer threshold = BinaryThresholdFilterType::New();
-  threshold->SetInput( reader->GetOutput() );
-  threshold->SetLowerThreshold( lowerThreshold );
-  threshold->SetUpperThreshold( upperThreshold );
-  threshold->SetOutsideValue( 0 );
+  threshold->SetInput(reader->GetOutput());
+  threshold->SetLowerThreshold(lowerThreshold);
+  threshold->SetUpperThreshold(upperThreshold);
+  threshold->SetOutsideValue(0);
 
-  using MeshType = itk::Mesh< double, Dimension >;
+  using MeshType = itk::Mesh<double, Dimension>;
 
-  using FilterType = itk::BinaryMask3DMeshSource< ImageType, MeshType >;
+  using FilterType = itk::BinaryMask3DMeshSource<ImageType, MeshType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( threshold->GetOutput() );
-  filter->SetObjectValue( 255 );
+  filter->SetInput(threshold->GetOutput());
+  filter->SetObjectValue(255);
 
-  using WriterType = itk::MeshFileWriter< MeshType >;
+  using WriterType = itk::MeshFileWriter<MeshType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Mesh/TranslateOneMesh/Code.cxx
+++ b/src/Core/Mesh/TranslateOneMesh/Code.cxx
@@ -22,16 +22,17 @@
 #include "itkTranslationTransform.h"
 #include "itkTransformMeshFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -39,38 +40,38 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 3;
 
   using PixelType = double;
-  using MeshType = itk::Mesh< PixelType, Dimension >;
+  using MeshType = itk::Mesh<PixelType, Dimension>;
 
-  using ReaderType = itk::MeshFileReader< MeshType >;
+  using ReaderType = itk::MeshFileReader<MeshType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using TransformType = itk::TranslationTransform< MeshType::PointType::CoordRepType, Dimension >;
+  using TransformType = itk::TranslationTransform<MeshType::PointType::CoordRepType, Dimension>;
   TransformType::Pointer translation = TransformType::New();
 
   TransformType::OutputVectorType displacement;
-  displacement.Fill( 1. );
+  displacement.Fill(1.);
 
-  translation->Translate( displacement );
+  translation->Translate(displacement);
 
-  using FilterType = itk::TransformMeshFilter< MeshType, MeshType, TransformType >;
+  using FilterType = itk::TransformMeshFilter<MeshType, MeshType, TransformType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetTransform( translation );
+  filter->SetInput(reader->GetOutput());
+  filter->SetTransform(translation);
 
-  using WriterType = itk::MeshFileWriter< MeshType >;
+  using WriterType = itk::MeshFileWriter<MeshType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Mesh/WorkingWithPointAndCellData/Code.cxx
+++ b/src/Core/Mesh/WorkingWithPointAndCellData/Code.cxx
@@ -25,51 +25,50 @@ constexpr unsigned int Dimension = 3;
 using TCoordinate = float;
 
 // ...and then type alias the mesh, sphere, and writer.
-using TMesh = itk::Mesh< TCoordinate, Dimension >;
-using TSphere = itk::RegularSphereMeshSource< TMesh >;
-using TMeshWriter = itk::MeshFileWriter< TMesh >;
+using TMesh = itk::Mesh<TCoordinate, Dimension>;
+using TSphere = itk::RegularSphereMeshSource<TMesh>;
+using TMeshWriter = itk::MeshFileWriter<TMesh>;
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
 
-    // Create the sphere source.
-    TSphere::Pointer sphere = TSphere::New();
-    sphere->Update();
+  // Create the sphere source.
+  TSphere::Pointer sphere = TSphere::New();
+  sphere->Update();
 
-    // We now assign it to a mesh pointer.
-    TMesh::Pointer mesh = sphere->GetOutput();
+  // We now assign it to a mesh pointer.
+  TMesh::Pointer mesh = sphere->GetOutput();
 
-    // It is necessary to disconnect the mesh from the pipeline;
-    // otherwise, the point and cell data will be deallocated
-    // when we call "Update()" on the writer later in the program.
-    mesh->DisconnectPipeline();
+  // It is necessary to disconnect the mesh from the pipeline;
+  // otherwise, the point and cell data will be deallocated
+  // when we call "Update()" on the writer later in the program.
+  mesh->DisconnectPipeline();
 
-    // Let's assign a value to each of the mesh's points...
-    for (unsigned int i = 0; i < mesh->GetNumberOfPoints(); ++i)
-        mesh->SetPointData( i, 5.0 );
+  // Let's assign a value to each of the mesh's points...
+  for (unsigned int i = 0; i < mesh->GetNumberOfPoints(); ++i)
+    mesh->SetPointData(i, 5.0);
 
-    // ...and assign a different value to each of the mesh's cells.
-    for (unsigned int i = 0; i < mesh->GetNumberOfCells(); ++i)
-        mesh->SetCellData( i, 10.0 );
+  // ...and assign a different value to each of the mesh's cells.
+  for (unsigned int i = 0; i < mesh->GetNumberOfCells(); ++i)
+    mesh->SetCellData(i, 10.0);
 
-    // We'll print out some data about the points...
-    std::cout << mesh->GetNumberOfPoints() << std::endl; // 66
-    std::cout << mesh->GetPointData()->Size() << std::endl; // 66
-    std::cout << mesh->GetPointData()->ElementAt( 0 ) << std::endl << std::endl; // 5.0
+  // We'll print out some data about the points...
+  std::cout << mesh->GetNumberOfPoints() << std::endl;                       // 66
+  std::cout << mesh->GetPointData()->Size() << std::endl;                    // 66
+  std::cout << mesh->GetPointData()->ElementAt(0) << std::endl << std::endl; // 5.0
 
-    // ...and about the cells.
-    std::cout << mesh->GetNumberOfCells() << std::endl; // 128
-    std::cout << mesh->GetCellData()->Size() << std::endl; // 128
-    std::cout << mesh->GetCellData()->ElementAt( 0 ) << std::endl << std::endl; // 10.0
+  // ...and about the cells.
+  std::cout << mesh->GetNumberOfCells() << std::endl;                       // 128
+  std::cout << mesh->GetCellData()->Size() << std::endl;                    // 128
+  std::cout << mesh->GetCellData()->ElementAt(0) << std::endl << std::endl; // 10.0
 
-    // Finally, we'll write the data to file.  Note that the only mesh file
-    // formats supported by ITK which support cell and point data are .vtk and .gii.
-    TMeshWriter::Pointer meshWriter = TMeshWriter::New();
-    meshWriter->SetFileName( "mesh.vtk" );
-    meshWriter->SetInput( mesh );
-    meshWriter->Update();
+  // Finally, we'll write the data to file.  Note that the only mesh file
+  // formats supported by ITK which support cell and point data are .vtk and .gii.
+  TMeshWriter::Pointer meshWriter = TMeshWriter::New();
+  meshWriter->SetFileName("mesh.vtk");
+  meshWriter->SetInput(mesh);
+  meshWriter->Update();
 
-    return EXIT_SUCCESS;
-
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Mesh/WriteMeshToVTP/Code.cxx
+++ b/src/Core/Mesh/WriteMeshToVTP/Code.cxx
@@ -20,80 +20,90 @@
 #include "itkVTKPolyDataWriter.h"
 
 constexpr unsigned int Dimension = 3;
-using MeshType = itk::Mesh< float, Dimension >;
+using MeshType = itk::Mesh<float, Dimension>;
 
-MeshType::Pointer CreateMeshWithEdges();
+MeshType::Pointer
+CreateMeshWithEdges();
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
 
-    MeshType::Pointer mesh = CreateMeshWithEdges();
+  MeshType::Pointer mesh = CreateMeshWithEdges();
 
-    using WriterType = itk::VTKPolyDataWriter<MeshType>;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput(mesh);
-    writer->SetFileName("test.vtk");
-    writer->Update();
+  using WriterType = itk::VTKPolyDataWriter<MeshType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(mesh);
+  writer->SetFileName("test.vtk");
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-MeshType::Pointer CreateMeshWithEdges()
+MeshType::Pointer
+CreateMeshWithEdges()
 {
 
-    MeshType::Pointer  mesh = MeshType::New();
+  MeshType::Pointer mesh = MeshType::New();
 
-    // Create points
-    MeshType::PointType p0,p1,p2,p3;
+  // Create points
+  MeshType::PointType p0, p1, p2, p3;
 
-    p0[0]= -1.0; p0[1]= -1.0; p0[2]= 0.0; // first  point ( -1, -1, 0 )
-    p1[0]=  1.0; p1[1]= -1.0; p1[2]= 0.0; // second point (  1, -1, 0 )
-    p2[0]=  1.0; p2[1]=  1.0; p2[2]= 0.0; // third  point (  1,  1, 0 )
-    p3[0]=  1.0; p3[1]=  1.0; p3[2]= 1.0; // third  point (  1,  1, 1 )
+  p0[0] = -1.0;
+  p0[1] = -1.0;
+  p0[2] = 0.0; // first  point ( -1, -1, 0 )
+  p1[0] = 1.0;
+  p1[1] = -1.0;
+  p1[2] = 0.0; // second point (  1, -1, 0 )
+  p2[0] = 1.0;
+  p2[1] = 1.0;
+  p2[2] = 0.0; // third  point (  1,  1, 0 )
+  p3[0] = 1.0;
+  p3[1] = 1.0;
+  p3[2] = 1.0; // third  point (  1,  1, 1 )
 
-    mesh->SetPoint( 0, p0 );
-    mesh->SetPoint( 1, p1 );
-    mesh->SetPoint( 2, p2 );
-    mesh->SetPoint( 3, p3 );
+  mesh->SetPoint(0, p0);
+  mesh->SetPoint(1, p1);
+  mesh->SetPoint(2, p2);
+  mesh->SetPoint(3, p3);
 
-    std::cout << "Points = " << mesh->GetNumberOfPoints() << std::endl;
+  std::cout << "Points = " << mesh->GetNumberOfPoints() << std::endl;
 
-    //access points
-    using PointsIterator = MeshType::PointsContainer::Iterator;
+  // access points
+  using PointsIterator = MeshType::PointsContainer::Iterator;
 
-    PointsIterator  pointIterator = mesh->GetPoints()->Begin();
+  PointsIterator pointIterator = mesh->GetPoints()->Begin();
 
-    PointsIterator end = mesh->GetPoints()->End();
-    while( pointIterator != end )
-    {
-        MeshType::PointType p = pointIterator.Value();  // access the point
-        std::cout << p << std::endl;                    // print the point
-        ++pointIterator;                                // advance to next point
-    }
+  PointsIterator end = mesh->GetPoints()->End();
+  while (pointIterator != end)
+  {
+    MeshType::PointType p = pointIterator.Value(); // access the point
+    std::cout << p << std::endl;                   // print the point
+    ++pointIterator;                               // advance to next point
+  }
 
-    using CellAutoPointer = MeshType::CellType::CellAutoPointer;
-    using LineType = itk::LineCell< MeshType::CellType >;
+  using CellAutoPointer = MeshType::CellType::CellAutoPointer;
+  using LineType = itk::LineCell<MeshType::CellType>;
 
 
-    CellAutoPointer line0;
-    line0.TakeOwnership(  new LineType  );
-    line0->SetPointId(0, 0); // line between points 0 and 1
-    line0->SetPointId(1, 1);
-    mesh->SetCell( 0, line0);
+  CellAutoPointer line0;
+  line0.TakeOwnership(new LineType);
+  line0->SetPointId(0, 0); // line between points 0 and 1
+  line0->SetPointId(1, 1);
+  mesh->SetCell(0, line0);
 
-    CellAutoPointer line1;
-    line1.TakeOwnership(  new LineType  );
-    line1->SetPointId(0, 1); // line between points 1 and 2
-    line1->SetPointId(1, 2);
-    mesh->SetCell( 1, line1);
+  CellAutoPointer line1;
+  line1.TakeOwnership(new LineType);
+  line1->SetPointId(0, 1); // line between points 1 and 2
+  line1->SetPointId(1, 2);
+  mesh->SetCell(1, line1);
 
-    CellAutoPointer line2;
-    line2.TakeOwnership(  new LineType  );
-    line2->SetPointId(0, 2); // line between points 2 and 3
-    line2->SetPointId(1, 3);
-    mesh->SetCell( 2, line2);
+  CellAutoPointer line2;
+  line2.TakeOwnership(new LineType);
+  line2->SetPointId(0, 2); // line between points 2 and 3
+  line2->SetPointId(1, 3);
+  mesh->SetCell(2, line2);
 
-    return mesh;
+  return mesh;
 }
-

--- a/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/Code.cxx
+++ b/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/Code.cxx
@@ -19,23 +19,24 @@
 #include "itkQuadEdgeMesh.h"
 #include "itkMeshFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * outputFileName = argv[1];
 
   constexpr unsigned int Dimension = 3;
 
   using CoordType = double;
-  using MeshType = itk::QuadEdgeMesh< CoordType, Dimension >;
+  using MeshType = itk::QuadEdgeMesh<CoordType, Dimension>;
 
   MeshType::Pointer mesh = MeshType::New();
 
@@ -43,7 +44,7 @@ int main( int argc, char* argv[] )
   using PointsContainerPointer = MeshType::PointsContainerPointer;
 
   PointsContainerPointer points = PointsContainer::New();
-  points->Reserve( 100 );
+  points->Reserve(100);
 
   using PointType = MeshType::PointType;
   PointType p;
@@ -52,46 +53,46 @@ int main( int argc, char* argv[] )
   using PointIdentifier = MeshType::PointIdentifier;
   PointIdentifier k = 0;
 
-  for( int i = 0; i < 10; i++ )
+  for (int i = 0; i < 10; i++)
+  {
+    p[0] = static_cast<CoordType>(i);
+
+    for (int j = 0; j < 10; j++)
     {
-    p[0] = static_cast< CoordType >( i );
-
-    for( int j = 0; j < 10; j++ )
-      {
-      p[1] = static_cast< CoordType >( j );
-      points->SetElement( k, p );
+      p[1] = static_cast<CoordType>(j);
+      points->SetElement(k, p);
       k++;
-      }
     }
+  }
 
-  mesh->SetPoints( points );
+  mesh->SetPoints(points);
 
   k = 0;
 
-  for( int i = 0; i < 9; i++ )
+  for (int i = 0; i < 9; i++)
+  {
+    for (int j = 0; j < 9; j++)
     {
-    for( int j = 0; j < 9; j++ )
-      {
-      mesh->AddFaceTriangle( k, k+1,  k+11 );
-      mesh->AddFaceTriangle( k, k+11, k+10 );
+      mesh->AddFaceTriangle(k, k + 1, k + 11);
+      mesh->AddFaceTriangle(k, k + 11, k + 10);
       k++;
-      }
+    }
     k++;
-    }
+  }
 
-  using WriterType = itk::MeshFileWriter< MeshType >;
+  using WriterType = itk::MeshFileWriter<MeshType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( mesh );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(mesh);
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/QuadEdgeMesh/CutMesh/Code.cxx
+++ b/src/Core/QuadEdgeMesh/CutMesh/Code.cxx
@@ -22,23 +22,24 @@
 #include "itkMeshFileReader.h"
 #include "itkMeshFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-     {
-     std::cerr << "Usage: "<< std::endl;
-     std::cerr << argv[0];
-     std::cerr << " <InputFileName> <OutputFileName>";
-     std::cerr << std::endl;
-     return EXIT_FAILURE;
-     }
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0];
+    std::cerr << " <InputFileName> <OutputFileName>";
+    std::cerr << std::endl;
+    return EXIT_FAILURE;
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
 
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
-  using MeshType = itk::QuadEdgeMesh< CoordType, Dimension >;
+  using MeshType = itk::QuadEdgeMesh<CoordType, Dimension>;
   using MeshPointer = MeshType::Pointer;
   using MeshPointsContainerPointer = MeshType::PointsContainerPointer;
   using MeshPointsContainerIterator = MeshType::PointsContainerIterator;
@@ -46,106 +47,106 @@ int main( int argc, char* argv[] )
   using MeshPointIdentifier = MeshType::PointIdentifier;
   using MeshCellIdentifier = MeshType::CellIdentifier;
 
-  using ReaderType = itk::MeshFileReader< MeshType >;
+  using ReaderType = itk::MeshFileReader<MeshType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   MeshPointer mesh = reader->GetOutput();
 
   MeshPointer output = MeshType::New();
 
-  std::map< MeshPointIdentifier, MeshPointIdentifier > verticesMap;
-  std::set< MeshCellIdentifier > facesSet;
+  std::map<MeshPointIdentifier, MeshPointIdentifier> verticesMap;
+  std::set<MeshCellIdentifier>                       facesSet;
 
   MeshPointsContainerPointer points = mesh->GetPoints();
 
-  MeshPointsContainerIterator pIt   = points->Begin();
-  MeshPointsContainerIterator pEnd  = points->End();
+  MeshPointsContainerIterator pIt = points->Begin();
+  MeshPointsContainerIterator pEnd = points->End();
 
-  while( pIt != pEnd )
+  while (pIt != pEnd)
   {
     MeshPointType p = pIt->Value();
 
-    if( ( p[2] < 0. ) )
-      {
+    if ((p[2] < 0.))
+    {
       // here you do not want to use operator = to copy the coordinates from the
       // input mesh to the output one. Indeed the operator = does not only copy
       // the coordinates, but also the pointer to first QuadEdge of the 0-ring,
       // and it would be wrong.
       MeshPointType q;
-      q.CastFrom( p );
+      q.CastFrom(p);
 
-      verticesMap[ pIt->Index() ] = output->AddPoint( q );
+      verticesMap[pIt->Index()] = output->AddPoint(q);
 
       // iterate on the 0-ring (vertex neighbors)
-      MeshType::QEType* qe = p.GetEdge();
-      MeshType::QEType* temp = qe;
+      MeshType::QEType * qe = p.GetEdge();
+      MeshType::QEType * temp = qe;
       do
-        {
+      {
         // insert the corresponding faces into std::set
-        facesSet.insert( temp->GetLeft() );
+        facesSet.insert(temp->GetLeft());
 
         temp = temp->GetOnext();
-        } while( qe != temp );
-      }
+      } while (qe != temp);
+    }
     ++pIt;
   }
 
   MeshType::CellsContainerPointer cells = mesh->GetCells();
 
-  using PolygonType = itk::QuadEdgeMeshPolygonCell< MeshType::CellType >;
+  using PolygonType = itk::QuadEdgeMeshPolygonCell<MeshType::CellType>;
 
   // iterate on the faces to be added into resulting mesh
-  for( auto fIt : facesSet )
-    {
-    auto* face = dynamic_cast< PolygonType* >( cells->ElementAt( fIt ) );
+  for (auto fIt : facesSet)
+  {
+    auto *                    face = dynamic_cast<PolygonType *>(cells->ElementAt(fIt));
     MeshType::PointIdentifier id[3];
 
-    if( face )
-      {
-      MeshType::QEType *qe = face->GetEdgeRingEntry();
-      MeshType::QEType *temp = qe;
+    if (face)
+    {
+      MeshType::QEType * qe = face->GetEdgeRingEntry();
+      MeshType::QEType * temp = qe;
 
       unsigned int k = 0;
 
       // iterate on the vertices of a given face
       do
-        {
+      {
         // add the corresponding vertex into the output mesh if it has not been added yet
-        if( verticesMap.find( temp->GetOrigin() ) == verticesMap.end() )
-          {
-          MeshType::PointType p = mesh->GetPoint( temp->GetOrigin() );
+        if (verticesMap.find(temp->GetOrigin()) == verticesMap.end())
+        {
+          MeshType::PointType p = mesh->GetPoint(temp->GetOrigin());
 
           MeshType::PointType q;
-          q.CastFrom( p );
+          q.CastFrom(p);
 
-          verticesMap[ temp->GetOrigin() ] = output->AddPoint( q );
-          }
-        id[ k++ ] = verticesMap[ temp->GetOrigin() ];
+          verticesMap[temp->GetOrigin()] = output->AddPoint(q);
+        }
+        id[k++] = verticesMap[temp->GetOrigin()];
 
         temp = temp->GetLnext();
-        } while( qe != temp );
+      } while (qe != temp);
 
       // add the corresponding face into the output mesh
-      output->AddFaceTriangle( id[0], id[1], id[2] );
-      }
+      output->AddFaceTriangle(id[0], id[1], id[2]);
     }
+  }
 
   // save the corresponding mesh
-  using MeshWriterType = itk::MeshFileWriter< MeshType >;
+  using MeshWriterType = itk::MeshFileWriter<MeshType>;
   MeshWriterType::Pointer writer = MeshWriterType::New();
-  writer->SetInput( output );
-  writer->SetFileName( outputFileName );
+  writer->SetInput(output);
+  writer->SetFileName(outputFileName);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject& e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/Code.cxx
+++ b/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/Code.cxx
@@ -20,36 +20,37 @@
 #include "itkVTKPolyDataReader.h"
 #include "itkQuadEdgeMeshBoundaryEdgesMeshFunction.h"
 
-int main( int argc, char* argv [] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage: " << argv[0] << " <InputFileName>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
 
-  using MeshType = itk::QuadEdgeMesh< CoordType, Dimension >;
-  using VTKReaderType = itk::VTKPolyDataReader< MeshType >;
+  using MeshType = itk::QuadEdgeMesh<CoordType, Dimension>;
+  using VTKReaderType = itk::VTKPolyDataReader<MeshType>;
 
   VTKReaderType::Pointer reader = VTKReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   try
-    {
+  {
     reader->Update();
-    }
-  catch( itk::ExceptionObject& e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   MeshType::Pointer mesh = reader->GetOutput();
 
-  using BoundaryExtractorType = itk::QuadEdgeMeshBoundaryEdgesMeshFunction< MeshType >;
+  using BoundaryExtractorType = itk::QuadEdgeMeshBoundaryEdgesMeshFunction<MeshType>;
 
   BoundaryExtractorType::Pointer extractor = BoundaryExtractorType::New();
 
@@ -62,48 +63,48 @@ int main( int argc, char* argv [] )
   using EdgeListPointer = MeshType::EdgeListPointerType;
   using EdgeListIterator = EdgeListType::iterator;
 
-  EdgeListPointer list = extractor->Evaluate( *mesh );
+  EdgeListPointer list = extractor->Evaluate(*mesh);
 
-  if( list->empty() )
-    {
+  if (list->empty())
+  {
     std::cerr << "There is no border on this mesh" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   std::cout << "There are " << list->size() << " borders on this mesh" << std::endl;
 
-  auto it = list->begin();
+  auto                   it = list->begin();
   const EdgeListIterator end = list->end();
 
   size_t i = 0;
-  while( it != end )
-    {
+  while (it != end)
+  {
     std::cout << i << ": ";
 
-    MeshIteratorGeom eIt = (*it)->BeginGeomLnext();
+    MeshIteratorGeom       eIt = (*it)->BeginGeomLnext();
     const MeshIteratorGeom eEnd = (*it)->EndGeomLnext();
 
     MeshPointIdentifier id = MeshType::m_NoPoint;
 
-    while( eIt != eEnd )
-      {
-      MeshQEType* qe = eIt.Value();
+    while (eIt != eEnd)
+    {
+      MeshQEType * qe = eIt.Value();
 
-      if( qe->GetOrigin() != id )
-        {
+      if (qe->GetOrigin() != id)
+      {
         std::cout << qe->GetOrigin();
-        }
+      }
 
       id = qe->GetDestination();
 
       std::cout << " -> " << id;
       ++eIt;
-      }
+    }
 
     std::cout << std::endl;
 
     ++it;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/Code.cxx
+++ b/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/Code.cxx
@@ -19,47 +19,48 @@
 #include "itkMeshFileReader.h"
 #include "itkQuadEdgeMesh.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <VertexId>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 3;
 
   using PixelType = double;
-  using MeshType = itk::QuadEdgeMesh< PixelType, Dimension >;
+  using MeshType = itk::QuadEdgeMesh<PixelType, Dimension>;
 
-  using ReaderType = itk::MeshFileReader< MeshType >;
+  using ReaderType = itk::MeshFileReader<MeshType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   try
-    {
+  {
     reader->Update();
-    }
-  catch( itk::ExceptionObject& e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   MeshType::Pointer mesh = reader->GetOutput();
 
-  MeshType::PointIdentifier id = std::stoi( argv[2] );
+  MeshType::PointIdentifier id = std::stoi(argv[2]);
 
-  MeshType::QEType* qe = mesh->FindEdge( id );
+  MeshType::QEType * qe = mesh->FindEdge(id);
 
-  MeshType::QEType* temp = qe;
+  MeshType::QEType * temp = qe;
   do
-    {
+  {
     std::cout << temp->GetLeft() << std::endl;
     temp = temp->GetOnext();
-    } while( qe != temp );
+  } while (qe != temp);
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/QuadEdgeMesh/PrintVertexNeighbors/Code.cxx
+++ b/src/Core/QuadEdgeMesh/PrintVertexNeighbors/Code.cxx
@@ -19,52 +19,53 @@
 #include "itkMeshFileReader.h"
 #include "itkQuadEdgeMesh.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <VertexId>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 3;
   using CoordinateType = double;
-  using MeshType = itk::QuadEdgeMesh< CoordinateType, Dimension >;
-  using ReaderType = itk::MeshFileReader< MeshType >;
+  using MeshType = itk::QuadEdgeMesh<CoordinateType, Dimension>;
+  using ReaderType = itk::MeshFileReader<MeshType>;
 
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   try
-    {
+  {
     reader->Update();
-    }
-  catch( itk::ExceptionObject& e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   MeshType::Pointer mesh = reader->GetOutput();
 
-  auto id = static_cast< MeshType::PointIdentifier >( std::stoi( argv[2] ) );
+  auto id = static_cast<MeshType::PointIdentifier>(std::stoi(argv[2]));
 
-  MeshType::QEType* qe = mesh->FindEdge( id );
-  if( qe == nullptr )
-    {
+  MeshType::QEType * qe = mesh->FindEdge(id);
+  if (qe == nullptr)
+  {
     std::cerr << "Error: either this vertex does not exist, either this vertex is not connected." << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  MeshType::QEType* qe2 = qe;
+  MeshType::QEType * qe2 = qe;
 
   do
-    {
+  {
     std::cout << qe->GetDestination() << std::endl;
     qe = qe->GetOnext();
-    } while( qe2 != qe );
+  } while (qe2 != qe);
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/SpatialObjects/Blob/Code.cxx
+++ b/src/Core/SpatialObjects/Blob/Code.cxx
@@ -17,25 +17,26 @@
  *=========================================================================*/
 #include "itkBlobSpatialObject.h"
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-    using BlobType = itk::BlobSpatialObject<2>;
+  using BlobType = itk::BlobSpatialObject<2>;
 
-    // Create a list of points
-    BlobType::BlobPointListType points;
-    for(unsigned int i = 0; i < 20; i++)
-    {
-        BlobType::BlobPointType point;
-        point.SetPositionInObjectSpace (i,i);
+  // Create a list of points
+  BlobType::BlobPointListType points;
+  for (unsigned int i = 0; i < 20; i++)
+  {
+    BlobType::BlobPointType point;
+    point.SetPositionInObjectSpace(i, i);
 
-        points.push_back(point);
-    }
+    points.push_back(point);
+  }
 
-    BlobType::Pointer blob = BlobType::New();
-    blob->SetPoints(points);
+  BlobType::Pointer blob = BlobType::New();
+  blob->SetPoints(points);
 
-    BlobType::BoundingBoxType::BoundsArrayType bounds = blob->GetMyBoundingBoxInWorldSpace()->GetBounds();
-    std::cout << "Bounds: " << bounds << std::endl;
+  BlobType::BoundingBoxType::BoundsArrayType bounds = blob->GetMyBoundingBoxInWorldSpace()->GetBounds();
+  std::cout << "Bounds: " << bounds << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/SpatialObjects/ContourSpatialObject/Code.cxx
+++ b/src/Core/SpatialObjects/ContourSpatialObject/Code.cxx
@@ -21,20 +21,20 @@
 #include "itkImageFileWriter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main( int  /*argc*/, char * /*argv*/[] )
+int
+main(int /*argc*/, char * /*argv*/[])
 {
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ContourType = itk::ContourSpatialObject< Dimension >;
+  using ContourType = itk::ContourSpatialObject<Dimension>;
 
-  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-    ContourType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<ContourType, ImageType>;
 
 
   // Create a list of points
@@ -42,32 +42,31 @@ int main( int  /*argc*/, char * /*argv*/[] )
 
   // Add some points
   ContourType::ControlPointType point;
-  point.SetPositionInObjectSpace(0,0);
+  point.SetPositionInObjectSpace(0, 0);
   points.push_back(point);
-  point.SetPositionInObjectSpace(0,30);
+  point.SetPositionInObjectSpace(0, 30);
   points.push_back(point);
-  point.SetPositionInObjectSpace(30,30);
+  point.SetPositionInObjectSpace(30, 30);
   points.push_back(point);
-  point.SetPositionInObjectSpace(0,0);
+  point.SetPositionInObjectSpace(0, 0);
   points.push_back(point);
 
   // Create a contour from the list of points
   ContourType::Pointer contour = ContourType::New();
   contour->SetControlPoints(points);
 
-  SpatialObjectToImageFilterType::Pointer imageFilter =
-    SpatialObjectToImageFilterType::New();
-  itk::Size<2> size;
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
+  itk::Size<2>                            size;
   size.Fill(50);
   imageFilter->SetInsideValue(255); // white
   imageFilter->SetSize(size);
   imageFilter->SetInput(contour);
   imageFilter->Update();
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName("contour.png");
-  writer->SetInput( imageFilter->GetOutput() );
+  writer->SetInput(imageFilter->GetOutput());
   writer->Update();
 
 #ifdef ENABLE_QUICKVIEW
@@ -75,5 +74,5 @@ int main( int  /*argc*/, char * /*argv*/[] )
   viewer.AddImage(imageFilter->GetOutput());
   viewer.Visualize();
 #endif
-return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/SpatialObjects/ConvertSpatialObjectToImage/Code.cxx
+++ b/src/Core/SpatialObjects/ConvertSpatialObjectToImage/Code.cxx
@@ -19,91 +19,90 @@
 #include "itkEllipseSpatialObject.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-    if( argc != 2 )
-    {
-        std::cerr << "Usage: " << argv[0] << " outputimagefile " << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " outputimagefile " << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using PixelType = unsigned char;
-    constexpr unsigned int Dimension = 2;
+  using PixelType = unsigned char;
+  constexpr unsigned int Dimension = 2;
 
-    using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    //  The SpatialObjectToImageFilter requires that the user defines the grid
-    //  parameters of the output image. This includes the number of pixels along
-    //  each dimension, the pixel spacing, image direction and
+  //  The SpatialObjectToImageFilter requires that the user defines the grid
+  //  parameters of the output image. This includes the number of pixels along
+  //  each dimension, the pixel spacing, image direction and
 
-    ImageType::SizeType size;
-    size[ 0 ] =  50;
-    size[ 1 ] =  50;
+  ImageType::SizeType size;
+  size[0] = 50;
+  size[1] = 50;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing[0] =  100.0 / size[0];
-    spacing[1] =  100.0 / size[1];
+  ImageType::SpacingType spacing;
+  spacing[0] = 100.0 / size[0];
+  spacing[1] = 100.0 / size[1];
 
-    imageFilter->SetSpacing( spacing );
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 20;
-    //ellipse->SetRadiusInObjectSpace(  size[0] * 0.2 * spacing[0] );
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 20;
+  // ellipse->SetRadiusInObjectSpace(  size[0] * 0.2 * spacing[0] );
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    // Position the ellipse
+  // Position the ellipse
 
-    using TransformType = EllipseType::TransformType;
+  using TransformType = EllipseType::TransformType;
 
-    TransformType::Pointer transform = TransformType::New();
+  TransformType::Pointer transform = TransformType::New();
 
-    transform->SetIdentity();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  size[0] * spacing[0] / 2.0;
-    translation[ 1 ] =  size[1] * spacing[1] / 4.0;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = size[0] * spacing[0] / 2.0;
+  translation[1] = size[1] * spacing[1] / 4.0;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultInsideValue(255);
 
-    ellipse->SetDefaultOutsideValue(0);
+  ellipse->SetDefaultOutsideValue(0);
 
-    imageFilter->SetUseObjectValue( true );
+  imageFilter->SetUseObjectValue(true);
 
-    imageFilter->SetOutsideValue( 0 );
+  imageFilter->SetOutsideValue(0);
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
 
-    writer->SetFileName( argv[1] );
-    writer->SetInput( imageFilter->GetOutput() );
+  writer->SetFileName(argv[1]);
+  writer->SetInput(imageFilter->GetOutput());
 
-    try
-    {
-        imageFilter->Update();
-        writer->Update();
-    }
-    catch( itk::ExceptionObject & excp )
-    {
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    imageFilter->Update();
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/SpatialObjects/Ellipse/Code.cxx
+++ b/src/Core/SpatialObjects/Ellipse/Code.cxx
@@ -19,91 +19,90 @@
 #include "itkEllipseSpatialObject.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-    if( argc != 2 )
-    {
-        std::cerr << "Usage: " << argv[0] << " outputimagefile " << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " outputimagefile " << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using PixelType = unsigned char;
-    constexpr unsigned int Dimension = 2;
+  using PixelType = unsigned char;
+  constexpr unsigned int Dimension = 2;
 
-    using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    //  The SpatialObjectToImageFilter requires that the user defines the grid
-    //  parameters of the output image. This includes the number of pixels along
-    //  each dimension, the pixel spacing, image direction and
+  //  The SpatialObjectToImageFilter requires that the user defines the grid
+  //  parameters of the output image. This includes the number of pixels along
+  //  each dimension, the pixel spacing, image direction and
 
-    ImageType::SizeType size;
-    size[ 0 ] =  50;
-    size[ 1 ] =  50;
+  ImageType::SizeType size;
+  size[0] = 50;
+  size[1] = 50;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing[0] =  100.0 / size[0];
-    spacing[1] =  100.0 / size[1];
+  ImageType::SpacingType spacing;
+  spacing[0] = 100.0 / size[0];
+  spacing[1] = 100.0 / size[1];
 
-    imageFilter->SetSpacing( spacing );
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 20;
-    //ellipse->SetRadiusInObjectSpace(  size[0] * 0.2 * spacing[0] );
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 20;
+  // ellipse->SetRadiusInObjectSpace(  size[0] * 0.2 * spacing[0] );
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    // Position the ellipse
+  // Position the ellipse
 
-    using TransformType = EllipseType::TransformType;
+  using TransformType = EllipseType::TransformType;
 
-    TransformType::Pointer transform = TransformType::New();
+  TransformType::Pointer transform = TransformType::New();
 
-    transform->SetIdentity();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  size[0] * spacing[0] / 2.0;
-    translation[ 1 ] =  size[1] * spacing[1] / 4.0;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = size[0] * spacing[0] / 2.0;
+  translation[1] = size[1] * spacing[1] / 4.0;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultInsideValue(255);
 
-    ellipse->SetDefaultOutsideValue(0);
+  ellipse->SetDefaultOutsideValue(0);
 
-    imageFilter->SetUseObjectValue( true );
+  imageFilter->SetUseObjectValue(true);
 
-    imageFilter->SetOutsideValue( 0 );
+  imageFilter->SetOutsideValue(0);
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
 
-    writer->SetFileName( argv[1] );
-    writer->SetInput( imageFilter->GetOutput() );
+  writer->SetFileName(argv[1]);
+  writer->SetInput(imageFilter->GetOutput());
 
-    try
-    {
-        imageFilter->Update();
-        writer->Update();
-    }
-    catch( itk::ExceptionObject & excp )
-    {
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    imageFilter->Update();
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/SpatialObjects/LineSpatialObject2/Code.cxx
+++ b/src/Core/SpatialObjects/LineSpatialObject2/Code.cxx
@@ -20,51 +20,50 @@
 #include "itkLineSpatialObjectPoint.h"
 #include "itkImageFileWriter.h"
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-    using PixelType = unsigned char;
-    constexpr unsigned int Dimension = 2;
+  using PixelType = unsigned char;
+  constexpr unsigned int Dimension = 2;
 
-    using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    using LineType = itk::LineSpatialObject< Dimension >;
+  using LineType = itk::LineSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            LineType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<LineType, ImageType>;
 
 
-    // Create a list of points
-    std::vector<LineType::LinePointType> points;
-    for(unsigned int i = 0; i < 20; i++)
-    {
-        LineType::LinePointType point;
-        point.SetPositionInObjectSpace(10,i);
+  // Create a list of points
+  std::vector<LineType::LinePointType> points;
+  for (unsigned int i = 0; i < 20; i++)
+  {
+    LineType::LinePointType point;
+    point.SetPositionInObjectSpace(10, i);
 
-        LineType::LinePointType::CovariantVectorType normal;
-        normal[0] = 0;
-        normal[1] = 1;
-        point.SetNormalInObjectSpace(normal,0);
-        points.push_back(point);
-    }
+    LineType::LinePointType::CovariantVectorType normal;
+    normal[0] = 0;
+    normal[1] = 1;
+    point.SetNormalInObjectSpace(normal, 0);
+    points.push_back(point);
+  }
 
-    // Create a line from the list of points
-    LineType::Pointer line = LineType::New();
-    line->SetPoints(points);
+  // Create a line from the list of points
+  LineType::Pointer line = LineType::New();
+  line->SetPoints(points);
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
-    itk::Size<2> size;
-    size.Fill(50);
-    imageFilter->SetInsideValue(255); // white
-    imageFilter->SetSize(size);
-    imageFilter->SetInput(line);
-    imageFilter->Update();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
+  itk::Size<2>                            size;
+  size.Fill(50);
+  imageFilter->SetInsideValue(255); // white
+  imageFilter->SetSize(size);
+  imageFilter->SetInput(line);
+  imageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("line.png");
-    writer->SetInput( imageFilter->GetOutput() );
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("line.png");
+  writer->SetInput(imageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/TestKernel/GenerateRandomImage/Code.cxx
+++ b/src/Core/TestKernel/GenerateRandomImage/Code.cxx
@@ -20,44 +20,44 @@
 #include "itkRandomImageSource.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char* argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage:" << std::endl;
     std::cerr << argv[0] << " <OutputFileName>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   const char * outputFileName = argv[1];
 
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::SizeType size;
-  size.Fill( 10 );
+  size.Fill(10);
 
-  using RandomImageSourceType = itk::RandomImageSource< ImageType >;
+  using RandomImageSourceType = itk::RandomImageSource<ImageType>;
 
-  RandomImageSourceType::Pointer randomImageSource =
-    RandomImageSourceType::New();
+  RandomImageSourceType::Pointer randomImageSource = RandomImageSourceType::New();
   randomImageSource->SetNumberOfWorkUnits(1); // to produce reproducible results
-  randomImageSource->SetSize( size );
+  randomImageSource->SetSize(size);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( randomImageSource->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(randomImageSource->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
+++ b/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
@@ -22,31 +22,32 @@
 #include "itkResampleImageFilter.h"
 #include "itkWindowedSincInterpolateImageFunction.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <DefaultPixelValue>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using ScalarType = double;
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const auto defaultValue = static_cast< ScalarType >( std::stod( argv[3] ) );
+  const auto   defaultValue = static_cast<ScalarType>(std::stod(argv[3]));
 
-  using MatrixType = itk::Matrix< ScalarType, Dimension + 1, Dimension + 1 >;
+  using MatrixType = itk::Matrix<ScalarType, Dimension + 1, Dimension + 1>;
   MatrixType matrix;
-  matrix[0][0] = std::cos( 0.05 );
-  matrix[0][1] = std::sin( 0.05 );
+  matrix[0][0] = std::cos(0.05);
+  matrix[0][1] = std::sin(0.05);
   matrix[0][2] = 0.;
 
-  matrix[1][0] = - matrix[0][1];
+  matrix[1][0] = -matrix[0][1];
   matrix[1][1] = matrix[0][0];
   matrix[1][2] = 0.;
 
@@ -55,64 +56,64 @@ int main( int argc, char* argv[] )
   matrix[2][2] = 1.;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
   reader->Update();
 
   ImageType::ConstPointer input = reader->GetOutput();
 
-  const ImageType::SizeType& size = input->GetLargestPossibleRegion().GetSize();
+  const ImageType::SizeType & size = input->GetLargestPossibleRegion().GetSize();
 
-  using ResampleImageFilterType = itk::ResampleImageFilter< ImageType, ImageType >;
+  using ResampleImageFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
   ResampleImageFilterType::Pointer resample = ResampleImageFilterType::New();
-  resample->SetInput( input );
-  resample->SetReferenceImage( input );
+  resample->SetInput(input);
+  resample->SetReferenceImage(input);
   resample->UseReferenceImageOn();
-  resample->SetSize( size );
-  resample->SetDefaultPixelValue( defaultValue );
+  resample->SetSize(size);
+  resample->SetDefaultPixelValue(defaultValue);
 
   constexpr unsigned int Radius = 3;
-  using InterpolatorType = itk::WindowedSincInterpolateImageFunction< ImageType, Radius >;
+  using InterpolatorType = itk::WindowedSincInterpolateImageFunction<ImageType, Radius>;
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
 
-  resample->SetInterpolator( interpolator );
+  resample->SetInterpolator(interpolator);
 
-  using TransformType = itk::AffineTransform< ScalarType, Dimension >;
+  using TransformType = itk::AffineTransform<ScalarType, Dimension>;
   TransformType::Pointer transform = TransformType::New();
 
   // get transform parameters from MatrixType
-  TransformType::ParametersType parameters( Dimension * Dimension + Dimension );
-  for( unsigned int i = 0; i < Dimension; i++ )
+  TransformType::ParametersType parameters(Dimension * Dimension + Dimension);
+  for (unsigned int i = 0; i < Dimension; i++)
+  {
+    for (unsigned int j = 0; j < Dimension; j++)
     {
-    for( unsigned int j = 0; j < Dimension; j++ )
-      {
-      parameters[ i * Dimension + j ] = matrix[ i ][ j ];
-      }
+      parameters[i * Dimension + j] = matrix[i][j];
     }
-  for( unsigned int i = 0; i < Dimension; i++ )
-    {
-    parameters[ i + Dimension * Dimension ] = matrix[ i ][ Dimension ];
-    }
-  transform->SetParameters( parameters );
+  }
+  for (unsigned int i = 0; i < Dimension; i++)
+  {
+    parameters[i + Dimension * Dimension] = matrix[i][Dimension];
+  }
+  transform->SetParameters(parameters);
 
-  resample->SetTransform( transform );
+  resample->SetTransform(transform);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( resample->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(resample->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Transform/CartesianToAzimuthElevation/Code.cxx
+++ b/src/Core/Transform/CartesianToAzimuthElevation/Code.cxx
@@ -18,21 +18,20 @@
 #include "itkPoint.h"
 #include "itkAzimuthElevationToCartesianTransform.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using PointType = itk::Point<double, 3>;
-    PointType spherical;
-    spherical[0] = 0.0;
-    spherical[1] = 45; // set elevation to 45 degrees
-    spherical[2] = 1;
-    std::cout << "spherical: " << spherical << std::endl;
+  using PointType = itk::Point<double, 3>;
+  PointType spherical;
+  spherical[0] = 0.0;
+  spherical[1] = 45; // set elevation to 45 degrees
+  spherical[2] = 1;
+  std::cout << "spherical: " << spherical << std::endl;
 
-    using AzimuthElevationToCartesian = itk::AzimuthElevationToCartesianTransform< double, 3 >;
-    AzimuthElevationToCartesian::Pointer azimuthElevation =
-            AzimuthElevationToCartesian::New();
+  using AzimuthElevationToCartesian = itk::AzimuthElevationToCartesianTransform<double, 3>;
+  AzimuthElevationToCartesian::Pointer azimuthElevation = AzimuthElevationToCartesian::New();
 
-    std::cout << "Cartesian: " << azimuthElevation->TransformAzElToCartesian(spherical) << std::endl;
+  std::cout << "Cartesian: " << azimuthElevation->TransformAzElToCartesian(spherical) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Core/Transform/CopyACompositeTransform/Code.cxx
+++ b/src/Core/Transform/CopyACompositeTransform/Code.cxx
@@ -21,40 +21,41 @@
 #include "itkCompositeTransform.h"
 #include "itkCompositeTransformIOHelper.h"
 
-int main( int , char* [] )
+int
+main(int, char *[])
 {
   using ScalarType = float;
   constexpr unsigned int Dimension = 3;
 
-  using EulerTransformType = itk::Euler3DTransform< ScalarType >;
-  EulerTransformType::Pointer eulerTransform = EulerTransformType::New();
-  EulerTransformType::ParametersType eulerParameters( 6 );
+  using EulerTransformType = itk::Euler3DTransform<ScalarType>;
+  EulerTransformType::Pointer        eulerTransform = EulerTransformType::New();
+  EulerTransformType::ParametersType eulerParameters(6);
   eulerParameters[0] = 0.1;
   eulerParameters[1] = 0.2;
   eulerParameters[2] = 0.3;
   eulerParameters[3] = 4.0;
   eulerParameters[4] = 5.0;
   eulerParameters[5] = 6.0;
-  eulerTransform->SetParameters( eulerParameters );
+  eulerTransform->SetParameters(eulerParameters);
 
-  EulerTransformType::FixedParametersType eulerFixedParameters( Dimension );
+  EulerTransformType::FixedParametersType eulerFixedParameters(Dimension);
   eulerFixedParameters[0] = -3.5;
   eulerFixedParameters[1] = -4.5;
   eulerFixedParameters[2] = -5.5;
-  eulerTransform->SetFixedParameters( eulerFixedParameters );
+  eulerTransform->SetFixedParameters(eulerFixedParameters);
 
-  using ScaleTransformType = itk::ScaleTransform< ScalarType, Dimension >;
-  ScaleTransformType::Pointer scaleTransform = ScaleTransformType::New();
-  ScaleTransformType::ParametersType scaleParameters( Dimension );
+  using ScaleTransformType = itk::ScaleTransform<ScalarType, Dimension>;
+  ScaleTransformType::Pointer        scaleTransform = ScaleTransformType::New();
+  ScaleTransformType::ParametersType scaleParameters(Dimension);
   scaleParameters[0] = 0.6;
   scaleParameters[1] = 0.7;
   scaleParameters[2] = 0.8;
-  scaleTransform->SetParameters( scaleParameters );
+  scaleTransform->SetParameters(scaleParameters);
 
-  using CompositeTransformType = itk::CompositeTransform< ScalarType, Dimension >;
+  using CompositeTransformType = itk::CompositeTransform<ScalarType, Dimension>;
   CompositeTransformType::Pointer compositeTransform = CompositeTransformType::New();
-  compositeTransform->AddTransform( eulerTransform );
-  compositeTransform->AddTransform( scaleTransform );
+  compositeTransform->AddTransform(eulerTransform);
+  compositeTransform->AddTransform(scaleTransform);
   std::cout << "Original transform: " << compositeTransform << std::endl;
 
 

--- a/src/Core/Transform/CopyANonCompositeTransform/Code.cxx
+++ b/src/Core/Transform/CopyANonCompositeTransform/Code.cxx
@@ -18,25 +18,26 @@
 
 #include "itkEuler3DTransform.h"
 
-int main( int, char* [] )
+int
+main(int, char *[])
 {
-  using TransformType = itk::Euler3DTransform< float >;
+  using TransformType = itk::Euler3DTransform<float>;
 
-  TransformType::Pointer transform = TransformType::New();
-  TransformType::ParametersType parameters( 6 );
+  TransformType::Pointer        transform = TransformType::New();
+  TransformType::ParametersType parameters(6);
   parameters[0] = 0.1;
   parameters[1] = 0.2;
   parameters[2] = 0.3;
   parameters[3] = 4.0;
   parameters[4] = 5.0;
   parameters[5] = 6.0;
-  transform->SetParameters( parameters );
+  transform->SetParameters(parameters);
 
-  TransformType::FixedParametersType fixedParameters( 3 );
+  TransformType::FixedParametersType fixedParameters(3);
   fixedParameters[0] = -3.5;
   fixedParameters[1] = -4.5;
   fixedParameters[2] = -5.5;
-  transform->SetFixedParameters( fixedParameters );
+  transform->SetFixedParameters(fixedParameters);
   std::cout << "Original transform: " << transform << std::endl;
 
   TransformType::Pointer transformCopy = transform->Clone();

--- a/src/Core/Transform/GlobalRegistrationTwoImagesAffine/Code.cxx
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesAffine/Code.cxx
@@ -32,284 +32,274 @@
 constexpr unsigned int Dimension = 2;
 using PixelType = unsigned char;
 
-using ImageType = itk::Image< PixelType, Dimension >;
+using ImageType = itk::Image<PixelType, Dimension>;
 
-static void CreateEllipseImage(ImageType::Pointer image);
-static void CreateSphereImage(ImageType::Pointer image);
+static void
+CreateEllipseImage(ImageType::Pointer image);
+static void
+CreateSphereImage(ImageType::Pointer image);
 
-int main(int, char *[] )
+int
+main(int, char *[])
 {
-    //  The transform that will map the fixed image into the moving image.
-    using TransformType = itk::AffineTransform< double, Dimension >;
+  //  The transform that will map the fixed image into the moving image.
+  using TransformType = itk::AffineTransform<double, Dimension>;
 
-    //  An optimizer is required to explore the parameter space of the transform
-    //  in search of optimal values of the metric.
-    using OptimizerType = itk::RegularStepGradientDescentOptimizer;
+  //  An optimizer is required to explore the parameter space of the transform
+  //  in search of optimal values of the metric.
+  using OptimizerType = itk::RegularStepGradientDescentOptimizer;
 
-    //  The metric will compare how well the two images match each other. Metric
-    //  types are usually parameterized by the image types as it can be seen in
-    //  the following type declaration.
-    using MetricType = itk::MeanSquaresImageToImageMetric<
-            ImageType,
-            ImageType >;
+  //  The metric will compare how well the two images match each other. Metric
+  //  types are usually parameterized by the image types as it can be seen in
+  //  the following type declaration.
+  using MetricType = itk::MeanSquaresImageToImageMetric<ImageType, ImageType>;
 
-    //  Finally, the type of the interpolator is declared. The interpolator will
-    //  evaluate the intensities of the moving image at non-grid positions.
-    using InterpolatorType = itk:: LinearInterpolateImageFunction<
-            ImageType,
-            double          >;
+  //  Finally, the type of the interpolator is declared. The interpolator will
+  //  evaluate the intensities of the moving image at non-grid positions.
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double>;
 
-    //  The registration method type is instantiated using the types of the
-    //  fixed and moving images. This class is responsible for interconnecting
-    //  all the components that we have described so far.
-    using RegistrationType = itk::ImageRegistrationMethod<
-            ImageType,
-            ImageType >;
+  //  The registration method type is instantiated using the types of the
+  //  fixed and moving images. This class is responsible for interconnecting
+  //  all the components that we have described so far.
+  using RegistrationType = itk::ImageRegistrationMethod<ImageType, ImageType>;
 
-    // Create components
-    MetricType::Pointer         metric        = MetricType::New();
-    TransformType::Pointer      transform     = TransformType::New();
-    OptimizerType::Pointer      optimizer     = OptimizerType::New();
-    InterpolatorType::Pointer   interpolator  = InterpolatorType::New();
-    RegistrationType::Pointer   registration  = RegistrationType::New();
+  // Create components
+  MetricType::Pointer       metric = MetricType::New();
+  TransformType::Pointer    transform = TransformType::New();
+  OptimizerType::Pointer    optimizer = OptimizerType::New();
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  RegistrationType::Pointer registration = RegistrationType::New();
 
-    // Each component is now connected to the instance of the registration method.
-    registration->SetMetric(        metric        );
-    registration->SetOptimizer(     optimizer     );
-    registration->SetTransform(     transform     );
-    registration->SetInterpolator(  interpolator  );
+  // Each component is now connected to the instance of the registration method.
+  registration->SetMetric(metric);
+  registration->SetOptimizer(optimizer);
+  registration->SetTransform(transform);
+  registration->SetInterpolator(interpolator);
 
-    // Get the two images
-    ImageType::Pointer  fixedImage  = ImageType::New();
-    ImageType::Pointer movingImage = ImageType::New();
+  // Get the two images
+  ImageType::Pointer fixedImage = ImageType::New();
+  ImageType::Pointer movingImage = ImageType::New();
 
-    CreateSphereImage(fixedImage);
-    CreateEllipseImage(movingImage);
+  CreateSphereImage(fixedImage);
+  CreateEllipseImage(movingImage);
 
-    // Write the two synthetic inputs
-    using WriterType = itk::ImageFileWriter< ImageType >;
+  // Write the two synthetic inputs
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
-    WriterType::Pointer      fixedWriter =  WriterType::New();
-    fixedWriter->SetFileName("fixed.png");
-    fixedWriter->SetInput( fixedImage);
-    fixedWriter->Update();
+  WriterType::Pointer fixedWriter = WriterType::New();
+  fixedWriter->SetFileName("fixed.png");
+  fixedWriter->SetInput(fixedImage);
+  fixedWriter->Update();
 
-    WriterType::Pointer      movingWriter =  WriterType::New();
-    movingWriter->SetFileName("moving.png");
-    movingWriter->SetInput( movingImage);
-    movingWriter->Update();
+  WriterType::Pointer movingWriter = WriterType::New();
+  movingWriter->SetFileName("moving.png");
+  movingWriter->SetInput(movingImage);
+  movingWriter->Update();
 
-    // Set the registration inputs
-    registration->SetFixedImage(fixedImage);
-    registration->SetMovingImage(movingImage);
+  // Set the registration inputs
+  registration->SetFixedImage(fixedImage);
+  registration->SetMovingImage(movingImage);
 
-    registration->SetFixedImageRegion(
-            fixedImage->GetLargestPossibleRegion() );
+  registration->SetFixedImageRegion(fixedImage->GetLargestPossibleRegion());
 
-    //  Initialize the transform
-    using ParametersType = RegistrationType::ParametersType;
-    ParametersType initialParameters( transform->GetNumberOfParameters() );
+  //  Initialize the transform
+  using ParametersType = RegistrationType::ParametersType;
+  ParametersType initialParameters(transform->GetNumberOfParameters());
 
-    // rotation matrix
-    initialParameters[0] = 1.0;  // R(0,0)
-    initialParameters[1] = 0.0;  // R(0,1)
-    initialParameters[2] = 0.0;  // R(1,0)
-    initialParameters[3] = 1.0;  // R(1,1)
+  // rotation matrix
+  initialParameters[0] = 1.0; // R(0,0)
+  initialParameters[1] = 0.0; // R(0,1)
+  initialParameters[2] = 0.0; // R(1,0)
+  initialParameters[3] = 1.0; // R(1,1)
 
-    // translation vector
-    initialParameters[4] = 0.0;
-    initialParameters[5] = 0.0;
+  // translation vector
+  initialParameters[4] = 0.0;
+  initialParameters[5] = 0.0;
 
-    registration->SetInitialTransformParameters( initialParameters );
+  registration->SetInitialTransformParameters(initialParameters);
 
-    optimizer->SetMaximumStepLength( .1 ); // If this is set too high, you will get a
-    //"itk::ERROR: MeanSquaresImageToImageMetric(0xa27ce70): Too many samples map outside moving image buffer: 1818 / 10000" error
+  optimizer->SetMaximumStepLength(.1); // If this is set too high, you will get a
+  //"itk::ERROR: MeanSquaresImageToImageMetric(0xa27ce70): Too many samples map outside moving image buffer: 1818 /
+  //10000" error
 
-    optimizer->SetMinimumStepLength( 0.01 );
+  optimizer->SetMinimumStepLength(0.01);
 
-    // Set a stopping criterion
-    optimizer->SetNumberOfIterations( 200 );
+  // Set a stopping criterion
+  optimizer->SetNumberOfIterations(200);
 
-    // Connect an observer
-    //CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
-    //optimizer->AddObserver( itk::IterationEvent(), observer );
+  // Connect an observer
+  // CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  // optimizer->AddObserver( itk::IterationEvent(), observer );
 
-    try
-    {
-        registration->Update();
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cerr << "ExceptionObject caught !" << std::endl;
-        std::cerr << err << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    registration->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    //  The result of the registration process is an array of parameters that
-    //  defines the spatial transformation in an unique way. This final result is
-    //  obtained using the \code{GetLastTransformParameters()} method.
+  //  The result of the registration process is an array of parameters that
+  //  defines the spatial transformation in an unique way. This final result is
+  //  obtained using the \code{GetLastTransformParameters()} method.
 
-    ParametersType finalParameters = registration->GetLastTransformParameters();
-    std::cout << "Final parameters: " << finalParameters << std::endl;
+  ParametersType finalParameters = registration->GetLastTransformParameters();
+  std::cout << "Final parameters: " << finalParameters << std::endl;
 
-    //  The value of the image metric corresponding to the last set of parameters
-    //  can be obtained with the \code{GetValue()} method of the optimizer.
+  //  The value of the image metric corresponding to the last set of parameters
+  //  can be obtained with the \code{GetValue()} method of the optimizer.
 
-    const double bestValue = optimizer->GetValue();
+  const double bestValue = optimizer->GetValue();
 
-    // Print out results
-    //
-    std::cout << "Result = " << std::endl;
-    std::cout << " Metric value  = " << bestValue          << std::endl;
+  // Print out results
+  //
+  std::cout << "Result = " << std::endl;
+  std::cout << " Metric value  = " << bestValue << std::endl;
 
-    //  It is common, as the last step of a registration task, to use the
-    //  resulting transform to map the moving image into the fixed image space.
-    //  This is easily done with the \doxygen{ResampleImageFilter}.
+  //  It is common, as the last step of a registration task, to use the
+  //  resulting transform to map the moving image into the fixed image space.
+  //  This is easily done with the \doxygen{ResampleImageFilter}.
 
-    using ResampleFilterType = itk::ResampleImageFilter<
-            ImageType,
-            ImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
-    ResampleFilterType::Pointer resampler = ResampleFilterType::New();
-    resampler->SetInput( movingImage);
+  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  resampler->SetInput(movingImage);
 
-    //  The Transform that is produced as output of the Registration method is
-    //  also passed as input to the resampling filter. Note the use of the
-    //  methods \code{GetOutput()} and \code{Get()}. This combination is needed
-    //  here because the registration method acts as a filter whose output is a
-    //  transform decorated in the form of a \doxygen{DataObject}. For details in
-    //  this construction you may want to read the documentation of the
-    //  \doxygen{DataObjectDecorator}.
+  //  The Transform that is produced as output of the Registration method is
+  //  also passed as input to the resampling filter. Note the use of the
+  //  methods \code{GetOutput()} and \code{Get()}. This combination is needed
+  //  here because the registration method acts as a filter whose output is a
+  //  transform decorated in the form of a \doxygen{DataObject}. For details in
+  //  this construction you may want to read the documentation of the
+  //  \doxygen{DataObjectDecorator}.
 
-    resampler->SetTransform( registration->GetOutput()->Get() );
+  resampler->SetTransform(registration->GetOutput()->Get());
 
-    //  As described in Section \ref{sec:ResampleImageFilter}, the
-    //  ResampleImageFilter requires additional parameters to be specified, in
-    //  particular, the spacing, origin and size of the output image. The default
-    //  pixel value is also set to a distinct gray level in order to highlight
-    //  the regions that are mapped outside of the moving image.
+  //  As described in Section \ref{sec:ResampleImageFilter}, the
+  //  ResampleImageFilter requires additional parameters to be specified, in
+  //  particular, the spacing, origin and size of the output image. The default
+  //  pixel value is also set to a distinct gray level in order to highlight
+  //  the regions that are mapped outside of the moving image.
 
-    resampler->SetSize( fixedImage->GetLargestPossibleRegion().GetSize() );
-    resampler->SetOutputOrigin(  fixedImage->GetOrigin() );
-    resampler->SetOutputSpacing( fixedImage->GetSpacing() );
-    resampler->SetOutputDirection( fixedImage->GetDirection() );
-    resampler->SetDefaultPixelValue( 100 );
+  resampler->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
+  resampler->SetOutputOrigin(fixedImage->GetOrigin());
+  resampler->SetOutputSpacing(fixedImage->GetSpacing());
+  resampler->SetOutputDirection(fixedImage->GetDirection());
+  resampler->SetDefaultPixelValue(100);
 
-    //  The output of the filter is passed to a writer that will store the
-    //  image in a file. An \doxygen{CastImageFilter} is used to convert the
-    //  pixel type of the resampled image to the final type used by the
-    //  writer. The cast and writer filters are instantiated below.
+  //  The output of the filter is passed to a writer that will store the
+  //  image in a file. An \doxygen{CastImageFilter} is used to convert the
+  //  pixel type of the resampled image to the final type used by the
+  //  writer. The cast and writer filters are instantiated below.
 
-    using CastFilterType = itk::CastImageFilter<
-            ImageType,
-            ImageType >;
+  using CastFilterType = itk::CastImageFilter<ImageType, ImageType>;
 
-    WriterType::Pointer      writer =  WriterType::New();
-    CastFilterType::Pointer  caster =  CastFilterType::New();
-    writer->SetFileName("output.png");
+  WriterType::Pointer     writer = WriterType::New();
+  CastFilterType::Pointer caster = CastFilterType::New();
+  writer->SetFileName("output.png");
 
-    caster->SetInput( resampler->GetOutput() );
-    writer->SetInput( caster->GetOutput()   );
-    writer->Update();
+  caster->SetInput(resampler->GetOutput());
+  writer->SetInput(caster->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateEllipseImage(ImageType::Pointer image)
+void
+CreateEllipseImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 20;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 20;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  65;
-    translation[ 1 ] =  45;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 65;
+  translation[1] = 45;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
-
+  image->Graft(imageFilter->GetOutput());
 }
 
-void CreateSphereImage(ImageType::Pointer image)
+void
+CreateSphereImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 10;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 10;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  50;
-    translation[ 1 ] =  50;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 50;
+  translation[1] = 50;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
+  image->Graft(imageFilter->GetOutput());
 }

--- a/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/Code.cxx
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/Code.cxx
@@ -22,9 +22,9 @@
 #include "itkEllipseSpatialObject.h"
 
 #if ITK_VERSION_MAJOR < 4
-#include "itkBSplineDeformableTransform.h"
+#  include "itkBSplineDeformableTransform.h"
 #else
-#include "itkBSplineTransform.h"
+#  include "itkBSplineTransform.h"
 #endif
 #include "itkLBFGSOptimizer.h"
 #include "itkImageFileWriter.h"
@@ -33,102 +33,92 @@
 #include "itkSquaredDifferenceImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 constexpr unsigned int ImageDimension = 2;
 using PixelType = float;
 
-using ImageType = itk::Image< PixelType, ImageDimension >;
+using ImageType = itk::Image<PixelType, ImageDimension>;
 
-static void CreateEllipseImage(ImageType::Pointer image);
-static void CreateCircleImage(ImageType::Pointer image);
+static void
+CreateEllipseImage(ImageType::Pointer image);
+static void
+CreateCircleImage(ImageType::Pointer image);
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
 
-    const unsigned int SpaceDimension = ImageDimension;
-    constexpr unsigned int SplineOrder = 3;
-    using CoordinateRepType = double;
+  const unsigned int     SpaceDimension = ImageDimension;
+  constexpr unsigned int SplineOrder = 3;
+  using CoordinateRepType = double;
 
 #if ITK_VERSION_MAJOR < 4
-    using TransformType = itk::BSplineDeformableTransform<
-                            CoordinateRepType,
-                            SpaceDimension,
-                            SplineOrder >;
+  using TransformType = itk::BSplineDeformableTransform<CoordinateRepType, SpaceDimension, SplineOrder>;
 #else
-    using TransformType = itk::BSplineTransform<
-            CoordinateRepType,
-            SpaceDimension,
-            SplineOrder >;
+  using TransformType = itk::BSplineTransform<CoordinateRepType, SpaceDimension, SplineOrder>;
 #endif
-    using OptimizerType = itk::LBFGSOptimizer;
+  using OptimizerType = itk::LBFGSOptimizer;
 
 
-    using MetricType = itk::MeanSquaresImageToImageMetric<
-            ImageType,
-            ImageType >;
+  using MetricType = itk::MeanSquaresImageToImageMetric<ImageType, ImageType>;
 
-    using InterpolatorType = itk:: LinearInterpolateImageFunction<
-            ImageType,
-            double          >;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double>;
 
-    using RegistrationType = itk::ImageRegistrationMethod<
-            ImageType,
-            ImageType >;
+  using RegistrationType = itk::ImageRegistrationMethod<ImageType, ImageType>;
 
-    MetricType::Pointer         metric        = MetricType::New();
-    OptimizerType::Pointer      optimizer     = OptimizerType::New();
-    InterpolatorType::Pointer   interpolator  = InterpolatorType::New();
-    RegistrationType::Pointer   registration  = RegistrationType::New();
+  MetricType::Pointer       metric = MetricType::New();
+  OptimizerType::Pointer    optimizer = OptimizerType::New();
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  RegistrationType::Pointer registration = RegistrationType::New();
 
 
+  // The old registration framework has problems with multi-threading
+  // For now, we set the number of work units to 1
+  registration->SetNumberOfWorkUnits(1);
 
-    // The old registration framework has problems with multi-threading
-    // For now, we set the number of work units to 1
-    registration->SetNumberOfWorkUnits(1);
+  registration->SetMetric(metric);
+  registration->SetOptimizer(optimizer);
+  registration->SetInterpolator(interpolator);
 
-    registration->SetMetric(        metric        );
-    registration->SetOptimizer(     optimizer     );
-    registration->SetInterpolator(  interpolator  );
+  TransformType::Pointer transform = TransformType::New();
+  registration->SetTransform(transform);
 
-    TransformType::Pointer  transform = TransformType::New();
-    registration->SetTransform( transform );
+  // Create the synthetic images
+  ImageType::Pointer fixedImage = ImageType::New();
+  CreateCircleImage(fixedImage);
 
-    // Create the synthetic images
-    ImageType::Pointer  fixedImage  = ImageType::New();
-    CreateCircleImage(fixedImage);
+  ImageType::Pointer movingImage = ImageType::New();
+  CreateEllipseImage(movingImage);
 
-    ImageType::Pointer movingImage = ImageType::New();
-    CreateEllipseImage(movingImage);
+  // Setup the registration
+  registration->SetFixedImage(fixedImage);
+  registration->SetMovingImage(movingImage);
 
-    // Setup the registration
-    registration->SetFixedImage(  fixedImage   );
-    registration->SetMovingImage(   movingImage);
+  ImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
+  registration->SetFixedImageRegion(fixedRegion);
 
-    ImageType::RegionType fixedRegion = fixedImage->GetBufferedRegion();
-    registration->SetFixedImageRegion( fixedRegion );
-
-    //  Here we define the parameters of the BSplineDeformableTransform grid.  We
-    //  arbitrarily decide to use a grid with $5 \times 5$ nodes within the image.
-    //  The reader should note that the BSpline computation requires a
-    //  finite support region ( 1 grid node at the lower borders and 2
-    //  grid nodes at upper borders). Therefore in this example, we set
-    //  the grid size to be $8 \times 8$ and place the grid origin such that
-    //  grid node (1,1) coincides with the first pixel in the fixed image.
+  //  Here we define the parameters of the BSplineDeformableTransform grid.  We
+  //  arbitrarily decide to use a grid with $5 \times 5$ nodes within the image.
+  //  The reader should note that the BSpline computation requires a
+  //  finite support region ( 1 grid node at the lower borders and 2
+  //  grid nodes at upper borders). Therefore in this example, we set
+  //  the grid size to be $8 \times 8$ and place the grid origin such that
+  //  grid node (1,1) coincides with the first pixel in the fixed image.
 
 #if ITK_VERSION_MAJOR < 4
-    using RegionType = TransformType::RegionType;
-  RegionType bsplineRegion;
-  RegionType::SizeType   gridSizeOnImage;
-  RegionType::SizeType   gridBorderSize;
-  RegionType::SizeType   totalGridSize;
+  using RegionType = TransformType::RegionType;
+  RegionType           bsplineRegion;
+  RegionType::SizeType gridSizeOnImage;
+  RegionType::SizeType gridBorderSize;
+  RegionType::SizeType totalGridSize;
 
-  gridSizeOnImage.Fill( 5 );
-  gridBorderSize.Fill( 3 );    // Border for spline order = 3 ( 1 lower, 2 upper )
+  gridSizeOnImage.Fill(5);
+  gridBorderSize.Fill(3); // Border for spline order = 3 ( 1 lower, 2 upper )
   totalGridSize = gridSizeOnImage + gridBorderSize;
 
-  bsplineRegion.SetSize( totalGridSize );
+  bsplineRegion.SetSize(totalGridSize);
 
   using SpacingType = TransformType::SpacingType;
   SpacingType spacing = fixedImage->GetSpacing();
@@ -138,248 +128,229 @@ int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
 
   ImageType::SizeType fixedImageSize = fixedRegion.GetSize();
 
-  for(unsigned int r=0; r<ImageDimension; r++)
-    {
-    spacing[r] *= static_cast<double>(fixedImageSize[r] - 1)  /
-                  static_cast<double>(gridSizeOnImage[r] - 1);
-    }
+  for (unsigned int r = 0; r < ImageDimension; r++)
+  {
+    spacing[r] *= static_cast<double>(fixedImageSize[r] - 1) / static_cast<double>(gridSizeOnImage[r] - 1);
+  }
 
   ImageType::DirectionType gridDirection = fixedImage->GetDirection();
-  SpacingType gridOriginOffset = gridDirection * spacing;
+  SpacingType              gridOriginOffset = gridDirection * spacing;
 
   OriginType gridOrigin = origin - gridOriginOffset;
 
-  transform->SetGridSpacing( spacing );
-  transform->SetGridOrigin( gridOrigin );
-  transform->SetGridRegion( bsplineRegion );
-  transform->SetGridDirection( gridDirection );
+  transform->SetGridSpacing(spacing);
+  transform->SetGridOrigin(gridOrigin);
+  transform->SetGridRegion(bsplineRegion);
+  transform->SetGridDirection(gridDirection);
 #else
-    TransformType::PhysicalDimensionsType   fixedPhysicalDimensions;
-    TransformType::MeshSizeType             meshSize;
-    for( unsigned int i=0; i < ImageDimension; i++ )
-    {
-        fixedPhysicalDimensions[i] = fixedImage->GetSpacing()[i] *
-                                     static_cast<double>(
-                                             fixedImage->GetLargestPossibleRegion().GetSize()[i] - 1 );
-    }
-    unsigned int numberOfGridNodesInOneDimension = 5;
-    meshSize.Fill( numberOfGridNodesInOneDimension - SplineOrder );
-    transform->SetTransformDomainOrigin( fixedImage->GetOrigin() );
-    transform->SetTransformDomainPhysicalDimensions( fixedPhysicalDimensions );
-    transform->SetTransformDomainMeshSize( meshSize );
-    transform->SetTransformDomainDirection( fixedImage->GetDirection() );
+  TransformType::PhysicalDimensionsType fixedPhysicalDimensions;
+  TransformType::MeshSizeType           meshSize;
+  for (unsigned int i = 0; i < ImageDimension; i++)
+  {
+    fixedPhysicalDimensions[i] =
+      fixedImage->GetSpacing()[i] * static_cast<double>(fixedImage->GetLargestPossibleRegion().GetSize()[i] - 1);
+  }
+  unsigned int numberOfGridNodesInOneDimension = 5;
+  meshSize.Fill(numberOfGridNodesInOneDimension - SplineOrder);
+  transform->SetTransformDomainOrigin(fixedImage->GetOrigin());
+  transform->SetTransformDomainPhysicalDimensions(fixedPhysicalDimensions);
+  transform->SetTransformDomainMeshSize(meshSize);
+  transform->SetTransformDomainDirection(fixedImage->GetDirection());
 #endif
 
-    using ParametersType = TransformType::ParametersType;
+  using ParametersType = TransformType::ParametersType;
 
-    const unsigned int numberOfParameters =
-            transform->GetNumberOfParameters();
+  const unsigned int numberOfParameters = transform->GetNumberOfParameters();
 
-    ParametersType parameters( numberOfParameters );
+  ParametersType parameters(numberOfParameters);
 
-    parameters.Fill( 0.0 );
+  parameters.Fill(0.0);
 
-    transform->SetParameters( parameters );
+  transform->SetParameters(parameters);
 
-    //  We now pass the parameters of the current transform as the initial
-    //  parameters to be used when the registration process starts.
+  //  We now pass the parameters of the current transform as the initial
+  //  parameters to be used when the registration process starts.
 
-    registration->SetInitialTransformParameters( transform->GetParameters() );
+  registration->SetInitialTransformParameters(transform->GetParameters());
 
-    std::cout << "Intial Parameters = " << std::endl;
-    std::cout << transform->GetParameters() << std::endl;
+  std::cout << "Intial Parameters = " << std::endl;
+  std::cout << transform->GetParameters() << std::endl;
 
-    //  Next we set the parameters of the LBFGS Optimizer.
+  //  Next we set the parameters of the LBFGS Optimizer.
 
-    optimizer->SetGradientConvergenceTolerance( 0.05 );
-    optimizer->SetLineSearchAccuracy( 0.9 );
-    optimizer->SetDefaultStepLength( .5 );
-    optimizer->TraceOn();
-    optimizer->SetMaximumNumberOfFunctionEvaluations( 1000 );
+  optimizer->SetGradientConvergenceTolerance(0.05);
+  optimizer->SetLineSearchAccuracy(0.9);
+  optimizer->SetDefaultStepLength(.5);
+  optimizer->TraceOn();
+  optimizer->SetMaximumNumberOfFunctionEvaluations(1000);
 
-    std::cout << std::endl << "Starting Registration" << std::endl;
+  std::cout << std::endl << "Starting Registration" << std::endl;
 
-    try
-    {
-        registration->Update();
-        std::cout << "Optimizer stop condition = "
-                  << registration->GetOptimizer()->GetStopConditionDescription()
-                  << std::endl;
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cerr << "ExceptionObject caught !" << std::endl;
-        std::cerr << err << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    registration->Update();
+    std::cout << "Optimizer stop condition = " << registration->GetOptimizer()->GetStopConditionDescription()
+              << std::endl;
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    OptimizerType::ParametersType finalParameters =
-            registration->GetLastTransformParameters();
+  OptimizerType::ParametersType finalParameters = registration->GetLastTransformParameters();
 
-    std::cout << "Last Transform Parameters" << std::endl;
-    std::cout << finalParameters << std::endl;
+  std::cout << "Last Transform Parameters" << std::endl;
+  std::cout << finalParameters << std::endl;
 
-    transform->SetParameters( finalParameters );
+  transform->SetParameters(finalParameters);
 
-    using ResampleFilterType = itk::ResampleImageFilter<
-            ImageType,
-            ImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
-    ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  ResampleFilterType::Pointer resample = ResampleFilterType::New();
 
-    resample->SetTransform( transform );
-    resample->SetInput( movingImage );
+  resample->SetTransform(transform);
+  resample->SetInput(movingImage);
 
-    resample->SetSize(    fixedImage->GetLargestPossibleRegion().GetSize() );
-    resample->SetOutputOrigin(  fixedImage->GetOrigin() );
-    resample->SetOutputSpacing( fixedImage->GetSpacing() );
-    resample->SetOutputDirection( fixedImage->GetDirection() );
-    resample->SetDefaultPixelValue( 100 );
+  resample->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
+  resample->SetOutputOrigin(fixedImage->GetOrigin());
+  resample->SetOutputSpacing(fixedImage->GetSpacing());
+  resample->SetOutputDirection(fixedImage->GetDirection());
+  resample->SetDefaultPixelValue(100);
 
-    using OutputPixelType = unsigned char;
+  using OutputPixelType = unsigned char;
 
-    using OutputImageType = itk::Image< OutputPixelType, ImageDimension >;
+  using OutputImageType = itk::Image<OutputPixelType, ImageDimension>;
 
-    using CastFilterType = itk::CastImageFilter<
-            ImageType,
-            OutputImageType >;
+  using CastFilterType = itk::CastImageFilter<ImageType, OutputImageType>;
 
-    using OutputWriterType = itk::ImageFileWriter< OutputImageType >;
+  using OutputWriterType = itk::ImageFileWriter<OutputImageType>;
 
-    OutputWriterType::Pointer      writer =  OutputWriterType::New();
-    CastFilterType::Pointer  caster =  CastFilterType::New();
+  OutputWriterType::Pointer writer = OutputWriterType::New();
+  CastFilterType::Pointer   caster = CastFilterType::New();
 
 
-    writer->SetFileName("output.png");
+  writer->SetFileName("output.png");
 
-    caster->SetInput( resample->GetOutput() );
-    writer->SetInput( caster->GetOutput()   );
+  caster->SetInput(resample->GetOutput());
+  writer->SetInput(caster->GetOutput());
 
-    try
-    {
-        writer->Update();
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cerr << "ExceptionObject caught !" << std::endl;
-        std::cerr << err << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+    return EXIT_FAILURE;
+  }
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            fixedImage.GetPointer(),true,
-            "Fixed Image");
-    viewer.AddImage(
-            movingImage.GetPointer(),true,
-            "Moving Image");
-    viewer.AddImage(
-            resample->GetOutput(),true,
-            "Resampled Moving Image");
+  QuickView viewer;
+  viewer.AddImage(fixedImage.GetPointer(), true, "Fixed Image");
+  viewer.AddImage(movingImage.GetPointer(), true, "Moving Image");
+  viewer.AddImage(resample->GetOutput(), true, "Resampled Moving Image");
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateEllipseImage(ImageType::Pointer image)
+void
+CreateEllipseImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< ImageDimension >;
+  using EllipseType = itk::EllipseSpatialObject<ImageDimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 20;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 20;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  65;
-    translation[ 1 ] =  45;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 65;
+  translation[1] = 45;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
-
+  image->Graft(imageFilter->GetOutput());
 }
 
-void CreateCircleImage(ImageType::Pointer image)
+void
+CreateCircleImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< ImageDimension >;
+  using EllipseType = itk::EllipseSpatialObject<ImageDimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 10;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 10;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  50;
-    translation[ 1 ] =  50;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 50;
+  translation[1] = 50;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
+  image->Graft(imageFilter->GetOutput());
 }
-

--- a/src/Core/Transform/ScaleAnImage/Code.cxx
+++ b/src/Core/Transform/ScaleAnImage/Code.cxx
@@ -23,85 +23,90 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using WriterType = itk::ImageFileWriter<ImageType>;
-    WriterType::Pointer inputWriter = WriterType::New();
-    inputWriter->SetFileName("input.png");
-    inputWriter->SetInput(image);
-    inputWriter->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer inputWriter = WriterType::New();
+  inputWriter->SetFileName("input.png");
+  inputWriter->SetInput(image);
+  inputWriter->Update();
 
-    // using TransformType = itk::ScaleTransform<float, 2>; // If you want to use float here, you must use:
-    // using ResampleImageFilterType = itk::ResampleImageFilter<ImageType, ImageType, float>; later.
-    using TransformType = itk::ScaleTransform<double, 2>;
-    TransformType::Pointer scaleTransform = TransformType::New();
-    itk::FixedArray<float, 2> scale;
-    scale[0] = 1.5; // newWidth/oldWidth
-    scale[1] = 1.5;
-    scaleTransform->SetScale(scale);
+  // using TransformType = itk::ScaleTransform<float, 2>; // If you want to use float here, you must use:
+  // using ResampleImageFilterType = itk::ResampleImageFilter<ImageType, ImageType, float>; later.
+  using TransformType = itk::ScaleTransform<double, 2>;
+  TransformType::Pointer    scaleTransform = TransformType::New();
+  itk::FixedArray<float, 2> scale;
+  scale[0] = 1.5; // newWidth/oldWidth
+  scale[1] = 1.5;
+  scaleTransform->SetScale(scale);
 
-    itk::Point<float,2> center;
-    center[0] = image->GetLargestPossibleRegion().GetSize()[0]/2;
-    center[1] = image->GetLargestPossibleRegion().GetSize()[1]/2;
+  itk::Point<float, 2> center;
+  center[0] = image->GetLargestPossibleRegion().GetSize()[0] / 2;
+  center[1] = image->GetLargestPossibleRegion().GetSize()[1] / 2;
 
-    scaleTransform->SetCenter(center);
+  scaleTransform->SetCenter(center);
 
-    using ResampleImageFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
-    ResampleImageFilterType::Pointer resampleFilter = ResampleImageFilterType::New();
-    resampleFilter->SetTransform(scaleTransform);
-    resampleFilter->SetInput(image);
-    resampleFilter->SetSize(image->GetLargestPossibleRegion().GetSize());
-    resampleFilter->Update();
+  using ResampleImageFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
+  ResampleImageFilterType::Pointer resampleFilter = ResampleImageFilterType::New();
+  resampleFilter->SetTransform(scaleTransform);
+  resampleFilter->SetInput(image);
+  resampleFilter->SetSize(image->GetLargestPossibleRegion().GetSize());
+  resampleFilter->Update();
 
-    WriterType::Pointer outputWriter = WriterType::New();
-    outputWriter->SetFileName("output.png");
-    outputWriter->SetInput(resampleFilter->GetOutput());
-    outputWriter->Update();
+  WriterType::Pointer outputWriter = WriterType::New();
+  outputWriter->SetFileName("output.png");
+  outputWriter->SetInput(resampleFilter->GetOutput());
+  outputWriter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    itk::Index<2> start;
-    start.Fill(0);
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(101);
+  itk::Size<2> size;
+  size.Fill(101);
 
-    ImageType::RegionType region(start, size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  ImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a white square
-    for(unsigned int r = 40; r < 60; r++)
+  // Make a white square
+  for (unsigned int r = 40; r < 60; r++)
+  {
+    for (unsigned int c = 40; c < 60; c++)
     {
-        for(unsigned int c = 40; c < 60; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Draw a white border
-    while(!imageIterator.IsAtEnd())
+  // Draw a white border
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] == 0 ||
+        imageIterator.GetIndex()[0] == static_cast<int>(image->GetLargestPossibleRegion().GetSize()[0]) - 1 ||
+        imageIterator.GetIndex()[1] == 0 ||
+        imageIterator.GetIndex()[1] == static_cast<int>(image->GetLargestPossibleRegion().GetSize()[1]) - 1)
     {
-        if(imageIterator.GetIndex()[0] == 0 || imageIterator.GetIndex()[0] == static_cast<int>(image->GetLargestPossibleRegion().GetSize()[0]) - 1 ||
-           imageIterator.GetIndex()[1] == 0 || imageIterator.GetIndex()[1] == static_cast<int>(image->GetLargestPossibleRegion().GetSize()[1]) - 1)
-        {
-            imageIterator.Set(255);
-        }
-        ++imageIterator;
+      imageIterator.Set(255);
     }
+    ++imageIterator;
+  }
 }

--- a/src/Core/Transform/TranslateAVectorImage/Code.cxx
+++ b/src/Core/Transform/TranslateAVectorImage/Code.cxx
@@ -22,36 +22,36 @@
 #include "itkCovariantVector.h"
 #include "itkNumericTraits.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    typedef itk::CovariantVector<double, 3> VectorType;
-    typedef itk::Image<VectorType, 2>  VectorImageType;
+  typedef itk::CovariantVector<double, 3> VectorType;
+  typedef itk::Image<VectorType, 2>       VectorImageType;
 
-    VectorImageType::Pointer image = VectorImageType::New();
-    itk::Index<2> start;
-    start.Fill(0);
+  VectorImageType::Pointer image = VectorImageType::New();
+  itk::Index<2>            start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(10);
+  itk::Size<2> size;
+  size.Fill(10);
 
-    itk::ImageRegion<2> region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(itk::NumericTraits<VectorType>::Zero);
+  itk::ImageRegion<2> region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(itk::NumericTraits<VectorType>::Zero);
 
-    itk::TranslationTransform<double,2>::Pointer transform =
-            itk::TranslationTransform<double,2>::New();
-    itk::TranslationTransform<double,2>::OutputVectorType translation;
-    translation[0] = 10;
-    translation[1] = 20;
-    transform->Translate(translation);
+  itk::TranslationTransform<double, 2>::Pointer          transform = itk::TranslationTransform<double, 2>::New();
+  itk::TranslationTransform<double, 2>::OutputVectorType translation;
+  translation[0] = 10;
+  translation[1] = 20;
+  transform->Translate(translation);
 
-    typedef itk::ResampleImageFilter< VectorImageType, VectorImageType > ResampleFilterType;
-    ResampleFilterType::Pointer vectorResampleFilter = ResampleFilterType::New();
-    vectorResampleFilter->SetInput(image);
-    vectorResampleFilter->SetSize(image->GetLargestPossibleRegion().GetSize());
-    vectorResampleFilter->SetTransform(transform);
-    vectorResampleFilter->Update();
+  typedef itk::ResampleImageFilter<VectorImageType, VectorImageType> ResampleFilterType;
+  ResampleFilterType::Pointer                                        vectorResampleFilter = ResampleFilterType::New();
+  vectorResampleFilter->SetInput(image);
+  vectorResampleFilter->SetSize(image->GetLargestPossibleRegion().GetSize());
+  vectorResampleFilter->SetTransform(transform);
+  vectorResampleFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Core/Transform/TranslateImage/Code.cxx
+++ b/src/Core/Transform/TranslateImage/Code.cxx
@@ -21,16 +21,17 @@
 #include "itkTranslationTransform.h"
 #include "itkResampleImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <translation X> <translation Y>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -38,41 +39,41 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
   reader->UpdateOutputInformation();
 
-  using TransformType = itk::TranslationTransform< double, Dimension >;
+  using TransformType = itk::TranslationTransform<double, Dimension>;
 
   TransformType::OutputVectorType vector;
-  vector[0] = std::stod( argv[3] );
-  vector[1] = std::stod( argv[4] );
+  vector[0] = std::stod(argv[3]);
+  vector[1] = std::stod(argv[4]);
 
   TransformType::Pointer translation = TransformType::New();
-  translation->Translate( vector );
+  translation->Translate(vector);
 
   using ResampleImageFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
   ResampleImageFilterType::Pointer resampleFilter = ResampleImageFilterType::New();
-  resampleFilter->SetTransform( translation.GetPointer() );
-  resampleFilter->SetInput( reader->GetOutput() );
-  resampleFilter->SetSize( reader->GetOutput()->GetLargestPossibleRegion().GetSize() );
+  resampleFilter->SetTransform(translation.GetPointer());
+  resampleFilter->SetInput(reader->GetOutput());
+  resampleFilter->SetSize(reader->GetOutput()->GetLargestPossibleRegion().GetSize());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( resampleFilter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(resampleFilter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Developer/ConceptChecking.cxx
+++ b/src/Developer/ConceptChecking.cxx
@@ -2,12 +2,14 @@
 #include <itkImage.h>
 
 template <typename TImage>
-void MyFunction(const TImage* const image)
+void
+MyFunction(const TImage * const image)
 {
-  itkConceptMacro( nameOfCheck, ( itk::Concept::IsFloatingPoint<typename TImage::ValueType> ) );
+  itkConceptMacro(nameOfCheck, (itk::Concept::IsFloatingPoint<typename TImage::ValueType>));
 }
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   using FloatImageType = itk::Image<float, 2>;
   FloatImageType::Pointer floatImage = FloatImageType::New();
@@ -18,14 +20,14 @@ int main(int, char*[])
   MyFunction(doubleImage.GetPointer());
 
   // Fails the concept check
-//   using IntImageType = itk::Image<int, 2>;
-//   IntImageType::Pointer intImage = IntImageType::New();
-//   MyFunction(intImage.GetPointer());
+  //   using IntImageType = itk::Image<int, 2>;
+  //   IntImageType::Pointer intImage = IntImageType::New();
+  //   MyFunction(intImage.GetPointer());
 
   // Fails the concept check
-//   using UCharImageType = itk::Image<unsigned char, 2>;
-//   UCharImageType::Pointer ucharImage = UCharImageType::New();
-//   MyFunction(ucharImage.GetPointer());
+  //   using UCharImageType = itk::Image<unsigned char, 2>;
+  //   UCharImageType::Pointer ucharImage = UCharImageType::New();
+  //   MyFunction(ucharImage.GetPointer());
 
   return EXIT_SUCCESS;
 }

--- a/src/Developer/Exceptions.cxx
+++ b/src/Developer/Exceptions.cxx
@@ -4,12 +4,13 @@
 
 #include "ImageSource.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;
   ImageType::Pointer image = ImageType::New();
-  
+
   // Create and the filter
   using FilterType = itk::ImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();

--- a/src/Developer/ImageFilter.cxx
+++ b/src/Developer/ImageFilter.cxx
@@ -5,9 +5,11 @@
 #include "ImageFilter.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;
@@ -35,14 +37,15 @@ int main(int, char*[])
 
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
   // Create an image with 2 connected components
-  typename TImage::IndexType corner = {{0,0}};
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-  unsigned int NumRows = 200;
-  unsigned int NumCols = 300;
-  typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
   typename TImage::RegionType region(corner, size);
 

--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -5,14 +5,14 @@
 
 namespace itk
 {
-template< class TImage>
-class ImageFilter:public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = ImageFilter;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -21,22 +21,23 @@ public:
   itkTypeMacro(ImageFilter, ImageToImageFilter);
 
 protected:
-  ImageFilter()= default;
-  ~ImageFilter() override= default;
+  ImageFilter() = default;
+  ~ImageFilter() override = default;
 
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
 private:
-  ImageFilter(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  ImageFilter(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "ImageFilter.hxx"
+#  include "ImageFilter.hxx"
 #endif
 
 

--- a/src/Developer/ImageFilter.hxx
+++ b/src/Developer/ImageFilter.hxx
@@ -10,25 +10,25 @@
 namespace itk
 {
 
-template< class TImage>
-void ImageFilter< TImage>
-::GenerateData()
+template <class TImage>
+void
+ImageFilter<TImage>::GenerateData()
 {
   typename TImage::ConstPointer input = this->GetInput();
-  typename TImage::Pointer output = this->GetOutput();
+  typename TImage::Pointer      output = this->GetOutput();
 
-  itk::Index<2> cornerPixel = input->GetLargestPossibleRegion().GetIndex();
+  itk::Index<2>              cornerPixel = input->GetLargestPossibleRegion().GetIndex();
   typename TImage::PixelType newValue = 3;
 
   this->AllocateOutputs();
 
-  ImageAlgorithm::Copy(input.GetPointer(), output.GetPointer(), output->GetRequestedRegion(),
-                       output->GetRequestedRegion() );
+  ImageAlgorithm::Copy(
+    input.GetPointer(), output.GetPointer(), output->GetRequestedRegion(), output->GetRequestedRegion());
 
-  output->SetPixel( cornerPixel, newValue );
+  output->SetPixel(cornerPixel, newValue);
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/ImageFilterMultipleInputs.cxx
+++ b/src/Developer/ImageFilterMultipleInputs.cxx
@@ -4,7 +4,8 @@
 
 #include "ImageFilterMultipleInputs.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.cxx
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.cxx
@@ -5,7 +5,8 @@
 
 #include "ImageFilterMultipleInputsDifferentType.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using VectorImageType = itk::Image<itk::CovariantVector<unsigned char, 3>, 2>;
@@ -22,7 +23,7 @@ int main(int, char*[])
   filter->SetInput(reader->GetOutput());
   filter->Update();
 
-  using WriterType = itk::ImageFileWriter< VectorImageType  >;
+  using WriterType = itk::ImageFileWriter<VectorImageType>;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName("TestOutput.jpg");
   writer->SetInput(filter->GetOutput());

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.h
@@ -5,14 +5,14 @@
 
 namespace itk
 {
-template< typename TImage, typename TMask>
-class ImageFilterMultipleInputsDifferentType : public ImageToImageFilter< TImage, TImage >
+template <typename TImage, typename TMask>
+class ImageFilterMultipleInputsDifferentType : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = ImageFilterMultipleInputsDifferentType;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -21,31 +21,36 @@ public:
   itkTypeMacro(ImageFilterMultipleInputsDifferentType, ImageToImageFilter);
 
   /** The image to be inpainted in regions where the mask is white.*/
-  void SetInputImage(const TImage* image);
+  void
+  SetInputImage(const TImage * image);
 
   /** The mask to be inpainted. White pixels will be inpainted, black pixels will be passed through to the output.*/
-  void SetInputMask(const TMask* mask);
+  void
+  SetInputMask(const TMask * mask);
 
 protected:
   ImageFilterMultipleInputsDifferentType();
-  ~ImageFilterMultipleInputsDifferentType() override= default;
+  ~ImageFilterMultipleInputsDifferentType() override = default;
 
-  typename TImage::ConstPointer GetInputImage();
-  typename TMask::ConstPointer GetInputMask();
-  
+  typename TImage::ConstPointer
+  GetInputImage();
+  typename TMask::ConstPointer
+  GetInputMask();
+
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
 private:
-  ImageFilterMultipleInputsDifferentType(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  ImageFilterMultipleInputsDifferentType(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "ImageFilterMultipleInputsDifferentType.hxx"
+#  include "ImageFilterMultipleInputsDifferentType.hxx"
 #endif
 
 

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
@@ -10,69 +10,71 @@
 namespace itk
 {
 
-template< typename TImage, typename TMask>
+template <typename TImage, typename TMask>
 ImageFilterMultipleInputsDifferentType<TImage, TMask>::ImageFilterMultipleInputsDifferentType()
 {
   this->SetNumberOfRequiredInputs(2);
 }
 
-template< typename TImage, typename TMask>
-void ImageFilterMultipleInputsDifferentType<TImage, TMask>::SetInputImage(const TImage* image)
+template <typename TImage, typename TMask>
+void
+ImageFilterMultipleInputsDifferentType<TImage, TMask>::SetInputImage(const TImage * image)
 {
-  SetNthInput(0, const_cast<TImage*>(image));
+  SetNthInput(0, const_cast<TImage *>(image));
 }
 
-template< typename TImage, typename TMask>
-void ImageFilterMultipleInputsDifferentType<TImage, TMask>::SetInputMask(const TMask* mask)
+template <typename TImage, typename TMask>
+void
+ImageFilterMultipleInputsDifferentType<TImage, TMask>::SetInputMask(const TMask * mask)
 {
-  SetNthInput(1, const_cast<TMask*>(mask));
+  SetNthInput(1, const_cast<TMask *>(mask));
 }
 
-template< typename TImage, typename TMask>
-typename TImage::ConstPointer ImageFilterMultipleInputsDifferentType<TImage, TMask>::GetInputImage()
+template <typename TImage, typename TMask>
+typename TImage::ConstPointer
+ImageFilterMultipleInputsDifferentType<TImage, TMask>::GetInputImage()
 {
-  return static_cast< const TImage * >
-         ( this->ProcessObject::GetInput(0) );
+  return static_cast<const TImage *>(this->ProcessObject::GetInput(0));
 }
 
-template< typename TImage, typename TMask>
-typename TMask::ConstPointer ImageFilterMultipleInputsDifferentType<TImage, TMask>::GetInputMask()
+template <typename TImage, typename TMask>
+typename TMask::ConstPointer
+ImageFilterMultipleInputsDifferentType<TImage, TMask>::GetInputMask()
 {
-  return static_cast< const TMask * >
-         ( this->ProcessObject::GetInput(1) );
+  return static_cast<const TMask *>(this->ProcessObject::GetInput(1));
 }
 
-template< typename TImage, typename TMask>
-void ImageFilterMultipleInputsDifferentType<TImage, TMask>::GenerateData()
+template <typename TImage, typename TMask>
+void
+ImageFilterMultipleInputsDifferentType<TImage, TMask>::GenerateData()
 {
   typename TImage::ConstPointer input = this->GetInputImage();
-  typename TMask::ConstPointer mask = this->GetInputMask();
+  typename TMask::ConstPointer  mask = this->GetInputMask();
 
   typename TImage::Pointer output = this->GetOutput();
   output->SetRegions(input->GetLargestPossibleRegion());
   output->Allocate();
 
-  itk::ImageRegionIterator<TImage> outputIterator(output, output->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<TImage>      outputIterator(output, output->GetLargestPossibleRegion());
   itk::ImageRegionConstIterator<TImage> inputIterator(input, input->GetLargestPossibleRegion());
 
-  while(!outputIterator.IsAtEnd())
+  while (!outputIterator.IsAtEnd())
+  {
+    if (inputIterator.GetIndex()[0] == inputIterator.GetIndex()[1])
     {
-    if(inputIterator.GetIndex()[0] == inputIterator.GetIndex()[1])
-      {
       outputIterator.Set(itk::CovariantVector<unsigned char, 3>(255));
-      }
+    }
     else
-      {
+    {
       outputIterator.Set(inputIterator.Get());
-      }
+    }
 
     ++inputIterator;
     ++outputIterator;
-    }
-
+  }
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/ImageFilterMultipleOutputs.cxx
+++ b/src/Developer/ImageFilterMultipleOutputs.cxx
@@ -4,7 +4,8 @@
 
 #include "ImageFilterMultipleOutputs.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;
@@ -15,20 +16,20 @@ int main(int, char*[])
   filter->Update();
 
   {
-  using WriterType = itk::ImageFileWriter< ImageType  >;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName("TestOutput1.jpg");
-  writer->SetInput(filter->GetOutput1());
-  writer->Update();
+    using WriterType = itk::ImageFileWriter<ImageType>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput1.jpg");
+    writer->SetInput(filter->GetOutput1());
+    writer->Update();
   }
-  
+
   {
-  using WriterType = itk::ImageFileWriter< ImageType  >;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName("TestOutput2.jpg");
-  writer->SetInput(filter->GetOutput2());
-  writer->Update();
+    using WriterType = itk::ImageFileWriter<ImageType>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput2.jpg");
+    writer->SetInput(filter->GetOutput2());
+    writer->Update();
   }
-  
+
   return EXIT_SUCCESS;
 }

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -5,14 +5,14 @@
 
 namespace itk
 {
-template< class TImage>
-class ImageFilterMultipleOutputs : public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class ImageFilterMultipleOutputs : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = ImageFilterMultipleOutputs;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -20,29 +20,33 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ImageFilterMultipleOutputs, ImageToImageFilter);
 
-  TImage* GetOutput1();
-  TImage* GetOutput2();
-  
+  TImage *
+  GetOutput1();
+  TImage *
+  GetOutput2();
+
 protected:
   ImageFilterMultipleOutputs();
-  ~ImageFilterMultipleOutputs() override= default;
+  ~ImageFilterMultipleOutputs() override = default;
 
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
   /**  Create the Output */
-  DataObject::Pointer MakeOutput(unsigned int idx);
+  DataObject::Pointer
+  MakeOutput(unsigned int idx);
 
 private:
-  ImageFilterMultipleOutputs(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  ImageFilterMultipleOutputs(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "ImageFilterMultipleOutputs.hxx"
+#  include "ImageFilterMultipleOutputs.hxx"
 #endif
 
 

--- a/src/Developer/ImageFilterMultipleOutputs.hxx
+++ b/src/Developer/ImageFilterMultipleOutputs.hxx
@@ -10,18 +10,19 @@
 namespace itk
 {
 
-template< class TImage>
+template <class TImage>
 ImageFilterMultipleOutputs<TImage>::ImageFilterMultipleOutputs()
 {
   this->SetNumberOfRequiredOutputs(2);
   this->SetNumberOfRequiredInputs(0);
 
-  this->SetNthOutput( 0, this->MakeOutput(0) );
-  this->SetNthOutput( 1, this->MakeOutput(1) );
+  this->SetNthOutput(0, this->MakeOutput(0));
+  this->SetNthOutput(1, this->MakeOutput(1));
 }
 
-template< class TImage>
-void ImageFilterMultipleOutputs<TImage>::GenerateData()
+template <class TImage>
+void
+ImageFilterMultipleOutputs<TImage>::GenerateData()
 {
   typename TImage::IndexType start;
   start[0] = 0;
@@ -34,28 +35,28 @@ void ImageFilterMultipleOutputs<TImage>::GenerateData()
   typename TImage::RegionType region;
   region.SetSize(size);
   region.SetIndex(start);
-  
+
   // Setup output 1
   typename TImage::Pointer output1 = this->GetOutput1();
   output1->SetRegions(region);
-  output1->Allocate();  
-  
+  output1->Allocate();
+
   itk::ImageRegionIterator<TImage> outputIterator1(output1, output1->GetLargestPossibleRegion());
   outputIterator1.GoToBegin();
-  
-  while(!outputIterator1.IsAtEnd())
+
+  while (!outputIterator1.IsAtEnd())
+  {
+    if (outputIterator1.GetIndex()[0] == outputIterator1.GetIndex()[1])
     {
-    if(outputIterator1.GetIndex()[0] == outputIterator1.GetIndex()[1])
-      {
       outputIterator1.Set(255);
-      }
+    }
     else
-      {
+    {
       outputIterator1.Set(0);
-      }
+    }
 
     ++outputIterator1;
-    }
+  }
 
   // Setup output 2
   typename TImage::Pointer output2 = this->GetOutput2();
@@ -65,58 +66,58 @@ void ImageFilterMultipleOutputs<TImage>::GenerateData()
   itk::ImageRegionIterator<TImage> outputIterator2(output2, output2->GetLargestPossibleRegion());
   outputIterator2.GoToBegin();
 
-  while(!outputIterator2.IsAtEnd())
+  while (!outputIterator2.IsAtEnd())
+  {
+    if (outputIterator2.GetIndex()[0] > 10)
     {
-    if(outputIterator2.GetIndex()[0] > 10)
-      {
       outputIterator2.Set(255);
-      }
+    }
     else
-      {
+    {
       outputIterator2.Set(0);
-      }
-
-    ++outputIterator2;
     }
 
+    ++outputIterator2;
+  }
 }
 
-template< class TImage>
-DataObject::Pointer ImageFilterMultipleOutputs<TImage>::MakeOutput(unsigned int idx)
+template <class TImage>
+DataObject::Pointer
+ImageFilterMultipleOutputs<TImage>::MakeOutput(unsigned int idx)
 {
   DataObject::Pointer output;
 
-  switch ( idx )
-    {
+  switch (idx)
+  {
     case 0:
-      output = ( TImage::New() ).GetPointer();
+      output = (TImage::New()).GetPointer();
       break;
     case 1:
-      output = ( TImage::New() ).GetPointer();
+      output = (TImage::New()).GetPointer();
       break;
     default:
       std::cerr << "No output " << idx << std::endl;
       output = nullptr;
       break;
-    }
+  }
   return output.GetPointer();
 }
 
-template< class TImage>
-TImage* ImageFilterMultipleOutputs<TImage>::GetOutput1()
+template <class TImage>
+TImage *
+ImageFilterMultipleOutputs<TImage>::GetOutput1()
 {
-  return dynamic_cast< TImage * >(
-           this->ProcessObject::GetOutput(0) );
+  return dynamic_cast<TImage *>(this->ProcessObject::GetOutput(0));
 }
 
-template< class TImage>
-TImage* ImageFilterMultipleOutputs<TImage>::GetOutput2()
+template <class TImage>
+TImage *
+ImageFilterMultipleOutputs<TImage>::GetOutput2()
 {
-  return dynamic_cast< TImage * >(
-           this->ProcessObject::GetOutput(1) );
+  return dynamic_cast<TImage *>(this->ProcessObject::GetOutput(1));
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.cxx
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.cxx
@@ -4,7 +4,8 @@
 
 #include "ImageFilterMultipleOutputsDifferentType.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using InputImageType = itk::Image<unsigned char, 2>;
@@ -17,20 +18,20 @@ int main(int, char*[])
   filter->Update();
 
   {
-  using WriterType = itk::ImageFileWriter< OutputImageType1  >;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName("TestOutput1.jpg");
-  writer->SetInput(filter->GetOutput1());
-  writer->Update();
+    using WriterType = itk::ImageFileWriter<OutputImageType1>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput1.jpg");
+    writer->SetInput(filter->GetOutput1());
+    writer->Update();
   }
-  
+
   {
-  using WriterType = itk::ImageFileWriter< OutputImageType2  >;
-  WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName("TestOutput2.jpg");
-  writer->SetInput(filter->GetOutput2());
-  writer->Update();
+    using WriterType = itk::ImageFileWriter<OutputImageType2>;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName("TestOutput2.jpg");
+    writer->SetInput(filter->GetOutput2());
+    writer->Update();
   }
-  
+
   return EXIT_SUCCESS;
 }

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.h
@@ -5,14 +5,16 @@
 
 namespace itk
 {
-template< typename TInputImage, typename TOutputImage1, typename TOutputImage2>
-class ImageFilterMultipleOutputsDifferentType : public ImageToImageFilter< TInputImage, TOutputImage1 > // This doesn't actually matter, as we will be overriding the output image type in MakeOutput()
+template <typename TInputImage, typename TOutputImage1, typename TOutputImage2>
+class ImageFilterMultipleOutputsDifferentType
+  : public ImageToImageFilter<TInputImage, TOutputImage1> // This doesn't actually matter, as we will be overriding the
+                                                          // output image type in MakeOutput()
 {
 public:
   /** Standard class type alias. */
   using Self = ImageFilterMultipleOutputsDifferentType;
-  using Superclass = ImageToImageFilter< TInputImage, TOutputImage1 >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TInputImage, TOutputImage1>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -20,29 +22,33 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ImageFilterMultipleOutputsDifferentType, ImageToImageFilter);
 
-  TOutputImage1* GetOutput1();
-  TOutputImage2* GetOutput2();
+  TOutputImage1 *
+  GetOutput1();
+  TOutputImage2 *
+  GetOutput2();
 
 protected:
   ImageFilterMultipleOutputsDifferentType();
-  ~ImageFilterMultipleOutputsDifferentType() override= default;
+  ~ImageFilterMultipleOutputsDifferentType() override = default;
 
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
   /**  Create the Output */
-  DataObject::Pointer MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
+  DataObject::Pointer
+  MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
 
 private:
-  ImageFilterMultipleOutputsDifferentType(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  ImageFilterMultipleOutputsDifferentType(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "ImageFilterMultipleOutputsDifferentType.hxx"
+#  include "ImageFilterMultipleOutputsDifferentType.hxx"
 #endif
 
 

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
@@ -10,18 +10,20 @@
 namespace itk
 {
 
-template< typename TInputImage, typename TOutputImage1, typename TOutputImage2>
-ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::ImageFilterMultipleOutputsDifferentType()
+template <typename TInputImage, typename TOutputImage1, typename TOutputImage2>
+ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::
+  ImageFilterMultipleOutputsDifferentType()
 {
   this->SetNumberOfRequiredOutputs(2);
   this->SetNumberOfRequiredInputs(0);
 
-  this->SetNthOutput( 0, this->MakeOutput(0) );
-  this->SetNthOutput( 1, this->MakeOutput(1) );
+  this->SetNthOutput(0, this->MakeOutput(0));
+  this->SetNthOutput(1, this->MakeOutput(1));
 }
 
-template< typename TInputImage, typename TOutputImage1, typename TOutputImage2>
-void ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::GenerateData()
+template <typename TInputImage, typename TOutputImage1, typename TOutputImage2>
+void
+ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::GenerateData()
 {
   itk::Index<2> start;
   start.Fill(0);
@@ -29,7 +31,7 @@ void ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutput
   itk::Size<2> size;
   size.Fill(20);
 
-  itk::ImageRegion<2> region(start,size);
+  itk::ImageRegion<2> region(start, size);
 
   // Setup output 1
   typename TOutputImage1::Pointer output1 = this->GetOutput1();
@@ -40,43 +42,46 @@ void ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutput
   typename TOutputImage2::Pointer output2 = this->GetOutput2();
   output2->SetRegions(region);
   output2->Allocate();
-
 }
 
-template< typename TInputImage, typename TOutputImage1, typename TOutputImage2>
-DataObject::Pointer ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx)
+template <typename TInputImage, typename TOutputImage1, typename TOutputImage2>
+DataObject::Pointer
+ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::MakeOutput(
+  ProcessObject::DataObjectPointerArraySizeType idx)
 {
   DataObject::Pointer output;
 
-  switch ( idx )
-    {
+  switch (idx)
+  {
     case 0:
-      output = ( TOutputImage1::New() ).GetPointer();
+      output = (TOutputImage1::New()).GetPointer();
       break;
     case 1:
-      output = ( TOutputImage2::New() ).GetPointer();
+      output = (TOutputImage2::New()).GetPointer();
       break;
     default:
       std::cerr << "No output " << idx << std::endl;
       output = nullptr;
       break;
-    }
+  }
   return output.GetPointer();
 }
 
-template< typename TInputImage, typename TOutputImage1, typename TOutputImage2>
-TOutputImage1* ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::GetOutput1()
+template <typename TInputImage, typename TOutputImage1, typename TOutputImage2>
+TOutputImage1 *
+ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::GetOutput1()
 {
-  return dynamic_cast< TOutputImage1 * >(this->ProcessObject::GetOutput(0) );
+  return dynamic_cast<TOutputImage1 *>(this->ProcessObject::GetOutput(0));
 }
 
-template< typename TInputImage, typename TOutputImage1, typename TOutputImage2>
-TOutputImage2* ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::GetOutput2()
+template <typename TInputImage, typename TOutputImage1, typename TOutputImage2>
+TOutputImage2 *
+ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage2>::GetOutput2()
 {
-  return dynamic_cast< TOutputImage2 * >(this->ProcessObject::GetOutput(1) );
+  return dynamic_cast<TOutputImage2 *>(this->ProcessObject::GetOutput(1));
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/ImageFilterX.h
+++ b/src/Developer/ImageFilterX.h
@@ -5,15 +5,14 @@
 
 namespace itk
 {
-template< class TImage>
-class ImageFilter:public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-
   /** Standard class type alias. */
   using Self = ImageFilter;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -21,28 +20,29 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(ImageFilter, ImageToImageFilter);
 
-  itkSetMacro( Variable, double );
-  itkGetMacro( Variable, double);
+  itkSetMacro(Variable, double);
+  itkGetMacro(Variable, double);
 
 protected:
-  ImageFilter()= default;
-  ~ImageFilter() override= default;
+  ImageFilter() = default;
+  ~ImageFilter() override = default;
 
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
   double m_Variable;
 
 private:
-  ImageFilter(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  ImageFilter(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "ImageFilterX.hxx"
+#  include "ImageFilterX.hxx"
 #endif
 
 

--- a/src/Developer/ImageFilterX.hxx
+++ b/src/Developer/ImageFilterX.hxx
@@ -9,14 +9,12 @@
 namespace itk
 {
 
-template< class TImage>
-void ImageFilter< TImage>
-::GenerateData()
-{
+template <class TImage>
+void
+ImageFilter<TImage>::GenerateData()
+{}
 
-}
-
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -7,14 +7,14 @@
 
 namespace itk
 {
-template< class TImage>
-class ImageFilter:public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = ImageFilter;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -28,28 +28,29 @@ public:
 
 
   /**  Smoothing filter type */
-  using InternalGaussianFilterType = RecursiveGaussianImageFilter< TImage, TImage >   ;
+  using InternalGaussianFilterType = RecursiveGaussianImageFilter<TImage, TImage>;
 
   /**  Pointer to a gaussian filter.  */
   using InternalGaussianFilterPointer = typename InternalGaussianFilterType::Pointer;
 
 protected:
   ImageFilter();
-  ~ImageFilter() override= default;
+  ~ImageFilter() override = default;
 
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
 private:
-  ImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);  //purposely not implemented
-
+  ImageFilter(const Self &); // purposely not implemented
+  void
+  operator=(const Self &); // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "ImageFilterY.hxx"
+#  include "ImageFilterY.hxx"
 #endif
 
 

--- a/src/Developer/ImageFilterY.hxx
+++ b/src/Developer/ImageFilterY.hxx
@@ -8,46 +8,43 @@
 namespace itk
 {
 
-template< class TImage>
-ImageFilter< TImage>
-::ImageFilter()
-= default;
+template <class TImage>
+ImageFilter<TImage>::ImageFilter() = default;
 
-template< class TImage>
-void ImageFilter< TImage>
-::GenerateData()
+template <class TImage>
+void
+ImageFilter<TImage>::GenerateData()
 {
   InternalGaussianFilterPointer smoothingFilters[ImageDimension];
 
   // Instantiate all filters
-  for ( unsigned int i = 0; i < ImageDimension; i++ )
-    {
+  for (unsigned int i = 0; i < ImageDimension; i++)
+  {
     smoothingFilters[i] = InternalGaussianFilterType::New();
     smoothingFilters[i]->SetOrder(EnumGaussianOrderType::ZeroOrder);
     smoothingFilters[i]->SetDirection(i);
-    }
+  }
 
   // Connect all filters (start at 1 because 0th filter is connected to the input
-  for ( unsigned int i = 1; i < ImageDimension; i++ )
-    {
-    smoothingFilters[i]->SetInput(
-      smoothingFilters[i - 1]->GetOutput() );
-    }
+  for (unsigned int i = 1; i < ImageDimension; i++)
+  {
+    smoothingFilters[i]->SetInput(smoothingFilters[i - 1]->GetOutput());
+  }
 
-  const typename TImage::ConstPointer inputImage( this->GetInput() );
+  const typename TImage::ConstPointer inputImage(this->GetInput());
 
   const typename TImage::RegionType region = inputImage->GetRequestedRegion();
 
   smoothingFilters[0]->SetInput(inputImage);
 
-  smoothingFilters[ImageDimension-1]->Update();
+  smoothingFilters[ImageDimension - 1]->Update();
 
   // Copy the output from the last filter
-  //this->GraftOutput( m_SmoothingFilters[ImageDimension-1]->GetOutput() );
-  this->GetOutput()->Graft(smoothingFilters[ImageDimension-1]->GetOutput() );
+  // this->GraftOutput( m_SmoothingFilters[ImageDimension-1]->GetOutput() );
+  this->GetOutput()->Graft(smoothingFilters[ImageDimension - 1]->GetOutput());
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -7,15 +7,14 @@
 
 namespace itk
 {
-template< class TImage>
-class ImageFilter:public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-
   /** Standard class type alias. */
   using Self = ImageFilter;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -24,22 +23,23 @@ public:
   itkTypeMacro(ImageFilter, ImageToImageFilter);
 
 protected:
-  ImageFilter(){}
-  ~ImageFilter(){}
+  ImageFilter() {}
+  ~ImageFilter() {}
 
   /** Does the real work. */
-  virtual void GenerateData();
+  virtual void
+  GenerateData();
 
 private:
-  ImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);  //purposely not implemented
-
+  ImageFilter(const Self &); // purposely not implemented
+  void
+  operator=(const Self &); // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "ImageFilter.hxx"
+#  include "ImageFilter.hxx"
 #endif
 
 

--- a/src/Developer/ImageSource.hxx
+++ b/src/Developer/ImageSource.hxx
@@ -9,15 +9,15 @@
 namespace itk
 {
 
-template< class TImage>
-void ImageFilter< TImage>
-::GenerateData()
+template <class TImage>
+void
+ImageFilter<TImage>::GenerateData()
 {
   double a = 2.1;
-  itkExceptionMacro ("Here is a variable: " << a << " and then more text.");
+  itkExceptionMacro("Here is a variable: " << a << " and then more text.");
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/InplaceImageFilter.cxx
+++ b/src/Developer/InplaceImageFilter.cxx
@@ -5,9 +5,11 @@
 #include "MyInPlaceImageFilter.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;
@@ -30,22 +32,23 @@ int main(int, char*[])
 
   // The follow calls fail. This is because the output has stolen the input's
   // buffer and the input has no image buffer.
-//   std::cout << "Image output:" << std::endl;
-//   std::cout << image->GetPixel(cornerPixel) << std::endl;
+  //   std::cout << "Image output:" << std::endl;
+  //   std::cout << image->GetPixel(cornerPixel) << std::endl;
 
   return EXIT_SUCCESS;
 }
 
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
   // Create an image with 2 connected components
-  typename TImage::IndexType corner = {{0,0}};
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-  unsigned int NumRows = 200;
-  unsigned int NumCols = 300;
-  typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
   typename TImage::RegionType region(corner, size);
 

--- a/src/Developer/MiniPipeline.cxx
+++ b/src/Developer/MiniPipeline.cxx
@@ -5,9 +5,11 @@
 #include "ImageFilterY.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;
@@ -25,8 +27,8 @@ int main(int, char*[])
 
   std::cout << "Input:" << std::endl;
   std::cout << filter->GetOutput()->GetLargestPossibleRegion() << std::endl;
-  
-  using WriterType = itk::ImageFileWriter< ImageType  >;
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName("Output.png");
   writer->SetInput(filter->GetOutput());
@@ -36,14 +38,15 @@ int main(int, char*[])
 }
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
   // Create an image with 2 connected components
-  typename TImage::IndexType corner = {{0,0}};
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-  unsigned int NumRows = 200;
-  unsigned int NumCols = 300;
-  typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
   typename TImage::RegionType region(corner, size);
 
@@ -51,9 +54,9 @@ void CreateImage(TImage* const image)
   image->Allocate();
 
   // Make another square
-  for(unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; r++)
   {
-    for(unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; c++)
     {
       typename TImage::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Developer/MultiThreadedImageFilter.cxx
+++ b/src/Developer/MultiThreadedImageFilter.cxx
@@ -5,12 +5,15 @@
 #include "MultiThreadedImageFilter.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
 template <typename TImage>
-static void OutputImage(TImage* const image);
+static void
+OutputImage(TImage * const image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;
@@ -36,17 +39,18 @@ int main(int, char*[])
 
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
   // Create an image with 2 connected components
-  typename TImage::IndexType corner = {{0,0}};
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-//   unsigned int NumRows = 200;
-//   unsigned int NumCols = 300;
+  //   unsigned int NumRows = 200;
+  //   unsigned int NumCols = 300;
 
-  unsigned int NumRows = 3;
-  unsigned int NumCols = 2;
-  typename TImage::SizeType size = {{NumRows, NumCols}};
+  unsigned int              NumRows = 3;
+  unsigned int              NumCols = 2;
+  typename TImage::SizeType size = { { NumRows, NumCols } };
 
   typename TImage::RegionType region(corner, size);
 
@@ -57,14 +61,15 @@ void CreateImage(TImage* const image)
 }
 
 template <typename TImage>
-void OutputImage(TImage* const image)
+void
+OutputImage(TImage * const image)
 {
   itk::ImageRegionConstIterator<TImage> imageIterator(image, image->GetLargestPossibleRegion());
 
-  while(!imageIterator.IsAtEnd())
-    {
+  while (!imageIterator.IsAtEnd())
+  {
     std::cout << imageIterator.Get() << std::endl;
 
     ++imageIterator;
-    }
+  }
 }

--- a/src/Developer/MultiThreadedImageFilter.h
+++ b/src/Developer/MultiThreadedImageFilter.h
@@ -5,14 +5,14 @@
 
 namespace itk
 {
-template< class TImage>
-class MultiThreadedImageFilter : public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class MultiThreadedImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = MultiThreadedImageFilter;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;
 
@@ -23,21 +23,22 @@ public:
   itkTypeMacro(ImageFilter, ImageToImageFilter);
 
 protected:
-  MultiThreadedImageFilter()= default;
-  ~MultiThreadedImageFilter() override= default;
+  MultiThreadedImageFilter() = default;
+  ~MultiThreadedImageFilter() override = default;
 
-  void DynamicThreadedGenerateData(const OutputImageRegionType &) override;
+  void
+  DynamicThreadedGenerateData(const OutputImageRegionType &) override;
 
 private:
-  MultiThreadedImageFilter(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  MultiThreadedImageFilter(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "MultiThreadedImageFilter.hxx"
+#  include "MultiThreadedImageFilter.hxx"
 #endif
 
 

--- a/src/Developer/MultiThreadedImageFilter.hxx
+++ b/src/Developer/MultiThreadedImageFilter.hxx
@@ -10,12 +10,12 @@
 namespace itk
 {
 
-template< class TImage>
-void MultiThreadedImageFilter< TImage>
-::DynamicThreadedGenerateData(const OutputImageRegionType & region)
+template <class TImage>
+void
+MultiThreadedImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType & region)
 {
   typename TImage::ConstPointer input = this->GetInput();
-  typename TImage::Pointer output = this->GetOutput();
+  typename TImage::Pointer      output = this->GetOutput();
 
   ImageAlgorithm::Copy(input.GetPointer(), output.GetPointer(), region, region);
 
@@ -23,10 +23,10 @@ void MultiThreadedImageFilter< TImage>
   std::cout << "cornerPixel: " << cornerPixel << std::endl;
   typename TImage::PixelType newValue = 3;
 
-  output->SetPixel( cornerPixel, newValue );
+  output->SetPixel(cornerPixel, newValue);
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -5,14 +5,14 @@
 
 namespace itk
 {
-template< class TImage>
+template <class TImage>
 class MyInPlaceImageFilter : public InPlaceImageFilter<TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = MyInPlaceImageFilter;
   using Superclass = InPlaceImageFilter<TImage>;
-  using Pointer = SmartPointer< Self >;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -21,22 +21,23 @@ public:
   itkTypeMacro(MyInPlaceImageFilter, InPlaceImageFilter);
 
 protected:
-  MyInPlaceImageFilter()= default;
-  ~MyInPlaceImageFilter() override= default;
+  MyInPlaceImageFilter() = default;
+  ~MyInPlaceImageFilter() override = default;
 
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
 private:
-  MyInPlaceImageFilter(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  MyInPlaceImageFilter(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "MyInPlaceImageFilter.hxx"
+#  include "MyInPlaceImageFilter.hxx"
 #endif
 
 

--- a/src/Developer/MyInPlaceImageFilter.hxx
+++ b/src/Developer/MyInPlaceImageFilter.hxx
@@ -10,12 +10,12 @@
 namespace itk
 {
 
-template< class TImage>
-void MyInPlaceImageFilter< TImage>
-::GenerateData()
+template <class TImage>
+void
+MyInPlaceImageFilter<TImage>::GenerateData()
 {
   typename TImage::ConstPointer input = this->GetInput();
-  typename TImage::Pointer output = this->GetOutput();
+  typename TImage::Pointer      output = this->GetOutput();
 
   // This call must come before the GetRunningInPlace() call or the
   // GetRunningInPlace() will return an incorrect result.
@@ -27,12 +27,12 @@ void MyInPlaceImageFilter< TImage>
     return;
   }
 
-  itk::Index<2> cornerPixel = input->GetLargestPossibleRegion().GetIndex();
+  itk::Index<2>              cornerPixel = input->GetLargestPossibleRegion().GetIndex();
   typename TImage::PixelType newValue = 3;
-  output->SetPixel( cornerPixel, newValue);
+  output->SetPixel(cornerPixel, newValue);
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/OilPaintingImageFilter.cxx
+++ b/src/Developer/OilPaintingImageFilter.cxx
@@ -1,59 +1,53 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
- 
+
 #include "itkOilPaintingImageFilter.h"
- 
+
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
   if (argc < 2)
-    {
+  {
     std::cerr << "Usage: " << argv[0] << " inputFile [bins [radius]]" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   unsigned int numberOfBins = 50;
   if (argc > 3)
-    {
+  {
     numberOfBins = std::stoi(argv[2]);
-    }
+  }
 
   unsigned int radius = 2;
   if (argc > 4)
-    {
+  {
     radius = std::stoi(argv[3]);
-    }
+  }
 
   using ImageType = itk::Image<unsigned char, 2>;
   using FilterType = itk::OilPaintingImageFilter<ImageType>;
- 
+
   using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName(argv[1]);
   reader->Update();
- 
+
   FilterType::Pointer filter = FilterType::New();
   filter->SetInput(reader->GetOutput());
   filter->SetNumberOfBins(numberOfBins);
   filter->SetRadius(radius);
   filter->Update();
- 
+
 #ifdef ENABLE_QUICKVIEW
   QuickView viewer;
-  viewer.AddImage(
-    reader->GetOutput(),
-    true,
-    itksys::SystemTools::GetFilenameName(reader->GetFileName()));
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(reader->GetFileName()));
 
   std::stringstream desc;
-  desc << "OilPaintingImageFilter, bins = " << numberOfBins
-       << " radius = " << radius;
-  viewer.AddImage(
-    filter->GetOutput(),
-    true,
-    desc.str());  
+  desc << "OilPaintingImageFilter, bins = " << numberOfBins << " radius = " << radius;
+  viewer.AddImage(filter->GetOutput(), true, desc.str());
 
   viewer.Visualize();
 #endif

--- a/src/Developer/SetGetMacro.cxx
+++ b/src/Developer/SetGetMacro.cxx
@@ -4,7 +4,8 @@
 
 #include "ImageFilterX.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Developer/itkImageFilterMultipleInputs.h
+++ b/src/Developer/itkImageFilterMultipleInputs.h
@@ -5,14 +5,14 @@
 
 namespace itk
 {
-template< class TImage>
-class ImageFilterMultipleInputs : public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class ImageFilterMultipleInputs : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = ImageFilterMultipleInputs;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -21,28 +21,31 @@ public:
   itkTypeMacro(ImageFilterMultipleInputs, ImageToImageFilter);
 
   /** The image to be inpainted in regions where the mask is white.*/
-  void SetInputImage(const TImage* image);
+  void
+  SetInputImage(const TImage * image);
 
   /** The mask to be inpainted. White pixels will be inpainted, black pixels will be passed through to the output.*/
-  void SetInputMask(const TImage* mask);
-  
+  void
+  SetInputMask(const TImage * mask);
+
 protected:
   ImageFilterMultipleInputs();
-  ~ImageFilterMultipleInputs() override= default;
+  ~ImageFilterMultipleInputs() override = default;
 
   /** Does the real work. */
-  void GenerateData() override;
+  void
+  GenerateData() override;
 
 private:
-  ImageFilterMultipleInputs(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
-
+  ImageFilterMultipleInputs(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "itkImageFilterMultipleInputs.hxx"
+#  include "itkImageFilterMultipleInputs.hxx"
 #endif
 
 

--- a/src/Developer/itkImageFilterMultipleInputs.hxx
+++ b/src/Developer/itkImageFilterMultipleInputs.hxx
@@ -10,61 +10,56 @@
 namespace itk
 {
 
-template< class TImage>
-ImageFilterMultipleInputs<TImage>
-::ImageFilterMultipleInputs()
+template <class TImage>
+ImageFilterMultipleInputs<TImage>::ImageFilterMultipleInputs()
 {
   this->SetNumberOfRequiredInputs(2);
 }
 
-template< class TImage>
+template <class TImage>
 void
-ImageFilterMultipleInputs<TImage>
-::SetInputImage(const TImage* image)
+ImageFilterMultipleInputs<TImage>::SetInputImage(const TImage * image)
 {
-  this->SetNthInput(0, const_cast<TImage*>(image));
+  this->SetNthInput(0, const_cast<TImage *>(image));
 }
 
-template< class TImage>
+template <class TImage>
 void
-ImageFilterMultipleInputs<TImage>
-::SetInputMask(const TImage* mask)
+ImageFilterMultipleInputs<TImage>::SetInputMask(const TImage * mask)
 {
-  this->SetNthInput(1, const_cast<TImage*>(mask));
+  this->SetNthInput(1, const_cast<TImage *>(mask));
 }
 
-template< class TImage>
+template <class TImage>
 void
-ImageFilterMultipleInputs<TImage>
-::GenerateData()
+ImageFilterMultipleInputs<TImage>::GenerateData()
 {
   typename TImage::ConstPointer input = this->GetInput();
-  
+
   typename TImage::Pointer output = this->GetOutput();
   output->SetRegions(input->GetLargestPossibleRegion());
-  output->Allocate();  
-  
-  itk::ImageRegionIterator<TImage> outputIterator(output, output->GetLargestPossibleRegion());
+  output->Allocate();
+
+  itk::ImageRegionIterator<TImage>      outputIterator(output, output->GetLargestPossibleRegion());
   itk::ImageRegionConstIterator<TImage> inputIterator(input, input->GetLargestPossibleRegion());
 
-  while(!outputIterator.IsAtEnd())
+  while (!outputIterator.IsAtEnd())
+  {
+    if (inputIterator.GetIndex()[0] == inputIterator.GetIndex()[1])
     {
-    if(inputIterator.GetIndex()[0] == inputIterator.GetIndex()[1])
-      {
       outputIterator.Set(255);
-      }
+    }
     else
-      {
+    {
       outputIterator.Set(inputIterator.Get());
-      }
+    }
 
     ++inputIterator;
     ++outputIterator;
-    }
-
+  }
 }
 
-}// end namespace
+} // namespace itk
 
 
 #endif

--- a/src/Developer/itkOilPaintingImageFilter.h
+++ b/src/Developer/itkOilPaintingImageFilter.h
@@ -14,14 +14,14 @@ namespace itk
  *
  * \ingroup ImageFilters
  */
-template< class TImage>
-class OilPaintingImageFilter:public ImageToImageFilter< TImage, TImage >
+template <class TImage>
+class OilPaintingImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
   using Self = OilPaintingImageFilter;
-  using Superclass = ImageToImageFilter< TImage, TImage >;
-  using Pointer = SmartPointer< Self >;
+  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Pointer = SmartPointer<Self>;
   using RadiusType = typename NeighborhoodIterator<TImage>::RadiusType;
 
   /** Method for creation through the object factory. */
@@ -35,30 +35,34 @@ public:
 
   itkSetMacro(Radius, RadiusType);
   itkGetConstMacro(Radius, const RadiusType);
-  void SetRadius(unsigned int radius);
+  void
+  SetRadius(unsigned int radius);
 
 protected:
   OilPaintingImageFilter();
-  ~OilPaintingImageFilter() override= default;
+  ~OilPaintingImageFilter() override = default;
 
-  void BeforeThreadedGenerateData() override;
+  void
+  BeforeThreadedGenerateData() override;
 
   /** Does the real work. */
-  void DynamicThreadedGenerateData(const typename TImage::RegionType& outputRegionForThread) override;
+  void
+  DynamicThreadedGenerateData(const typename TImage::RegionType & outputRegionForThread) override;
 
 private:
-  OilPaintingImageFilter(const Self &) = delete; //purposely not implemented
-  void operator=(const Self &) = delete;  //purposely not implemented
+  OilPaintingImageFilter(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 
-  typename TImage::ValueType m_Maximum, m_Minimum;
+  typename TImage::ValueType                        m_Maximum, m_Minimum;
   typename NeighborhoodIterator<TImage>::RadiusType m_Radius;
-  unsigned int m_NumberOfBins;
+  unsigned int                                      m_NumberOfBins;
 };
-} //namespace ITK
+} // namespace itk
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#include "itkOilPaintingImageFilter.hxx"
+#  include "itkOilPaintingImageFilter.hxx"
 #endif
 
 #endif // __itkOilPaintingImageFilter_h

--- a/src/Developer/itkOilPaintingImageFilter.hxx
+++ b/src/Developer/itkOilPaintingImageFilter.hxx
@@ -10,83 +10,85 @@
 
 namespace itk
 {
-template<class TImage>
+template <class TImage>
 OilPaintingImageFilter<TImage>::OilPaintingImageFilter()
 {
-    this->m_NumberOfBins=20;
-    this->SetRadius(5);
+  this->m_NumberOfBins = 20;
+  this->SetRadius(5);
 }
 
-template<class TImage>
-void OilPaintingImageFilter<TImage>::SetRadius(unsigned int radius)
+template <class TImage>
+void
+OilPaintingImageFilter<TImage>::SetRadius(unsigned int radius)
 {
-    for (unsigned int i = 0; i < TImage::ImageDimension; ++i)
-      {
-      m_Radius[i] = radius;
-      }
+  for (unsigned int i = 0; i < TImage::ImageDimension; ++i)
+  {
+    m_Radius[i] = radius;
+  }
 }
 
-template<class TImage>
-void OilPaintingImageFilter<TImage>::BeforeThreadedGenerateData()
+template <class TImage>
+void
+OilPaintingImageFilter<TImage>::BeforeThreadedGenerateData()
 {
-    using CalculatorType = itk::MinimumMaximumImageCalculator< TImage >;
-    typename CalculatorType::Pointer calculatorI = CalculatorType::New();
-    calculatorI->SetImage( this->GetInput() );
-    calculatorI->Compute();
-    m_Maximum = calculatorI->GetMaximum();
-    m_Minimum = calculatorI->GetMinimum();
+  using CalculatorType = itk::MinimumMaximumImageCalculator<TImage>;
+  typename CalculatorType::Pointer calculatorI = CalculatorType::New();
+  calculatorI->SetImage(this->GetInput());
+  calculatorI->Compute();
+  m_Maximum = calculatorI->GetMaximum();
+  m_Minimum = calculatorI->GetMinimum();
 }
 
-template<class TImage>
-void OilPaintingImageFilter<TImage>
-::DynamicThreadedGenerateData(const typename TImage::RegionType& outputRegionForThread)
+template <class TImage>
+void
+OilPaintingImageFilter<TImage>::DynamicThreadedGenerateData(const typename TImage::RegionType & outputRegionForThread)
 {
   typename TImage::ConstPointer input = this->GetInput();
-  typename TImage::Pointer output = this->GetOutput();
+  typename TImage::Pointer      output = this->GetOutput();
 
-  itk::ImageRegionIterator<TImage> out(output, outputRegionForThread);
+  itk::ImageRegionIterator<TImage>       out(output, outputRegionForThread);
   itk::ConstNeighborhoodIterator<TImage> it(m_Radius, input, outputRegionForThread);
 
-  unsigned long long *bins=new unsigned long long[m_NumberOfBins];
+  unsigned long long * bins = new unsigned long long[m_NumberOfBins];
 
-  while(!out.IsAtEnd())
+  while (!out.IsAtEnd())
   {
-    for (unsigned int i=0; i<m_NumberOfBins; i++)
-      {
-      bins[i]=0; //reset histogram
-      }
+    for (unsigned int i = 0; i < m_NumberOfBins; i++)
+    {
+      bins[i] = 0; // reset histogram
+    }
 
-    //create histogram of values within the radius
+    // create histogram of values within the radius
     for (unsigned int i = 0; i < it.Size(); ++i)
-      {
-      typename TImage::ValueType val=it.GetPixel(i);
-      bins[int((m_NumberOfBins-0.001)*(val-m_Minimum)/(m_Maximum-m_Minimum))]++;
-      //casting to int rounds towards zero
-      //without -0.001, when val=max then we would go over the upper bound (index m_NumberOfBins)
-      }
+    {
+      typename TImage::ValueType val = it.GetPixel(i);
+      bins[int((m_NumberOfBins - 0.001) * (val - m_Minimum) / (m_Maximum - m_Minimum))]++;
+      // casting to int rounds towards zero
+      // without -0.001, when val=max then we would go over the upper bound (index m_NumberOfBins)
+    }
 
-    //find the peak
-    unsigned maxIndex=0;
-    unsigned long long maxBin=bins[0];
-    for (unsigned int i=1; i<m_NumberOfBins; i++)
+    // find the peak
+    unsigned           maxIndex = 0;
+    unsigned long long maxBin = bins[0];
+    for (unsigned int i = 1; i < m_NumberOfBins; i++)
+    {
+      if (bins[i] > maxBin)
       {
-      if (bins[i]>maxBin)
-        {
-        maxBin=bins[i];
-        maxIndex=i;
-        }
+        maxBin = bins[i];
+        maxIndex = i;
       }
+    }
 
-    //set middle value of a bin's range as intensity
-    out.Set((maxIndex+0.5)*(m_Maximum-m_Minimum)/m_NumberOfBins);
+    // set middle value of a bin's range as intensity
+    out.Set((maxIndex + 0.5) * (m_Maximum - m_Minimum) / m_NumberOfBins);
 
     ++it;
     ++out;
   }
 
-  delete [] bins; //dealloc array
+  delete[] bins; // dealloc array
 }
 
-}// end namespace
+} // namespace itk
 
 #endif //__itkOilPaintingImageFilter_hxx

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/Code.cxx
@@ -21,17 +21,18 @@
 #include "itkCurvatureAnisotropicDiffusionImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << " <numberOfIterations> <timeStep> <conductance>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -39,45 +40,45 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = float;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  const int numberOfIterations     = std::stoi( argv[3] );
-  const InputPixelType timeStep    = std::stod( argv[4] );
-  const InputPixelType conductance = std::stod( argv[5] );
+  const int            numberOfIterations = std::stoi(argv[3]);
+  const InputPixelType timeStep = std::stod(argv[4]);
+  const InputPixelType conductance = std::stod(argv[5]);
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::CurvatureAnisotropicDiffusionImageFilter< InputImageType, InputImageType >;
+  using FilterType = itk::CurvatureAnisotropicDiffusionImageFilter<InputImageType, InputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetNumberOfIterations( numberOfIterations );
-  filter->SetTimeStep( timeStep );
-  filter->SetConductanceParameter( conductance );
+  filter->SetInput(reader->GetOutput());
+  filter->SetNumberOfIterations(numberOfIterations);
+  filter->SetTimeStep(timeStep);
+  filter->SetConductanceParameter(conductance);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, OutputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, OutputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( filter->GetOutput() );
-  rescaler->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  rescaler->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  rescaler->SetInput(filter->GetOutput());
+  rescaler->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  rescaler->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(rescaler->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/Code.cxx
@@ -21,17 +21,18 @@
 #include "itkCurvatureFlowImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << " <numberOfIterations> <timeStep>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -39,43 +40,43 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = float;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  const int numberOfIterations     = std::stoi( argv[3] );
-  const InputPixelType timeStep    = std::stod( argv[4] );
+  const int            numberOfIterations = std::stoi(argv[3]);
+  const InputPixelType timeStep = std::stod(argv[4]);
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::CurvatureFlowImageFilter< InputImageType, InputImageType >;
+  using FilterType = itk::CurvatureFlowImageFilter<InputImageType, InputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetNumberOfIterations( numberOfIterations );
-  filter->SetTimeStep( timeStep );
+  filter->SetInput(reader->GetOutput());
+  filter->SetNumberOfIterations(numberOfIterations);
+  filter->SetTimeStep(timeStep);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, OutputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, OutputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( filter->GetOutput() );
-  rescaler->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  rescaler->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  rescaler->SetInput(filter->GetOutput());
+  rescaler->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  rescaler->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(rescaler->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/Code.cxx
@@ -21,17 +21,18 @@
 #include "itkGradientAnisotropicDiffusionImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << " <numberOfIterations> <timeStep> <conductance>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -39,45 +40,45 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = float;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  const int numberOfIterations     = std::stoi( argv[3] );
-  const InputPixelType timeStep    = std::stod( argv[4] );
-  const InputPixelType conductance = std::stod( argv[5] );
+  const int            numberOfIterations = std::stoi(argv[3]);
+  const InputPixelType timeStep = std::stod(argv[4]);
+  const InputPixelType conductance = std::stod(argv[5]);
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::GradientAnisotropicDiffusionImageFilter< InputImageType, InputImageType >;
+  using FilterType = itk::GradientAnisotropicDiffusionImageFilter<InputImageType, InputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetNumberOfIterations( numberOfIterations );
-  filter->SetTimeStep( timeStep );
-  filter->SetConductanceParameter( conductance );
+  filter->SetInput(reader->GetOutput());
+  filter->SetNumberOfIterations(numberOfIterations);
+  filter->SetTimeStep(timeStep);
+  filter->SetConductanceParameter(conductance);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, OutputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, OutputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( filter->GetOutput() );
-  rescaler->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  rescaler->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  rescaler->SetInput(filter->GetOutput());
+  rescaler->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  rescaler->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(rescaler->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx
@@ -21,52 +21,52 @@
 #include "itkImageFileWriter.h"
 #include "itkGradientAnisotropicDiffusionImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << " <OutputFileName>";
     std::cerr << " <NumberOfIterations> ";
     std::cerr << " <Conductance>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   using OutputPixelType = float;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
-  using FilterType = itk::GradientAnisotropicDiffusionImageFilter< InputImageType,
-    OutputImageType >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using FilterType = itk::GradientAnisotropicDiffusionImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetNumberOfIterations( std::stoi( argv[3] ) );
-  filter->SetTimeStep( 0.125 );
-  filter->SetConductanceParameter( std::stod( argv[4] ) );
+  filter->SetInput(reader->GetOutput());
+  filter->SetNumberOfIterations(std::stoi(argv[3]));
+  filter->SetTimeStep(0.125);
+  filter->SetConductanceParameter(std::stod(argv[4]));
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/Code.cxx
@@ -27,84 +27,77 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: "<< std::endl;
-        std::cerr << argv[0];
-        std::cerr << " InputFileName";
-        std::cerr << " [NumberOfIterations] ";
-        std::cerr << " [Conductance]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0];
+    std::cerr << " InputFileName";
+    std::cerr << " [NumberOfIterations] ";
+    std::cerr << " [Conductance]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // 0) Parse arguments
-    std::string inputFileName = argv[1];
+  // 0) Parse arguments
+  std::string inputFileName = argv[1];
 
-    using FloatImageType = itk::Image< itk::Vector<float, 3>, 2 >;
-    using RGBImageType = itk::Image< itk::RGBPixel<float>, 2 >;
+  using FloatImageType = itk::Image<itk::Vector<float, 3>, 2>;
+  using RGBImageType = itk::Image<itk::RGBPixel<float>, 2>;
 
-    // 1) Read the RGB image
-    using ReaderType = itk::ImageFileReader< RGBImageType >;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFileName );
+  // 1) Read the RGB image
+  using ReaderType = itk::ImageFileReader<RGBImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFileName);
 
-    // 2) Cast to Vector image for processing
-    using AdaptorInputType = itk::RGBToVectorImageAdaptor<RGBImageType>;
-    AdaptorInputType::Pointer adaptInput = AdaptorInputType::New();
-    adaptInput->SetImage(reader->GetOutput());
-    using CastInputType = itk::CastImageFilter<AdaptorInputType,FloatImageType>;
-    CastInputType::Pointer castInput = CastInputType::New();
-    castInput->SetInput(adaptInput);
+  // 2) Cast to Vector image for processing
+  using AdaptorInputType = itk::RGBToVectorImageAdaptor<RGBImageType>;
+  AdaptorInputType::Pointer adaptInput = AdaptorInputType::New();
+  adaptInput->SetImage(reader->GetOutput());
+  using CastInputType = itk::CastImageFilter<AdaptorInputType, FloatImageType>;
+  CastInputType::Pointer castInput = CastInputType::New();
+  castInput->SetInput(adaptInput);
 
-    // 3) Smooth the image
-    using VectorGradientAnisotropicDiffusionImageFilterType = itk::VectorGradientAnisotropicDiffusionImageFilter< FloatImageType,
-            FloatImageType >;
-    VectorGradientAnisotropicDiffusionImageFilterType::Pointer filter =
-            VectorGradientAnisotropicDiffusionImageFilterType::New();
-    filter->SetInput( castInput->GetOutput() );
-    filter->SetTimeStep(0.125);
-    if (argc > 2)
-    {
-        filter->SetNumberOfIterations(atoi(argv[2]));
-    }
-    if (argc > 3)
-    {
-        filter->SetConductanceParameter(atof(argv[3]));
-    }
+  // 3) Smooth the image
+  using VectorGradientAnisotropicDiffusionImageFilterType =
+    itk::VectorGradientAnisotropicDiffusionImageFilter<FloatImageType, FloatImageType>;
+  VectorGradientAnisotropicDiffusionImageFilterType::Pointer filter =
+    VectorGradientAnisotropicDiffusionImageFilterType::New();
+  filter->SetInput(castInput->GetOutput());
+  filter->SetTimeStep(0.125);
+  if (argc > 2)
+  {
+    filter->SetNumberOfIterations(atoi(argv[2]));
+  }
+  if (argc > 3)
+  {
+    filter->SetConductanceParameter(atof(argv[3]));
+  }
 
-    // 4) Cast the Vector image to an RGB image for display
-    using AdaptorOutputType = itk::VectorToRGBImageAdaptor<FloatImageType>;
-    AdaptorOutputType::Pointer adaptOutput = AdaptorOutputType::New();
-    adaptOutput->SetImage(filter->GetOutput());
-    using CastOutputType = itk::CastImageFilter<AdaptorOutputType,RGBImageType>;
-    CastOutputType::Pointer castOutput = CastOutputType::New();
-    castOutput->SetInput(adaptOutput);
+  // 4) Cast the Vector image to an RGB image for display
+  using AdaptorOutputType = itk::VectorToRGBImageAdaptor<FloatImageType>;
+  AdaptorOutputType::Pointer adaptOutput = AdaptorOutputType::New();
+  adaptOutput->SetImage(filter->GetOutput());
+  using CastOutputType = itk::CastImageFilter<AdaptorOutputType, RGBImageType>;
+  CastOutputType::Pointer castOutput = CastOutputType::New();
+  castOutput->SetInput(adaptOutput);
 
-    // 5) Display the input and smoothed images
+  // 5) Display the input and smoothed images
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddRGBImage(
-            reader->GetOutput(),
-            true,
-            itksys::SystemTools::GetFilenameName(inputFileName));
+  QuickView viewer;
+  viewer.AddRGBImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFileName));
 
-    std::stringstream desc;
-    desc << "VectorGradientAnisotropicDiffusionImageFilter\niterations: "
-         << filter->GetNumberOfIterations() << " conductance: "
-         << filter->GetConductanceParameter();
-    viewer.AddRGBImage(
-            castOutput->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "VectorGradientAnisotropicDiffusionImageFilter\niterations: " << filter->GetNumberOfIterations()
+       << " conductance: " << filter->GetConductanceParameter();
+  viewer.AddRGBImage(castOutput->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/Code.cxx
@@ -26,85 +26,78 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: "<< std::endl;
-        std::cerr << argv[0];
-        std::cerr << " InputFileName";
-        std::cerr << " [NumberOfIterations] ";
-        std::cerr << " [Conductance]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0];
+    std::cerr << " InputFileName";
+    std::cerr << " [NumberOfIterations] ";
+    std::cerr << " [Conductance]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // 0) Parse arguments
-    std::string inputFileName = argv[1];
+  // 0) Parse arguments
+  std::string inputFileName = argv[1];
 
-    using FloatImageType = itk::Image< itk::Vector<float, 3>, 2 >;
-    using RGBImageType = itk::Image< itk::RGBPixel<float>, 2 >;
+  using FloatImageType = itk::Image<itk::Vector<float, 3>, 2>;
+  using RGBImageType = itk::Image<itk::RGBPixel<float>, 2>;
 
-    // 1) Read the RGB image
-    using ReaderType = itk::ImageFileReader< RGBImageType >;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFileName );
+  // 1) Read the RGB image
+  using ReaderType = itk::ImageFileReader<RGBImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFileName);
 
-    // 2) Cast to Vector image for processing
-    using AdaptorInputType = itk::RGBToVectorImageAdaptor<RGBImageType>;
-    AdaptorInputType::Pointer adaptInput = AdaptorInputType::New();
-    adaptInput->SetImage(reader->GetOutput());
-    using CastInputType = itk::CastImageFilter<AdaptorInputType,FloatImageType>;
-    CastInputType::Pointer castInput = CastInputType::New();
-    castInput->SetInput(adaptInput);
+  // 2) Cast to Vector image for processing
+  using AdaptorInputType = itk::RGBToVectorImageAdaptor<RGBImageType>;
+  AdaptorInputType::Pointer adaptInput = AdaptorInputType::New();
+  adaptInput->SetImage(reader->GetOutput());
+  using CastInputType = itk::CastImageFilter<AdaptorInputType, FloatImageType>;
+  CastInputType::Pointer castInput = CastInputType::New();
+  castInput->SetInput(adaptInput);
 
-    // 3) Smooth the image
-    using VectorCurvatureAnisotropicDiffusionImageFilterType = itk::VectorCurvatureAnisotropicDiffusionImageFilter< FloatImageType,
-            FloatImageType >;
-    VectorCurvatureAnisotropicDiffusionImageFilterType::Pointer filter =
-            VectorCurvatureAnisotropicDiffusionImageFilterType::New();
-    filter->SetInput( castInput->GetOutput() );
-    filter->SetTimeStep(0.125);
-    if (argc > 2)
-    {
-        filter->SetNumberOfIterations(atoi(argv[2]));
-    }
-    if (argc > 3)
-    {
-        filter->SetConductanceParameter(atof(argv[3]));
-    }
+  // 3) Smooth the image
+  using VectorCurvatureAnisotropicDiffusionImageFilterType =
+    itk::VectorCurvatureAnisotropicDiffusionImageFilter<FloatImageType, FloatImageType>;
+  VectorCurvatureAnisotropicDiffusionImageFilterType::Pointer filter =
+    VectorCurvatureAnisotropicDiffusionImageFilterType::New();
+  filter->SetInput(castInput->GetOutput());
+  filter->SetTimeStep(0.125);
+  if (argc > 2)
+  {
+    filter->SetNumberOfIterations(atoi(argv[2]));
+  }
+  if (argc > 3)
+  {
+    filter->SetConductanceParameter(atof(argv[3]));
+  }
 
-    // 4) Cast the Vector image to an RGB image for display
-    using AdaptorOutputType = itk::VectorToRGBImageAdaptor<FloatImageType>;
-    AdaptorOutputType::Pointer adaptOutput = AdaptorOutputType::New();
-    adaptOutput->SetImage(filter->GetOutput());
-    using CastOutputType = itk::CastImageFilter<AdaptorOutputType,RGBImageType>;
-    CastOutputType::Pointer castOutput = CastOutputType::New();
-    castOutput->SetInput(adaptOutput);
+  // 4) Cast the Vector image to an RGB image for display
+  using AdaptorOutputType = itk::VectorToRGBImageAdaptor<FloatImageType>;
+  AdaptorOutputType::Pointer adaptOutput = AdaptorOutputType::New();
+  adaptOutput->SetImage(filter->GetOutput());
+  using CastOutputType = itk::CastImageFilter<AdaptorOutputType, RGBImageType>;
+  CastOutputType::Pointer castOutput = CastOutputType::New();
+  castOutput->SetInput(adaptOutput);
 
-    // 5) Display the input and smoothed images
+  // 5) Display the input and smoothed images
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddRGBImage(
-            reader->GetOutput(),
-            true,
-            itksys::SystemTools::GetFilenameName(inputFileName));
+  QuickView viewer;
+  viewer.AddRGBImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFileName));
 
-    std::stringstream desc;
-    desc << "VectorCurvatureAnisotropicDiffusionImageFilter\niterations: "
-         << filter->GetNumberOfIterations() << " conductance: "
-         << filter->GetConductanceParameter();
-    viewer.AddRGBImage(
-            castOutput->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "VectorCurvatureAnisotropicDiffusionImageFilter\niterations: " << filter->GetNumberOfIterations()
+       << " conductance: " << filter->GetConductanceParameter();
+  viewer.AddRGBImage(castOutput->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/Code.cxx
+++ b/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/Code.cxx
@@ -20,66 +20,67 @@
 #include "itkImageFileWriter.h"
 #include "itkAntiAliasBinaryImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 3 )
-    {
+  if (argc < 3)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " <inputImage> <outputImage>";
     std::cerr << " [maximumRMSError]";
     std::cerr << " [numberOfIterations]";
     std::cerr << " [numberOfLayers]" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  double maximumRMSError = 0.001;
-  if( argc > 3 )
-    {
-    maximumRMSError = std::stod( argv[3] );
-    }
+  double       maximumRMSError = 0.001;
+  if (argc > 3)
+  {
+    maximumRMSError = std::stod(argv[3]);
+  }
   int numberOfIterations = 50;
-  if( argc > 4 )
-    {
-    numberOfIterations = std::stoi( argv[4] );
-    }
+  if (argc > 4)
+  {
+    numberOfIterations = std::stoi(argv[4]);
+  }
   int numberOfLayers = 2;
-  if( argc > 5 )
-    {
-    numberOfLayers = std::stoi( argv[5] );
-    }
+  if (argc > 5)
+  {
+    numberOfLayers = std::stoi(argv[5]);
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = float;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::AntiAliasBinaryImageFilter< ImageType, ImageType >;
+  using FilterType = itk::AntiAliasBinaryImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetMaximumRMSError( maximumRMSError );
-  filter->SetNumberOfIterations( numberOfIterations );
-  filter->SetNumberOfLayers( numberOfLayers );
+  filter->SetInput(reader->GetOutput());
+  filter->SetMaximumRMSError(maximumRMSError);
+  filter->SetNumberOfIterations(numberOfIterations);
+  filter->SetNumberOfLayers(numberOfLayers);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/Code.cxx
@@ -22,110 +22,106 @@
 #include "itkSubtractImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 namespace
 {
-    using ImageType = itk::Image<unsigned char, 2>;
+using ImageType = itk::Image<unsigned char, 2>;
 }
 
-static void CreateImage(ImageType* const image);
+static void
+CreateImage(ImageType * const image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image;
+  ImageType::Pointer image;
 
-    if(argc == 1)
-    {
-        image = ImageType::New();
-        CreateImage(image);
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-        image = reader->GetOutput();
-    }
+  if (argc == 1)
+  {
+    image = ImageType::New();
+    CreateImage(image);
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+  }
 
-    unsigned int radius = 5;
-    if (argc == 3)
-    {
-        std::stringstream ss(argv[2]);
-        ss >> radius;
-    }
-    std::cout << "Radius: " << radius << std::endl;
-    using StructuringElementType = itk::BinaryBallStructuringElement<ImageType::PixelType, ImageType::ImageDimension>;
-    StructuringElementType structuringElement;
-    structuringElement.SetRadius(radius);
-    structuringElement.CreateStructuringElement();
+  unsigned int radius = 5;
+  if (argc == 3)
+  {
+    std::stringstream ss(argv[2]);
+    ss >> radius;
+  }
+  std::cout << "Radius: " << radius << std::endl;
+  using StructuringElementType = itk::BinaryBallStructuringElement<ImageType::PixelType, ImageType::ImageDimension>;
+  StructuringElementType structuringElement;
+  structuringElement.SetRadius(radius);
+  structuringElement.CreateStructuringElement();
 
-    using BinaryMorphologicalClosingImageFilterType = itk::BinaryMorphologicalClosingImageFilter <ImageType, ImageType, StructuringElementType>;
-    BinaryMorphologicalClosingImageFilterType::Pointer closingFilter
-            = BinaryMorphologicalClosingImageFilterType::New();
-    closingFilter->SetInput(image);
-    closingFilter->SetKernel(structuringElement);
-    closingFilter->Update();
+  using BinaryMorphologicalClosingImageFilterType =
+    itk::BinaryMorphologicalClosingImageFilter<ImageType, ImageType, StructuringElementType>;
+  BinaryMorphologicalClosingImageFilterType::Pointer closingFilter = BinaryMorphologicalClosingImageFilterType::New();
+  closingFilter->SetInput(image);
+  closingFilter->SetKernel(structuringElement);
+  closingFilter->Update();
 
-    using SubtractType = itk::SubtractImageFilter<ImageType>;
-    SubtractType::Pointer diff = SubtractType::New();
-    diff->SetInput1(closingFilter->GetOutput());
-    diff->SetInput2(image);
+  using SubtractType = itk::SubtractImageFilter<ImageType>;
+  SubtractType::Pointer diff = SubtractType::New();
+  diff->SetInput1(closingFilter->GetOutput());
+  diff->SetInput2(image);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    std::stringstream desc;
-    desc << "Original ";
-    viewer.AddImage(image.GetPointer(),
-                    true,
-                    desc.str());
+  QuickView         viewer;
+  std::stringstream desc;
+  desc << "Original ";
+  viewer.AddImage(image.GetPointer(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "BinaryClosing, radius = " << radius;
-    viewer.AddImage(closingFilter->GetOutput(),
-                    true,
-                    desc2.str());
+  std::stringstream desc2;
+  desc2 << "BinaryClosing, radius = " << radius;
+  viewer.AddImage(closingFilter->GetOutput(), true, desc2.str());
 
-    std::stringstream desc3;
-    desc3 << "BinaryClosing - Original";
-    viewer.AddImage(diff->GetOutput(),
-                    true,
-                    desc3.str());
-    viewer.Visualize();
+  std::stringstream desc3;
+  desc3 << "BinaryClosing - Original";
+  viewer.AddImage(diff->GetOutput(), true, desc3.str());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(ImageType* const image)
+void
+CreateImage(ImageType * const image)
 {
-    // Create an image with 2 connected components
-    itk::Index<2> corner = {{0,0}};
+  // Create an image with 2 connected components
+  itk::Index<2> corner = { { 0, 0 } };
 
-    itk::Size<2> size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  itk::Size<2> size;
+  unsigned int NumRows = 200;
+  unsigned int NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    itk::ImageRegion<2> region(corner, size);
+  itk::ImageRegion<2> region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make a square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            itk::Index<2> pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      itk::Index<2> pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 50);
-        }
+      image->SetPixel(pixelIndex, 50);
     }
+  }
 }
-

--- a/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.cxx
@@ -22,55 +22,53 @@
 #include "itkFlatStructuringElement.h"
 #include "itkBinaryDilateImageFilter.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc < 4 )
-    {
+  if (argc < 4)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " <inputImage> <outputImage> <radius>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
-  const char * inputImage = argv[1];
-  const char * outputImage = argv[2];
-  const unsigned int radiusValue = std::stoi( argv[3] );
+  }
+  const char *       inputImage = argv[1];
+  const char *       outputImage = argv[2];
+  const unsigned int radiusValue = std::stoi(argv[3]);
 
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using StructuringElementType = itk::FlatStructuringElement< Dimension >;
+  using StructuringElementType = itk::FlatStructuringElement<Dimension>;
   StructuringElementType::RadiusType radius;
-  radius.Fill( radiusValue );
-  StructuringElementType structuringElement =
-    StructuringElementType::Ball( radius );
+  radius.Fill(radiusValue);
+  StructuringElementType structuringElement = StructuringElementType::Ball(radius);
 
-  using BinaryDilateImageFilterType = itk::BinaryDilateImageFilter< ImageType, ImageType,
-    StructuringElementType >;
+  using BinaryDilateImageFilterType = itk::BinaryDilateImageFilter<ImageType, ImageType, StructuringElementType>;
 
-  BinaryDilateImageFilterType::Pointer dilateFilter =
-    BinaryDilateImageFilterType::New();
-  dilateFilter->SetInput( reader->GetOutput() );
-  dilateFilter->SetKernel( structuringElement );
+  BinaryDilateImageFilterType::Pointer dilateFilter = BinaryDilateImageFilterType::New();
+  dilateFilter->SetInput(reader->GetOutput());
+  dilateFilter->SetKernel(structuringElement);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( dilateFilter->GetOutput() );
-  writer->SetFileName( outputImage );
+  writer->SetInput(dilateFilter->GetOutput());
+  writer->SetFileName(outputImage);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.cxx
@@ -22,55 +22,53 @@
 #include "itkBinaryErodeImageFilter.h"
 #include "itkFlatStructuringElement.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 4 )
-    {
+  if (argc < 4)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " <inputImage> <outputImage> <radius>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
-  const char * inputImage = argv[1];
-  const char * outputImage = argv[2];
-  const unsigned int radiusValue = std::stoi( argv[3] );
+  }
+  const char *       inputImage = argv[1];
+  const char *       outputImage = argv[2];
+  const unsigned int radiusValue = std::stoi(argv[3]);
 
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using StructuringElementType = itk::FlatStructuringElement< Dimension >;
+  using StructuringElementType = itk::FlatStructuringElement<Dimension>;
   StructuringElementType::RadiusType radius;
-  radius.Fill( radiusValue );
-  StructuringElementType structuringElement =
-    StructuringElementType::Ball( radius );
+  radius.Fill(radiusValue);
+  StructuringElementType structuringElement = StructuringElementType::Ball(radius);
 
-  using BinaryErodeImageFilterType = itk::BinaryErodeImageFilter< ImageType, ImageType,
-    StructuringElementType >;
+  using BinaryErodeImageFilterType = itk::BinaryErodeImageFilter<ImageType, ImageType, StructuringElementType>;
 
-  BinaryErodeImageFilterType::Pointer erodeFilter =
-    BinaryErodeImageFilterType::New();
-  erodeFilter->SetInput( reader->GetOutput() );
-  erodeFilter->SetKernel( structuringElement );
+  BinaryErodeImageFilterType::Pointer erodeFilter = BinaryErodeImageFilterType::New();
+  erodeFilter->SetInput(reader->GetOutput());
+  erodeFilter->SetKernel(structuringElement);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( erodeFilter->GetOutput() );
-  writer->SetFileName( outputImage );
+  writer->SetInput(erodeFilter->GetOutput());
+  writer->SetFileName(outputImage);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/Code.cxx
@@ -22,109 +22,106 @@
 #include "itkSubtractImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 namespace
 {
-    using ImageType = itk::Image<unsigned char, 2>;
+using ImageType = itk::Image<unsigned char, 2>;
 }
 
-static void CreateImage(ImageType* const image);
+static void
+CreateImage(ImageType * const image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image;
+  ImageType::Pointer image;
 
-    if(argc == 1)
-    {
-        image = ImageType::New();
-        CreateImage(image);
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-        image = reader->GetOutput();
-    }
+  if (argc == 1)
+  {
+    image = ImageType::New();
+    CreateImage(image);
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+  }
 
-    unsigned int radius = 5;
-    if (argc == 3)
-    {
-        std::stringstream ss(argv[2]);
-        ss >> radius;
-    }
-    std::cout << "Radius: " << radius << std::endl;
-    using StructuringElementType = itk::BinaryBallStructuringElement<ImageType::PixelType, ImageType::ImageDimension>;
-    StructuringElementType structuringElement;
-    structuringElement.SetRadius(radius);
-    structuringElement.CreateStructuringElement();
+  unsigned int radius = 5;
+  if (argc == 3)
+  {
+    std::stringstream ss(argv[2]);
+    ss >> radius;
+  }
+  std::cout << "Radius: " << radius << std::endl;
+  using StructuringElementType = itk::BinaryBallStructuringElement<ImageType::PixelType, ImageType::ImageDimension>;
+  StructuringElementType structuringElement;
+  structuringElement.SetRadius(radius);
+  structuringElement.CreateStructuringElement();
 
-    using BinaryMorphologicalOpeningImageFilterType = itk::BinaryMorphologicalOpeningImageFilter <ImageType, ImageType, StructuringElementType>;
-    BinaryMorphologicalOpeningImageFilterType::Pointer openingFilter
-            = BinaryMorphologicalOpeningImageFilterType::New();
-    openingFilter->SetInput(image);
-    openingFilter->SetKernel(structuringElement);
-    openingFilter->Update();
+  using BinaryMorphologicalOpeningImageFilterType =
+    itk::BinaryMorphologicalOpeningImageFilter<ImageType, ImageType, StructuringElementType>;
+  BinaryMorphologicalOpeningImageFilterType::Pointer openingFilter = BinaryMorphologicalOpeningImageFilterType::New();
+  openingFilter->SetInput(image);
+  openingFilter->SetKernel(structuringElement);
+  openingFilter->Update();
 
-    using SubtractType = itk::SubtractImageFilter<ImageType>;
-    SubtractType::Pointer diff = SubtractType::New();
-    diff->SetInput1(image);
-    diff->SetInput2(openingFilter->GetOutput());
+  using SubtractType = itk::SubtractImageFilter<ImageType>;
+  SubtractType::Pointer diff = SubtractType::New();
+  diff->SetInput1(image);
+  diff->SetInput2(openingFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    std::stringstream desc;
-    desc << "Original ";
-    viewer.AddImage(image.GetPointer(),
-                    true,
-                    desc.str());
+  QuickView         viewer;
+  std::stringstream desc;
+  desc << "Original ";
+  viewer.AddImage(image.GetPointer(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "BinaryOpening, radius = " << radius;
-    viewer.AddImage(openingFilter->GetOutput(),
-                    true,
-                    desc2.str());
+  std::stringstream desc2;
+  desc2 << "BinaryOpening, radius = " << radius;
+  viewer.AddImage(openingFilter->GetOutput(), true, desc2.str());
 
-    std::stringstream desc3;
-    desc3 << "Original - BinaryOpening";
-    viewer.AddImage(diff->GetOutput(),
-                    true,
-                    desc3.str());
-    viewer.Visualize();
+  std::stringstream desc3;
+  desc3 << "Original - BinaryOpening";
+  viewer.AddImage(diff->GetOutput(), true, desc3.str());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(ImageType* const image)
+void
+CreateImage(ImageType * const image)
 {
-    // Create an image with 2 connected components
-    itk::Index<2> corner = {{0,0}};
+  // Create an image with 2 connected components
+  itk::Index<2> corner = { { 0, 0 } };
 
-    itk::Size<2> size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  itk::Size<2> size;
+  unsigned int NumRows = 200;
+  unsigned int NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    itk::ImageRegion<2> region(corner, size);
+  itk::ImageRegion<2> region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make a square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            itk::Index<2> pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      itk::Index<2> pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 50);
-        }
+      image->SetPixel(pixelIndex, 50);
     }
+  }
 }

--- a/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/Code.cxx
@@ -22,79 +22,80 @@
 #include "itkImageFileWriter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 template <typename TImage>
-void CreateImage(TImage* const image);
+void
+CreateImage(TImage * const image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-//   std::cerr << "Usage: " << std::endl;
-//   std::cerr << argv[0] << " InputImageFile OutputImageFile [iteration]" << std::endl;
+  //   std::cerr << "Usage: " << std::endl;
+  //   std::cerr << argv[0] << " InputImageFile OutputImageFile [iteration]" << std::endl;
 
-    using ImageType = itk::Image<unsigned char, 2>;
-    ImageType::Pointer image;
+  using ImageType = itk::Image<unsigned char, 2>;
+  ImageType::Pointer image;
 
-    unsigned int iteration = 1;
+  unsigned int iteration = 1;
 
-    if(argc < 3)
-    {
-        image = ImageType::New();
-        CreateImage(image.GetPointer());
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        image = reader->GetOutput();
-        std::stringstream ssIteration(argv[2]);
-    }
+  if (argc < 3)
+  {
+    image = ImageType::New();
+    CreateImage(image.GetPointer());
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    image = reader->GetOutput();
+    std::stringstream ssIteration(argv[2]);
+  }
 
-    using BinaryPruningImageFilterType = itk::BinaryPruningImageFilter <ImageType, ImageType >;
-    BinaryPruningImageFilterType::Pointer pruneFilter
-            = BinaryPruningImageFilterType::New();
-    pruneFilter->SetInput(image);
-    pruneFilter->SetIteration(iteration);
-    pruneFilter->GetOutput();
+  using BinaryPruningImageFilterType = itk::BinaryPruningImageFilter<ImageType, ImageType>;
+  BinaryPruningImageFilterType::Pointer pruneFilter = BinaryPruningImageFilterType::New();
+  pruneFilter->SetInput(image);
+  pruneFilter->SetIteration(iteration);
+  pruneFilter->GetOutput();
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(image.GetPointer());
-    viewer.AddImage(pruneFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage(image.GetPointer());
+  viewer.AddImage(pruneFilter->GetOutput());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
-    // This function creates a 2D image consisting of a black background,
-    // a large square of a non-zero pixel value, and a single "erroneous" pixel
-    // near the square.
-    typename TImage::IndexType corner = {{0,0}};
+  // This function creates a 2D image consisting of a black background,
+  // a large square of a non-zero pixel value, and a single "erroneous" pixel
+  // near the square.
+  typename TImage::IndexType corner = { { 0, 0 } };
 
-    typename TImage::SizeType size = {{200,200}};
+  typename TImage::SizeType size = { { 200, 200 } };
 
-    typename TImage::RegionType region(corner, size);
+  typename TImage::RegionType region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(int r = 40; r < 100; r++)
+  // Make a square
+  for (int r = 40; r < 100; r++)
+  {
+    for (int c = 40; c < 100; c++)
     {
-        for(int c = 40; c < 100; c++)
-        {
-            typename TImage::IndexType pixelIndex = {{r,c}};
-            image->SetPixel(pixelIndex, 50);
-        }
+      typename TImage::IndexType pixelIndex = { { r, c } };
+      image->SetPixel(pixelIndex, 50);
     }
+  }
 
-    typename TImage::IndexType pixelIndex = {{102, 102}};
+  typename TImage::IndexType pixelIndex = { { 102, 102 } };
 
-    image->SetPixel(pixelIndex, 50);
+  image->SetPixel(pixelIndex, 50);
 }
-

--- a/src/Filtering/BinaryMathematicalMorphology/ThinImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/ThinImage/Code.cxx
@@ -23,78 +23,83 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void WriteImage(const ImageType::Pointer image, const std::string& fileName);
-static void CreateImage(ImageType::Pointer image);
+static void
+WriteImage(const ImageType::Pointer image, const std::string & fileName);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image = ImageType::New();
-    if( argc == 2)
-    {
-        using ImageReader = itk::ImageFileReader<ImageType>;
-        ImageReader::Pointer reader = ImageReader::New();
-        std::string fileName = argv[1];
-        reader->SetFileName(fileName);
-        reader->Update();
-        image = reader->GetOutput();
-    }
-    else
-    {
-        CreateImage(image);
-        WriteImage(image, "input.png");
-    }
+  ImageType::Pointer image = ImageType::New();
+  if (argc == 2)
+  {
+    using ImageReader = itk::ImageFileReader<ImageType>;
+    ImageReader::Pointer reader = ImageReader::New();
+    std::string          fileName = argv[1];
+    reader->SetFileName(fileName);
+    reader->Update();
+    image = reader->GetOutput();
+  }
+  else
+  {
+    CreateImage(image);
+    WriteImage(image, "input.png");
+  }
 
-    using BinaryThinningImageFilterType = itk::BinaryThinningImageFilter <ImageType, ImageType>;
-    BinaryThinningImageFilterType::Pointer binaryThinningImageFilter = BinaryThinningImageFilterType::New();
-    binaryThinningImageFilter->SetInput(image);
-    binaryThinningImageFilter->Update();
+  using BinaryThinningImageFilterType = itk::BinaryThinningImageFilter<ImageType, ImageType>;
+  BinaryThinningImageFilterType::Pointer binaryThinningImageFilter = BinaryThinningImageFilterType::New();
+  binaryThinningImageFilter->SetInput(image);
+  binaryThinningImageFilter->Update();
 
-    // Rescale the image so that it can be seen (the output is 0 and 1, we want 0 and 255)
-    using RescaleType = itk::RescaleIntensityImageFilter< ImageType, ImageType >;
-    RescaleType::Pointer rescaler = RescaleType::New();
-    rescaler->SetInput( binaryThinningImageFilter->GetOutput() );
-    rescaler->SetOutputMinimum(0);
-    rescaler->SetOutputMaximum(255);
-    rescaler->Update();
+  // Rescale the image so that it can be seen (the output is 0 and 1, we want 0 and 255)
+  using RescaleType = itk::RescaleIntensityImageFilter<ImageType, ImageType>;
+  RescaleType::Pointer rescaler = RescaleType::New();
+  rescaler->SetInput(binaryThinningImageFilter->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(255);
+  rescaler->Update();
 
-    WriteImage(rescaler->GetOutput(), "output.png");
+  WriteImage(rescaler->GetOutput(), "output.png");
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create an image
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Draw a 5 pixel wide line
-    for(unsigned int i = 20; i < 80; ++i)
+  // Draw a 5 pixel wide line
+  for (unsigned int i = 20; i < 80; ++i)
+  {
+    for (unsigned int j = 50; j < 55; ++j)
     {
-        for(unsigned int j = 50; j < 55; ++j)
-        {
-            itk::Index<2> index;
-            index[0] = i;
-            index[1] = j;
-            image->SetPixel(index, 255);
-        }
+      itk::Index<2> index;
+      index[0] = i;
+      index[1] = j;
+      image->SetPixel(index, 255);
     }
+  }
 }
 
-void WriteImage(const ImageType::Pointer image, const std::string& fileName)
+void
+WriteImage(const ImageType::Pointer image, const std::string & fileName)
 {
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName(fileName);
-    writer->SetInput(image);
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(fileName);
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/Colormap/ApplyAColormapToAnImage/Code.cxx
+++ b/src/Filtering/Colormap/ApplyAColormapToAnImage/Code.cxx
@@ -23,48 +23,49 @@
 #include "itkRGBPixel.h"
 #include "itkScalarToRGBColormapImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using RGBPixelType = itk::RGBPixel< unsigned char >;
-  using RGBImageType = itk::Image< RGBPixelType, Dimension >;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType, Dimension>;
 
-  using RGBFilterType = itk::ScalarToRGBColormapImageFilter< ImageType, RGBImageType>;
+  using RGBFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
   RGBFilterType::Pointer rgbfilter = RGBFilterType::New();
-  rgbfilter->SetInput( reader->GetOutput() );
-  rgbfilter->SetColormap( itk::RGBColormapFilterEnumType::Hot );
+  rgbfilter->SetInput(reader->GetOutput());
+  rgbfilter->SetColormap(itk::RGBColormapFilterEnumType::Hot);
 
-  using WriterType = itk::ImageFileWriter< RGBImageType >;
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( rgbfilter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(rgbfilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Colormap/CreateACustomColormap/Code.cxx
+++ b/src/Filtering/Colormap/CreateACustomColormap/Code.cxx
@@ -28,29 +28,29 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
 
-int main(int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " <InputFileName> <OutputFileName>"
-              << std::endl;
+    std::cerr << argv[0] << " <InputFileName> <OutputFileName>" << std::endl;
 
     return EXIT_FAILURE;
-    }
+  }
 
   using PixelType = unsigned char;
-  using RGBPixelType = itk::RGBPixel< unsigned char >;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
 
-  using RGBImageType = itk::Image< RGBPixelType, 2 >;
-  using ImageType = itk::Image< PixelType, 2 >;
+  using RGBImageType = itk::Image<RGBPixelType, 2>;
+  using ImageType = itk::Image<PixelType, 2>;
 
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using ColormapType = itk::Function::CustomColormapFunction< PixelType, RGBPixelType >;
+  using ColormapType = itk::Function::CustomColormapFunction<PixelType, RGBPixelType>;
   ColormapType::Pointer colormap = ColormapType::New();
 
   ColormapType::ChannelType redChannel;
@@ -60,47 +60,41 @@ int main(int argc, char* argv[] )
   itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer random =
     itk::Statistics::MersenneTwisterRandomVariateGenerator::New();
 
-  random->SetSeed( 0 );
+  random->SetSeed(0);
 
-  for( unsigned int i = 0; i < 255; ++i )
-    {
-    redChannel.push_back(
-      static_cast< ColormapType::RealType >(
-        random->GetUniformVariate( 0., 1.0 ) ) );
+  for (unsigned int i = 0; i < 255; ++i)
+  {
+    redChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(0., 1.0)));
 
-    greenChannel.push_back(
-      static_cast< ColormapType::RealType >(
-        random->GetUniformVariate( 0., 1.0 ) ) );
+    greenChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(0., 1.0)));
 
-    blueChannel.push_back(
-      static_cast< ColormapType::RealType >(
-        random->GetUniformVariate( 0., 1.0 ) ) );
-    }
+    blueChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(0., 1.0)));
+  }
 
-  colormap->SetRedChannel( redChannel );
-  colormap->SetGreenChannel( greenChannel );
-  colormap->SetBlueChannel( blueChannel );
+  colormap->SetRedChannel(redChannel);
+  colormap->SetGreenChannel(greenChannel);
+  colormap->SetBlueChannel(blueChannel);
 
-  using ColormapFilterType = itk::ScalarToRGBColormapImageFilter< ImageType, RGBImageType >;
+  using ColormapFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
   ColormapFilterType::Pointer colormapFilter1 = ColormapFilterType::New();
 
-  colormapFilter1->SetInput( reader->GetOutput() );
-  colormapFilter1->SetColormap( colormap );
+  colormapFilter1->SetInput(reader->GetOutput());
+  colormapFilter1->SetColormap(colormap);
 
-  using WriterType = itk::ImageFileWriter< RGBImageType >;
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( colormapFilter1->GetOutput() );
-  writer->SetFileName( argv[2] );
+  writer->SetInput(colormapFilter1->GetOutput());
+  writer->SetFileName(argv[2]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Colormap/MapScalarsIntoJetColormap/Code.cxx
+++ b/src/Filtering/Colormap/MapScalarsIntoJetColormap/Code.cxx
@@ -18,17 +18,17 @@
 #include "itkJetColormapFunction.h"
 #include "itkRGBPixel.h"
 
-int main( int, char *[])
+int
+main(int, char *[])
 {
-    using PixelType = itk::RGBPixel<unsigned char>;
-    using ColormapType = itk::Function::JetColormapFunction<float, PixelType>;
-    ColormapType::Pointer colormap = ColormapType::New();
+  using PixelType = itk::RGBPixel<unsigned char>;
+  using ColormapType = itk::Function::JetColormapFunction<float, PixelType>;
+  ColormapType::Pointer colormap = ColormapType::New();
 
-    colormap->SetMinimumInputValue(0.0);
-    colormap->SetMaximumInputValue(1.0);
-    std::cout << "0: " << colormap->operator()(0.0f) << std::endl;
-    std::cout << "0.5: " << colormap->operator()(0.5f) << std::endl;
-    std::cout << "1: " << colormap->operator()(1.0f) << std::endl;
-    return EXIT_SUCCESS;
+  colormap->SetMinimumInputValue(0.0);
+  colormap->SetMaximumInputValue(1.0);
+  std::cout << "0: " << colormap->  operator()(0.0f) << std::endl;
+  std::cout << "0.5: " << colormap->operator()(0.5f) << std::endl;
+  std::cout << "1: " << colormap->  operator()(1.0f) << std::endl;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/Convolution/ColorNormalizedCorrelation/Code.cxx
+++ b/src/Filtering/Convolution/ColorNormalizedCorrelation/Code.cxx
@@ -26,7 +26,7 @@
 #include "itkCovariantVector.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 #include <iostream>
@@ -44,120 +44,122 @@ using UnsignedCharVectorImageType = itk::Image<UnsignedCharVectorType, 2>;
 using FloatImageType = itk::Image<float, 2>;
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::string filename = argv[1];
+  std::string filename = argv[1];
 
-    using ReaderType = itk::ImageFileReader<FloatVectorImageType>;
+  using ReaderType = itk::ImageFileReader<FloatVectorImageType>;
 
-    // Read the image
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(filename.c_str());
-    reader->Update();
+  // Read the image
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(filename.c_str());
+  reader->Update();
 
-    // Extract a small region
-    using ExtractFilterType = itk::RegionOfInterestImageFilter< FloatVectorImageType,
-            FloatVectorImageType >;
+  // Extract a small region
+  using ExtractFilterType = itk::RegionOfInterestImageFilter<FloatVectorImageType, FloatVectorImageType>;
 
-    ExtractFilterType::Pointer extractFilter = ExtractFilterType::New();
+  ExtractFilterType::Pointer extractFilter = ExtractFilterType::New();
 
-    FloatImageType::IndexType start;
-    start.Fill(50);
+  FloatImageType::IndexType start;
+  start.Fill(50);
 
-    FloatImageType::SizeType patchSize;
-    patchSize.Fill(51);
+  FloatImageType::SizeType patchSize;
+  patchSize.Fill(51);
 
-    FloatImageType::RegionType desiredRegion(start,patchSize);
+  FloatImageType::RegionType desiredRegion(start, patchSize);
 
-    extractFilter->SetRegionOfInterest(desiredRegion);
-    extractFilter->SetInput(reader->GetOutput());
-    extractFilter->Update();
+  extractFilter->SetRegionOfInterest(desiredRegion);
+  extractFilter->SetInput(reader->GetOutput());
+  extractFilter->Update();
 
-    // Perform normalized correlation
-    // <input type, mask type (not used), output type>
-    using CorrelationFilterType = itk::NormalizedCorrelationImageFilter<FloatVectorImageType, FloatVectorImageType, FloatImageType>;
+  // Perform normalized correlation
+  // <input type, mask type (not used), output type>
+  using CorrelationFilterType =
+    itk::NormalizedCorrelationImageFilter<FloatVectorImageType, FloatVectorImageType, FloatImageType>;
 
-    itk::ImageKernelOperator<FloatVectorType> kernelOperator;
-    kernelOperator.SetImageKernel(extractFilter->GetOutput());
+  itk::ImageKernelOperator<FloatVectorType> kernelOperator;
+  kernelOperator.SetImageKernel(extractFilter->GetOutput());
 
-    // The radius of the kernel must be the radius of the patch, NOT the size of the patch
-    itk::Size<2> radius = extractFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
-    radius[0] = (radius[0]-1) / 2;
-    radius[1] = (radius[1]-1) / 2;
+  // The radius of the kernel must be the radius of the patch, NOT the size of the patch
+  itk::Size<2> radius = extractFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
+  radius[0] = (radius[0] - 1) / 2;
+  radius[1] = (radius[1] - 1) / 2;
 
-    kernelOperator.CreateToRadius(radius);
+  kernelOperator.CreateToRadius(radius);
 
-    CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
-    correlationFilter->SetInput(reader->GetOutput());
-    correlationFilter->SetTemplate(kernelOperator);
-    correlationFilter->Update();
+  CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
+  correlationFilter->SetInput(reader->GetOutput());
+  correlationFilter->SetTemplate(kernelOperator);
+  correlationFilter->Update();
 
-    using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator <FloatImageType>;
+  using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator<FloatImageType>;
 
-    MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter
-            = MinimumMaximumImageCalculatorType::New ();
-    minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
-    minimumMaximumImageCalculatorFilter->Compute();
+  MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter =
+    MinimumMaximumImageCalculatorType::New();
+  minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
+  minimumMaximumImageCalculatorFilter->Compute();
 
-    itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
-    std::cout << "Maximum: " << maximumCorrelationPatchCenter << std::endl;
+  itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
+  std::cout << "Maximum: " << maximumCorrelationPatchCenter << std::endl;
 
-    // Note that the best correlation is at the center of the patch we extracted (ie. (75, 75) rather than the corner (50,50)
+  // Note that the best correlation is at the center of the patch we extracted (ie. (75, 75) rather than the corner
+  // (50,50)
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< FloatImageType, UnsignedCharImageType >;
-    using WriterType = itk::ImageFileWriter<UnsignedCharVectorImageType>;
-    {
-        RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-        rescaleFilter->SetInput(correlationFilter->GetOutput());
-        rescaleFilter->SetOutputMinimum(0);
-        rescaleFilter->SetOutputMaximum(255);
-        rescaleFilter->Update();
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
+  using WriterType = itk::ImageFileWriter<UnsignedCharVectorImageType>;
+  {
+    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+    rescaleFilter->SetInput(correlationFilter->GetOutput());
+    rescaleFilter->SetOutputMinimum(0);
+    rescaleFilter->SetOutputMaximum(255);
+    rescaleFilter->Update();
 
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetInput(rescaleFilter->GetOutput());
-        writer->SetFileName("correlation.png");
-        writer->Update();
-    }
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetInput(rescaleFilter->GetOutput());
+    writer->SetFileName("correlation.png");
+    writer->Update();
+  }
 
-    {
-        RescaleFilterType::Pointer rescaleFilter = RescaleVectorFilterType::New();
-        rescaleFilter->SetInput(extractFilter->GetOutput());
-        rescaleFilter->SetOutputMinimum(0);
-        rescaleFilter->SetOutputMaximum(255);
-        rescaleFilter->Update();
+  {
+    RescaleFilterType::Pointer rescaleFilter = RescaleVectorFilterType::New();
+    rescaleFilter->SetInput(extractFilter->GetOutput());
+    rescaleFilter->SetOutputMinimum(0);
+    rescaleFilter->SetOutputMaximum(255);
+    rescaleFilter->Update();
 
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetInput(rescaleFilter->GetOutput());
-        writer->SetFileName("patch.png");
-        writer->Update();
-    }
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetInput(rescaleFilter->GetOutput());
+    writer->SetFileName("patch.png");
+    writer->Update();
+  }
 
-    // Extract the best matching patch
-    FloatImageType::IndexType bestPatchStart;
-    bestPatchStart[0] = maximumCorrelationPatchCenter[0] - radius[0];
-    bestPatchStart[1] = maximumCorrelationPatchCenter[1] - radius[1];
+  // Extract the best matching patch
+  FloatImageType::IndexType bestPatchStart;
+  bestPatchStart[0] = maximumCorrelationPatchCenter[0] - radius[0];
+  bestPatchStart[1] = maximumCorrelationPatchCenter[1] - radius[1];
 
-    FloatImageType::RegionType bestPatchRegion(bestPatchStart,patchSize);
+  FloatImageType::RegionType bestPatchRegion(bestPatchStart, patchSize);
 
-    ExtractFilterType::Pointer bestPatchExtractFilter = ExtractFilterType::New();
-    bestPatchExtractFilter->SetRegionOfInterest(bestPatchRegion);
-    bestPatchExtractFilter->SetInput(reader->GetOutput());
-    bestPatchExtractFilter->Update();
+  ExtractFilterType::Pointer bestPatchExtractFilter = ExtractFilterType::New();
+  bestPatchExtractFilter->SetRegionOfInterest(bestPatchRegion);
+  bestPatchExtractFilter->SetInput(reader->GetOutput());
+  bestPatchExtractFilter->Update();
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(reader->GetOutput());
-    viewer.AddImage(extractFilter->GetOutput());
-    viewer.AddImage(correlationFilter->GetOutput());
-    viewer.AddImage(bestPatchExtractFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput());
+  viewer.AddImage(extractFilter->GetOutput());
+  viewer.AddImage(correlationFilter->GetOutput());
+  viewer.AddImage(bestPatchExtractFilter->GetOutput());
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/Convolution/ConvolveImageWithKernel/Code.cxx
+++ b/src/Filtering/Convolution/ConvolveImageWithKernel/Code.cxx
@@ -21,89 +21,86 @@
 #include "itkImageRegionIterator.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using ImageType = itk::Image<float, 2>;
 
-static void CreateKernel(ImageType::Pointer kernel, unsigned int width);
+static void
+CreateKernel(ImageType::Pointer kernel, unsigned int width);
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: ";
-        std::cerr << argv[0] << "inputImageFile [width]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: ";
+    std::cerr << argv[0] << "inputImageFile [width]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Parse command line arguments
-    unsigned int width = 3;
-    if (argc > 2)
-    {
-        width = std::stoi(argv[2]);
-    }
+  // Parse command line arguments
+  unsigned int width = 3;
+  if (argc > 2)
+  {
+    width = std::stoi(argv[2]);
+  }
 
-    ImageType::Pointer kernel = ImageType::New();
-    CreateKernel(kernel, width);
+  ImageType::Pointer kernel = ImageType::New();
+  CreateKernel(kernel, width);
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    using FilterType = itk::ConvolutionImageFilter<ImageType>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using FilterType = itk::ConvolutionImageFilter<ImageType>;
 
-    // Create and setup a reader
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( argv[1] );
+  // Create and setup a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
-    // Convolve image with kernel.
-    FilterType::Pointer convolutionFilter = FilterType::New();
-    convolutionFilter->SetInput(reader->GetOutput());
+  // Convolve image with kernel.
+  FilterType::Pointer convolutionFilter = FilterType::New();
+  convolutionFilter->SetInput(reader->GetOutput());
 #if ITK_VERSION_MAJOR >= 4
-    convolutionFilter->SetKernelImage(kernel);
+  convolutionFilter->SetKernelImage(kernel);
 #else
-    convolutionFilter->SetImageKernelInput(kernel);
+  convolutionFilter->SetImageKernelInput(kernel);
 #endif
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage<ImageType>(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  QuickView viewer;
+  viewer.AddImage<ImageType>(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    std::stringstream desc;
-    desc << "ConvolutionFilter\n"
-         << "Kernel Witdh = " << width;
-    viewer.AddImage<ImageType>(
-            convolutionFilter->GetOutput(),
-            true,
-            desc.str());
-    viewer.Visualize();
+  std::stringstream desc;
+  desc << "ConvolutionFilter\n"
+       << "Kernel Witdh = " << width;
+  viewer.AddImage<ImageType>(convolutionFilter->GetOutput(), true, desc.str());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateKernel(ImageType::Pointer kernel, unsigned int width)
+void
+CreateKernel(ImageType::Pointer kernel, unsigned int width)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(width);
+  ImageType::SizeType size;
+  size.Fill(width);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    kernel->SetRegions(region);
-    kernel->Allocate();
+  kernel->SetRegions(region);
+  kernel->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(kernel, region);
+  itk::ImageRegionIterator<ImageType> imageIterator(kernel, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        //imageIterator.Set(255);
-        imageIterator.Set(1);
+  while (!imageIterator.IsAtEnd())
+  {
+    // imageIterator.Set(255);
+    imageIterator.Set(1);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/Convolution/NormalizedCorrelation/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelation/Code.cxx
@@ -24,7 +24,7 @@
 #include "itkImageFileWriter.h"
 #include "itkMinimumMaximumImageCalculator.h"
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 #include <iostream>
@@ -33,120 +33,121 @@
 using FloatImageType = itk::Image<float, 2>;
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Required: filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Required: filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::string filename = argv[1];
+  std::string filename = argv[1];
 
-    using ReaderType = itk::ImageFileReader<FloatImageType>;
+  using ReaderType = itk::ImageFileReader<FloatImageType>;
 
-    // Read the image
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(filename.c_str());
-    reader->Update();
+  // Read the image
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(filename.c_str());
+  reader->Update();
 
-    // Extract a small region
-    using ExtractFilterType = itk::RegionOfInterestImageFilter< FloatImageType,
-            FloatImageType >;
+  // Extract a small region
+  using ExtractFilterType = itk::RegionOfInterestImageFilter<FloatImageType, FloatImageType>;
 
-    ExtractFilterType::Pointer extractFilter = ExtractFilterType::New();
+  ExtractFilterType::Pointer extractFilter = ExtractFilterType::New();
 
-    FloatImageType::IndexType start;
-    start.Fill(50);
+  FloatImageType::IndexType start;
+  start.Fill(50);
 
-    FloatImageType::SizeType patchSize;
-    patchSize.Fill(51);
+  FloatImageType::SizeType patchSize;
+  patchSize.Fill(51);
 
-    FloatImageType::RegionType desiredRegion(start,patchSize);
+  FloatImageType::RegionType desiredRegion(start, patchSize);
 
-    extractFilter->SetRegionOfInterest(desiredRegion);
-    extractFilter->SetInput(reader->GetOutput());
-    extractFilter->Update();
+  extractFilter->SetRegionOfInterest(desiredRegion);
+  extractFilter->SetInput(reader->GetOutput());
+  extractFilter->Update();
 
-    // Perform normalized correlation
-    // <input type, mask type (not used), output type>
-    using CorrelationFilterType = itk::NormalizedCorrelationImageFilter<FloatImageType, FloatImageType, FloatImageType>;
+  // Perform normalized correlation
+  // <input type, mask type (not used), output type>
+  using CorrelationFilterType = itk::NormalizedCorrelationImageFilter<FloatImageType, FloatImageType, FloatImageType>;
 
-    itk::ImageKernelOperator<float> kernelOperator;
-    kernelOperator.SetImageKernel(extractFilter->GetOutput());
+  itk::ImageKernelOperator<float> kernelOperator;
+  kernelOperator.SetImageKernel(extractFilter->GetOutput());
 
-    // The radius of the kernel must be the radius of the patch, NOT the size of the patch
-    itk::Size<2> radius = extractFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
-    radius[0] = (radius[0]-1) / 2;
-    radius[1] = (radius[1]-1) / 2;
+  // The radius of the kernel must be the radius of the patch, NOT the size of the patch
+  itk::Size<2> radius = extractFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
+  radius[0] = (radius[0] - 1) / 2;
+  radius[1] = (radius[1] - 1) / 2;
 
-    kernelOperator.CreateToRadius(radius);
+  kernelOperator.CreateToRadius(radius);
 
-    CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
-    correlationFilter->SetInput(reader->GetOutput());
-    correlationFilter->SetTemplate(kernelOperator);
-    correlationFilter->Update();
+  CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
+  correlationFilter->SetInput(reader->GetOutput());
+  correlationFilter->SetTemplate(kernelOperator);
+  correlationFilter->Update();
 
-    using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator <FloatImageType>;
+  using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator<FloatImageType>;
 
-    MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter
-            = MinimumMaximumImageCalculatorType::New ();
-    minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
-    minimumMaximumImageCalculatorFilter->Compute();
+  MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter =
+    MinimumMaximumImageCalculatorType::New();
+  minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
+  minimumMaximumImageCalculatorFilter->Compute();
 
-    itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
-    std::cout << "Maximum: " << maximumCorrelationPatchCenter << std::endl;
+  itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
+  std::cout << "Maximum: " << maximumCorrelationPatchCenter << std::endl;
 
-    // Note that the best correlation is at the center of the patch we extracted (ie. (75, 75) rather than the corner (50,50)
+  // Note that the best correlation is at the center of the patch we extracted (ie. (75, 75) rather than the corner
+  // (50,50)
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< FloatImageType, UnsignedCharImageType >;
-    using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
-    {
-        RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-        rescaleFilter->SetInput(correlationFilter->GetOutput());
-        rescaleFilter->SetOutputMinimum(0);
-        rescaleFilter->SetOutputMaximum(255);
-        rescaleFilter->Update();
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  {
+    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+    rescaleFilter->SetInput(correlationFilter->GetOutput());
+    rescaleFilter->SetOutputMinimum(0);
+    rescaleFilter->SetOutputMaximum(255);
+    rescaleFilter->Update();
 
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetInput(rescaleFilter->GetOutput());
-        writer->SetFileName("correlation.png");
-        writer->Update();
-    }
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetInput(rescaleFilter->GetOutput());
+    writer->SetFileName("correlation.png");
+    writer->Update();
+  }
 
-    {
-        RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-        rescaleFilter->SetInput(extractFilter->GetOutput());
-        rescaleFilter->SetOutputMinimum(0);
-        rescaleFilter->SetOutputMaximum(255);
-        rescaleFilter->Update();
+  {
+    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+    rescaleFilter->SetInput(extractFilter->GetOutput());
+    rescaleFilter->SetOutputMinimum(0);
+    rescaleFilter->SetOutputMaximum(255);
+    rescaleFilter->Update();
 
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetInput(rescaleFilter->GetOutput());
-        writer->SetFileName("patch.png");
-        writer->Update();
-    }
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetInput(rescaleFilter->GetOutput());
+    writer->SetFileName("patch.png");
+    writer->Update();
+  }
 
-    // Extract the best matching patch
-    FloatImageType::IndexType bestPatchStart;
-    bestPatchStart[0] = maximumCorrelationPatchCenter[0] - radius[0];
-    bestPatchStart[1] = maximumCorrelationPatchCenter[1] - radius[1];
+  // Extract the best matching patch
+  FloatImageType::IndexType bestPatchStart;
+  bestPatchStart[0] = maximumCorrelationPatchCenter[0] - radius[0];
+  bestPatchStart[1] = maximumCorrelationPatchCenter[1] - radius[1];
 
-    FloatImageType::RegionType bestPatchRegion(bestPatchStart,patchSize);
+  FloatImageType::RegionType bestPatchRegion(bestPatchStart, patchSize);
 
-    ExtractFilterType::Pointer bestPatchExtractFilter = ExtractFilterType::New();
-    bestPatchExtractFilter->SetRegionOfInterest(bestPatchRegion);
-    bestPatchExtractFilter->SetInput(reader->GetOutput());
-    bestPatchExtractFilter->Update();
+  ExtractFilterType::Pointer bestPatchExtractFilter = ExtractFilterType::New();
+  bestPatchExtractFilter->SetRegionOfInterest(bestPatchRegion);
+  bestPatchExtractFilter->SetInput(reader->GetOutput());
+  bestPatchExtractFilter->Update();
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(reader->GetOutput());
-    viewer.AddImage(extractFilter->GetOutput());
-    viewer.AddImage(correlationFilter->GetOutput());
-    viewer.AddImage(bestPatchExtractFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput());
+  viewer.AddImage(extractFilter->GetOutput());
+  viewer.AddImage(correlationFilter->GetOutput());
+  viewer.AddImage(bestPatchExtractFilter->GetOutput());
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/Code.cxx
@@ -29,110 +29,119 @@
 
 namespace
 {
-    using ImageType = itk::Image<unsigned char, 2>;
-    using FloatImageType = itk::Image<float, 2>;
-}
+using ImageType = itk::Image<unsigned char, 2>;
+using FloatImageType = itk::Image<float, 2>;
+} // namespace
 
-//using UnsignedCharImageType = itk::Image<unsigned char, 2>;
+// using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image, const itk::Index<2>& cornerOfSquare);
+static void
+CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare);
 
 template <typename TImage>
-static void WriteImage(TImage* const image, const std::string& filename);
+static void
+WriteImage(TImage * const image, const std::string & filename);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    itk::Index<2> offset;
-    offset[0] = 5;
-    offset[1] = 6;
+  itk::Index<2> offset;
+  offset[0] = 5;
+  offset[1] = 6;
 
-    ImageType::Pointer fixedImage = ImageType::New();
-    itk::Index<2> cornerOfFixedSquare;
-    cornerOfFixedSquare[0] = 3;
-    cornerOfFixedSquare[1] = 8;
-    CreateImage(fixedImage, cornerOfFixedSquare);
-    WriteImage(fixedImage.GetPointer(), "fixedImage.png");
+  ImageType::Pointer fixedImage = ImageType::New();
+  itk::Index<2>      cornerOfFixedSquare;
+  cornerOfFixedSquare[0] = 3;
+  cornerOfFixedSquare[1] = 8;
+  CreateImage(fixedImage, cornerOfFixedSquare);
+  WriteImage(fixedImage.GetPointer(), "fixedImage.png");
 
-    ImageType::Pointer movingImage = ImageType::New();
-    itk::Index<2> cornerOfMovingSquare;
-    cornerOfMovingSquare[0] = cornerOfFixedSquare[0] + offset[0];
-    cornerOfMovingSquare[1] = cornerOfFixedSquare[1] + offset[1];
-    CreateImage(movingImage, cornerOfMovingSquare);
-    WriteImage(movingImage.GetPointer(), "movingImage.png");
+  ImageType::Pointer movingImage = ImageType::New();
+  itk::Index<2>      cornerOfMovingSquare;
+  cornerOfMovingSquare[0] = cornerOfFixedSquare[0] + offset[0];
+  cornerOfMovingSquare[1] = cornerOfFixedSquare[1] + offset[1];
+  CreateImage(movingImage, cornerOfMovingSquare);
+  WriteImage(movingImage.GetPointer(), "movingImage.png");
 
-    // Perform normalized correlation
-    using CorrelationFilterType = itk::FFTNormalizedCorrelationImageFilter<ImageType, FloatImageType>;
-    CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
-    correlationFilter->SetFixedImage(fixedImage);
-    correlationFilter->SetMovingImage(movingImage);
-    correlationFilter->Update();
+  // Perform normalized correlation
+  using CorrelationFilterType = itk::FFTNormalizedCorrelationImageFilter<ImageType, FloatImageType>;
+  CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
+  correlationFilter->SetFixedImage(fixedImage);
+  correlationFilter->SetMovingImage(movingImage);
+  correlationFilter->Update();
 
-    WriteImage(correlationFilter->GetOutput(), "correlation.mha");
+  WriteImage(correlationFilter->GetOutput(), "correlation.mha");
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, ImageType>;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(correlationFilter->GetOutput());
-    rescaleFilter->SetOutputMinimum(0);
-    rescaleFilter->SetOutputMaximum(255);
-    rescaleFilter->Update();
-    WriteImage(rescaleFilter->GetOutput(), "correlation.png");
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, ImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(correlationFilter->GetOutput());
+  rescaleFilter->SetOutputMinimum(0);
+  rescaleFilter->SetOutputMaximum(255);
+  rescaleFilter->Update();
+  WriteImage(rescaleFilter->GetOutput(), "correlation.png");
 
-    using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator<FloatImageType>;
-    MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter = MinimumMaximumImageCalculatorType::New ();
-    minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
-    minimumMaximumImageCalculatorFilter->Compute();
+  using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator<FloatImageType>;
+  MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter =
+    MinimumMaximumImageCalculatorType::New();
+  minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
+  minimumMaximumImageCalculatorFilter->Compute();
 
-    itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
+  itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
 
-    itk::Size<2> outputSize = correlationFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
+  itk::Size<2> outputSize = correlationFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
 
-    itk::Index<2> maximumCorrelationPatchCenterFixed;
-    maximumCorrelationPatchCenterFixed[0] = outputSize[0]/2 - maximumCorrelationPatchCenter[0];
-    maximumCorrelationPatchCenterFixed[1] = outputSize[1]/2 - maximumCorrelationPatchCenter[1];
+  itk::Index<2> maximumCorrelationPatchCenterFixed;
+  maximumCorrelationPatchCenterFixed[0] = outputSize[0] / 2 - maximumCorrelationPatchCenter[0];
+  maximumCorrelationPatchCenterFixed[1] = outputSize[1] / 2 - maximumCorrelationPatchCenter[1];
 
-    std::cout << "Maximum location: " << maximumCorrelationPatchCenter << std::endl;
-    std::cout << "Maximum location fixed: " << maximumCorrelationPatchCenterFixed << std::endl; // This is the value we expect!
-    std::cout << "Maximum value: " << minimumMaximumImageCalculatorFilter->GetMaximum() << std::endl; // If the images can be perfectly aligned, the value is 1
+  std::cout << "Maximum location: " << maximumCorrelationPatchCenter << std::endl;
+  std::cout << "Maximum location fixed: " << maximumCorrelationPatchCenterFixed
+            << std::endl; // This is the value we expect!
+  std::cout << "Maximum value: " << minimumMaximumImageCalculatorFilter->GetMaximum()
+            << std::endl; // If the images can be perfectly aligned, the value is 1
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image, const itk::Index<2>& cornerOfSquare)
+void
+CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(51);
+  ImageType::SizeType size;
+  size.Fill(51);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    ImageType::IndexValueType squareSize = 8;
+  ImageType::IndexValueType squareSize = 8;
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > cornerOfSquare[0] &&
+        imageIterator.GetIndex()[0] < cornerOfSquare[0] + squareSize &&
+        imageIterator.GetIndex()[1] > cornerOfSquare[1] && imageIterator.GetIndex()[1] < cornerOfSquare[1] + squareSize)
     {
-        if(imageIterator.GetIndex()[0] > cornerOfSquare[0] && imageIterator.GetIndex()[0] < cornerOfSquare[0] + squareSize &&
-           imageIterator.GetIndex()[1] > cornerOfSquare[1] && imageIterator.GetIndex()[1] < cornerOfSquare[1] + squareSize)
-        {
-            imageIterator.Set(255);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
     }
+
+    ++imageIterator;
+  }
 }
 
 template <typename TImage>
-void WriteImage(TImage* const image, const std::string& filename)
+void
+WriteImage(TImage * const image, const std::string & filename)
 {
-    using WriterType = itk::ImageFileWriter<TImage>;
-    typename WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName(filename);
-    writer->SetInput(image);
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<TImage>;
+  typename WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(filename);
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/Code.cxx
@@ -29,153 +29,162 @@
 
 namespace
 {
-    using ImageType = itk::Image<unsigned char, 2>;
-    using FloatImageType = itk::Image<float, 2>;
-    using MaskType = itk::Image<unsigned char, 2>;
-}
+using ImageType = itk::Image<unsigned char, 2>;
+using FloatImageType = itk::Image<float, 2>;
+using MaskType = itk::Image<unsigned char, 2>;
+} // namespace
 
-static void CreateMask(MaskType* const mask);
-static void CreateImage(ImageType::Pointer image, const itk::Index<2>& cornerOfSquare);
-
-template <typename TImage>
-void WriteImage(TImage* const image, const std::string& filename);
-
-int main(int, char *[])
-{
-    itk::Index<2> offset;
-    offset[0] = 5;
-    offset[1] = 6;
-
-    // Setup mask
-    MaskType::Pointer mask = MaskType::New();
-    CreateMask(mask);
-
-    ImageType::Pointer fixedImage = ImageType::New();
-    itk::Index<2> cornerOfFixedSquare;
-    cornerOfFixedSquare[0] = 3;
-    cornerOfFixedSquare[1] = 8;
-    CreateImage(fixedImage, cornerOfFixedSquare);
-    WriteImage(fixedImage.GetPointer(), "fixedImage.png");
-
-    ImageType::Pointer movingImage = ImageType::New();
-    itk::Index<2> cornerOfMovingSquare;
-    cornerOfMovingSquare[0] = cornerOfFixedSquare[0] + offset[0];
-    cornerOfMovingSquare[1] = cornerOfFixedSquare[1] + offset[1];
-    CreateImage(movingImage, cornerOfMovingSquare);
-    WriteImage(movingImage.GetPointer(), "movingImage.png");
-
-    // Perform normalized correlation
-    using CorrelationFilterType = itk::FFTNormalizedCorrelationImageFilter<ImageType, FloatImageType>;
-    CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
-    correlationFilter->SetFixedImage(fixedImage);
-    correlationFilter->SetMovingImage(movingImage);
-    correlationFilter->SetMovingImageMask(mask);
-    //correlationFilter->SetFixedImageMask(mask);
-    correlationFilter->Update();
-
-    WriteImage(correlationFilter->GetOutput(), "correlation.mha");
-
-    using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, ImageType>;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(correlationFilter->GetOutput());
-    rescaleFilter->SetOutputMinimum(0);
-    rescaleFilter->SetOutputMaximum(255);
-    rescaleFilter->Update();
-    WriteImage(rescaleFilter->GetOutput(), "correlation.png");
-
-    using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator<FloatImageType>;
-    MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter = MinimumMaximumImageCalculatorType::New ();
-    minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
-    minimumMaximumImageCalculatorFilter->Compute();
-
-    itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
-
-    itk::Size<2> outputSize = correlationFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
-
-    itk::Index<2> maximumCorrelationPatchCenterFixed;
-    maximumCorrelationPatchCenterFixed[0] = outputSize[0]/2 - maximumCorrelationPatchCenter[0];
-    maximumCorrelationPatchCenterFixed[1] = outputSize[1]/2 - maximumCorrelationPatchCenter[1];
-
-    std::cout << "Maximum location: " << maximumCorrelationPatchCenter << std::endl;
-    std::cout << "Maximum location fixed: " << maximumCorrelationPatchCenterFixed << std::endl; // This is the value we expect!
-    std::cout << "Maximum value: " << minimumMaximumImageCalculatorFilter->GetMaximum() << std::endl; // If the images can be perfectly aligned, the value is 1
-
-    return EXIT_SUCCESS;
-}
-
-void CreateImage(ImageType::Pointer image, const itk::Index<2>& cornerOfSquare)
-{
-    ImageType::IndexType start;
-    start.Fill(0);
-
-    ImageType::SizeType size;
-    size.Fill(51);
-
-    ImageType::RegionType region(start,size);
-
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
-
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
-
-    ImageType::IndexValueType squareSize = 8;
-
-    while(!imageIterator.IsAtEnd())
-    {
-        if(imageIterator.GetIndex()[0] > cornerOfSquare[0] && imageIterator.GetIndex()[0] < cornerOfSquare[0] + squareSize &&
-           imageIterator.GetIndex()[1] > cornerOfSquare[1] && imageIterator.GetIndex()[1] < cornerOfSquare[1] + squareSize)
-        {
-            imageIterator.Set(255);
-        }
-
-        ++imageIterator;
-    }
-}
+static void
+CreateMask(MaskType * const mask);
+static void
+CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare);
 
 template <typename TImage>
-void WriteImage(TImage* const image, const std::string& filename)
+void
+WriteImage(TImage * const image, const std::string & filename);
+
+int
+main(int, char *[])
 {
-    using WriterType = itk::ImageFileWriter<TImage>;
-    typename WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName(filename);
-    writer->SetInput(image);
-    writer->Update();
+  itk::Index<2> offset;
+  offset[0] = 5;
+  offset[1] = 6;
+
+  // Setup mask
+  MaskType::Pointer mask = MaskType::New();
+  CreateMask(mask);
+
+  ImageType::Pointer fixedImage = ImageType::New();
+  itk::Index<2>      cornerOfFixedSquare;
+  cornerOfFixedSquare[0] = 3;
+  cornerOfFixedSquare[1] = 8;
+  CreateImage(fixedImage, cornerOfFixedSquare);
+  WriteImage(fixedImage.GetPointer(), "fixedImage.png");
+
+  ImageType::Pointer movingImage = ImageType::New();
+  itk::Index<2>      cornerOfMovingSquare;
+  cornerOfMovingSquare[0] = cornerOfFixedSquare[0] + offset[0];
+  cornerOfMovingSquare[1] = cornerOfFixedSquare[1] + offset[1];
+  CreateImage(movingImage, cornerOfMovingSquare);
+  WriteImage(movingImage.GetPointer(), "movingImage.png");
+
+  // Perform normalized correlation
+  using CorrelationFilterType = itk::FFTNormalizedCorrelationImageFilter<ImageType, FloatImageType>;
+  CorrelationFilterType::Pointer correlationFilter = CorrelationFilterType::New();
+  correlationFilter->SetFixedImage(fixedImage);
+  correlationFilter->SetMovingImage(movingImage);
+  correlationFilter->SetMovingImageMask(mask);
+  // correlationFilter->SetFixedImageMask(mask);
+  correlationFilter->Update();
+
+  WriteImage(correlationFilter->GetOutput(), "correlation.mha");
+
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, ImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(correlationFilter->GetOutput());
+  rescaleFilter->SetOutputMinimum(0);
+  rescaleFilter->SetOutputMaximum(255);
+  rescaleFilter->Update();
+  WriteImage(rescaleFilter->GetOutput(), "correlation.png");
+
+  using MinimumMaximumImageCalculatorType = itk::MinimumMaximumImageCalculator<FloatImageType>;
+  MinimumMaximumImageCalculatorType::Pointer minimumMaximumImageCalculatorFilter =
+    MinimumMaximumImageCalculatorType::New();
+  minimumMaximumImageCalculatorFilter->SetImage(correlationFilter->GetOutput());
+  minimumMaximumImageCalculatorFilter->Compute();
+
+  itk::Index<2> maximumCorrelationPatchCenter = minimumMaximumImageCalculatorFilter->GetIndexOfMaximum();
+
+  itk::Size<2> outputSize = correlationFilter->GetOutput()->GetLargestPossibleRegion().GetSize();
+
+  itk::Index<2> maximumCorrelationPatchCenterFixed;
+  maximumCorrelationPatchCenterFixed[0] = outputSize[0] / 2 - maximumCorrelationPatchCenter[0];
+  maximumCorrelationPatchCenterFixed[1] = outputSize[1] / 2 - maximumCorrelationPatchCenter[1];
+
+  std::cout << "Maximum location: " << maximumCorrelationPatchCenter << std::endl;
+  std::cout << "Maximum location fixed: " << maximumCorrelationPatchCenterFixed
+            << std::endl; // This is the value we expect!
+  std::cout << "Maximum value: " << minimumMaximumImageCalculatorFilter->GetMaximum()
+            << std::endl; // If the images can be perfectly aligned, the value is 1
+
+  return EXIT_SUCCESS;
+}
+
+void
+CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare)
+{
+  ImageType::IndexType start;
+  start.Fill(0);
+
+  ImageType::SizeType size;
+  size.Fill(51);
+
+  ImageType::RegionType region(start, size);
+
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
+
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
+
+  ImageType::IndexValueType squareSize = 8;
+
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > cornerOfSquare[0] &&
+        imageIterator.GetIndex()[0] < cornerOfSquare[0] + squareSize &&
+        imageIterator.GetIndex()[1] > cornerOfSquare[1] && imageIterator.GetIndex()[1] < cornerOfSquare[1] + squareSize)
+    {
+      imageIterator.Set(255);
+    }
+
+    ++imageIterator;
+  }
+}
+
+template <typename TImage>
+void
+WriteImage(TImage * const image, const std::string & filename)
+{
+  using WriterType = itk::ImageFileWriter<TImage>;
+  typename WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(filename);
+  writer->SetInput(image);
+  writer->Update();
 }
 
 
-void CreateMask(MaskType* const mask)
+void
+CreateMask(MaskType * const mask)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(51);
+  ImageType::SizeType size;
+  size.Fill(51);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    mask->SetRegions(region);
-    mask->Allocate();
-    mask->FillBuffer(255); // Make the whole mask "valid"
+  mask->SetRegions(region);
+  mask->Allocate();
+  mask->FillBuffer(255); // Make the whole mask "valid"
 
-    //unsigned int squareSize = 8;
-    ImageType::IndexValueType squareSize = 3;
+  // unsigned int squareSize = 8;
+  ImageType::IndexValueType squareSize = 3;
 
-    itk::Index<2> cornerOfSquare = {{3,8}};
+  itk::Index<2> cornerOfSquare = { { 3, 8 } };
 
-    // Remove pixels from the mask in a small square. The correlationw will not be computed at these pixels.
-    itk::ImageRegionIterator<MaskType> maskIterator(mask, region);
+  // Remove pixels from the mask in a small square. The correlationw will not be computed at these pixels.
+  itk::ImageRegionIterator<MaskType> maskIterator(mask, region);
 
-    while(!maskIterator.IsAtEnd())
+  while (!maskIterator.IsAtEnd())
+  {
+    if (maskIterator.GetIndex()[0] > cornerOfSquare[0] && maskIterator.GetIndex()[0] < cornerOfSquare[0] + squareSize &&
+        maskIterator.GetIndex()[1] > cornerOfSquare[1] && maskIterator.GetIndex()[1] < cornerOfSquare[1] + squareSize)
     {
-        if(maskIterator.GetIndex()[0] > cornerOfSquare[0] &&
-           maskIterator.GetIndex()[0] < cornerOfSquare[0] + squareSize &&
-           maskIterator.GetIndex()[1] > cornerOfSquare[1] &&
-           maskIterator.GetIndex()[1] < cornerOfSquare[1] + squareSize)
-        {
-            maskIterator.Set(0);
-        }
-
-        ++maskIterator;
+      maskIterator.Set(0);
     }
+
+    ++maskIterator;
+  }
 }

--- a/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/Code.cxx
+++ b/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/Code.cxx
@@ -23,72 +23,64 @@
 #include "itksys/SystemTools.hxx"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char* argv[])
+int
+main(int argc, char * argv[])
 {
-    if( argc < 2 )
-    {
-        std::cerr << argv[0] << " InputFileName [NumberOfIterations]" <<std ::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << argv[0] << " InputFileName [NumberOfIterations]" << std ::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::string inputFileName = argv[1];
+  std::string inputFileName = argv[1];
 
-    unsigned int numberOfIterations = 2;
-    if (argc > 2)
-    {
-        numberOfIterations = std::stoi(argv[2]);
-    }
+  unsigned int numberOfIterations = 2;
+  if (argc > 2)
+  {
+    numberOfIterations = std::stoi(argv[2]);
+  }
 
-    constexpr unsigned int Dimension = 2;
+  constexpr unsigned int Dimension = 2;
 
-    using InputPixelType = float;
-    using OutputPixelType = float;
+  using InputPixelType = float;
+  using OutputPixelType = float;
 
-    using InputImageType = itk::Image< InputPixelType, Dimension >;
-    using ReaderType = itk::ImageFileReader< InputImageType >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
 
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(inputFileName);
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFileName);
 
-    using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-    using FilterType = itk::BinaryMinMaxCurvatureFlowImageFilter< InputImageType, OutputImageType >;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput( reader->GetOutput() );
-    filter->SetThreshold( 255 );
-    filter->SetNumberOfIterations(numberOfIterations);
+  using FilterType = itk::BinaryMinMaxCurvatureFlowImageFilter<InputImageType, OutputImageType>;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(reader->GetOutput());
+  filter->SetThreshold(255);
+  filter->SetNumberOfIterations(numberOfIterations);
 
-    using SubtractType = itk::SubtractImageFilter<OutputImageType>;
-    SubtractType::Pointer diff = SubtractType::New();
-    diff->SetInput1(reader->GetOutput());
-    diff->SetInput2(filter->GetOutput());
+  using SubtractType = itk::SubtractImageFilter<OutputImageType>;
+  SubtractType::Pointer diff = SubtractType::New();
+  diff->SetInput1(reader->GetOutput());
+  diff->SetInput2(filter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(inputFileName));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFileName));
 
-    std::stringstream desc;
-    desc << "BinaryMinMaxCurvature, iterations = "
-         << numberOfIterations;
-    viewer.AddImage(
-            filter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "BinaryMinMaxCurvature, iterations = " << numberOfIterations;
+  viewer.AddImage(filter->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Original - BinaryMinMaxCurvatureFlow";
-    viewer.AddImage(
-            diff->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "Original - BinaryMinMaxCurvatureFlow";
+  viewer.AddImage(diff->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/Code.cxx
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/Code.cxx
@@ -22,69 +22,61 @@
 #include "itkImageFileReader.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << argv[0];
-        std::cerr << " inputImage [iterations]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage [iterations]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    int iterations = 5;
-    if (argc > 2)
-    {
-        iterations = std::stoi(argv[2]);
-    }
+  int iterations = 5;
+  if (argc > 2)
+  {
+    iterations = std::stoi(argv[2]);
+  }
 
-    using InternalPixelType = float;
-    constexpr unsigned int Dimension = 2;
-    using InternalImageType = itk::Image< InternalPixelType, Dimension >;
+  using InternalPixelType = float;
+  constexpr unsigned int Dimension = 2;
+  using InternalImageType = itk::Image<InternalPixelType, Dimension>;
 
-    using ReaderType = itk::ImageFileReader< InternalImageType >;
+  using ReaderType = itk::ImageFileReader<InternalImageType>;
 
-    ReaderType::Pointer reader = ReaderType::New();
+  ReaderType::Pointer reader = ReaderType::New();
 
-    reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-    using CurvatureFlowImageFilterType = itk::CurvatureFlowImageFilter< InternalImageType, InternalImageType >;
+  using CurvatureFlowImageFilterType = itk::CurvatureFlowImageFilter<InternalImageType, InternalImageType>;
 
-    CurvatureFlowImageFilterType::Pointer smoothing = CurvatureFlowImageFilterType::New();
+  CurvatureFlowImageFilterType::Pointer smoothing = CurvatureFlowImageFilterType::New();
 
-    smoothing->SetInput( reader->GetOutput() );
-    smoothing->SetNumberOfIterations( iterations );
-    smoothing->SetTimeStep( 0.125 );
+  smoothing->SetInput(reader->GetOutput());
+  smoothing->SetNumberOfIterations(iterations);
+  smoothing->SetTimeStep(0.125);
 
-    using SubtractImageFilterType = itk::SubtractImageFilter< InternalImageType >;
-    SubtractImageFilterType::Pointer diff = SubtractImageFilterType::New();
-    diff->SetInput1(reader->GetOutput());
-    diff->SetInput2(smoothing->GetOutput());
+  using SubtractImageFilterType = itk::SubtractImageFilter<InternalImageType>;
+  SubtractImageFilterType::Pointer diff = SubtractImageFilterType::New();
+  diff->SetInput1(reader->GetOutput());
+  diff->SetInput2(smoothing->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage<InternalImageType>(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  QuickView viewer;
+  viewer.AddImage<InternalImageType>(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    std::stringstream desc;
-    desc << "CurvatureFlow\niterations = " << iterations;
-    viewer.AddImage<InternalImageType>(
-            smoothing->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "CurvatureFlow\niterations = " << iterations;
+  viewer.AddImage<InternalImageType>(smoothing->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Original - CurvatureFlow";
-    viewer.AddImage<InternalImageType>(
-            diff->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "Original - CurvatureFlow";
+  viewer.AddImage<InternalImageType>(diff->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/Code.cxx
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/Code.cxx
@@ -23,71 +23,64 @@
 #include "itkImageFileWriter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << argv[0];
-        std::cerr << " inputImage [iterations]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " inputImage [iterations]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::string inputFileName = argv[1];
+  std::string inputFileName = argv[1];
 
-    int iterations = 5;
-    if (argc > 2)
-    {
-        std::stringstream ss(argv[2]);
-        ss >> iterations;
-    }
-    std::string inputFilename = argv[1];
+  int iterations = 5;
+  if (argc > 2)
+  {
+    std::stringstream ss(argv[2]);
+    ss >> iterations;
+  }
+  std::string inputFilename = argv[1];
 
-    using PixelType = float;
-    constexpr unsigned int Dimension = 2;
+  using PixelType = float;
+  constexpr unsigned int Dimension = 2;
 
-    using ImageType = itk::Image< PixelType, Dimension >;
-    using ReaderType = itk::ImageFileReader< ImageType >;
-    using MinMaxCurvatureFlowImageFilterType = itk::MinMaxCurvatureFlowImageFilter< ImageType, ImageType >;
-    using SubtractType = itk::SubtractImageFilter<ImageType>;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using MinMaxCurvatureFlowImageFilterType = itk::MinMaxCurvatureFlowImageFilter<ImageType, ImageType>;
+  using SubtractType = itk::SubtractImageFilter<ImageType>;
 
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFilename );
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename);
 
-    MinMaxCurvatureFlowImageFilterType::Pointer minMaxCurvatureFlowImageFilter = MinMaxCurvatureFlowImageFilterType::New();
-    minMaxCurvatureFlowImageFilter->SetInput( reader->GetOutput() );
-    minMaxCurvatureFlowImageFilter->SetNumberOfIterations( iterations );
-    minMaxCurvatureFlowImageFilter->SetTimeStep( 0.125 );
+  MinMaxCurvatureFlowImageFilterType::Pointer minMaxCurvatureFlowImageFilter =
+    MinMaxCurvatureFlowImageFilterType::New();
+  minMaxCurvatureFlowImageFilter->SetInput(reader->GetOutput());
+  minMaxCurvatureFlowImageFilter->SetNumberOfIterations(iterations);
+  minMaxCurvatureFlowImageFilter->SetTimeStep(0.125);
 
-    SubtractType::Pointer diff = SubtractType::New();
-    diff->SetInput1(reader->GetOutput());
-    diff->SetInput2(minMaxCurvatureFlowImageFilter->GetOutput());
+  SubtractType::Pointer diff = SubtractType::New();
+  diff->SetInput1(reader->GetOutput());
+  diff->SetInput2(minMaxCurvatureFlowImageFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(inputFilename));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFilename));
 
-    std::stringstream desc;
-    desc << "MinMaxCurvatureFlow, iterations = " << iterations;
-    viewer.AddImage(
-            minMaxCurvatureFlowImageFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "MinMaxCurvatureFlow, iterations = " << iterations;
+  viewer.AddImage(minMaxCurvatureFlowImageFilter->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Original - Median";
-    viewer.AddImage(
-            diff->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "Original - Median";
+  viewer.AddImage(diff->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/Code.cxx
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/Code.cxx
@@ -27,100 +27,87 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " InputImageFile [iterations]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " InputImageFile [iterations]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    int iterations = 5;
-    if (argc > 2)
-    {
-        std::stringstream ss(argv[2]);
-        ss >> iterations;
-    }
-    std::string inputFilename = argv[1];
+  int iterations = 5;
+  if (argc > 2)
+  {
+    std::stringstream ss(argv[2]);
+    ss >> iterations;
+  }
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using ComponentType = float;
-    using PixelType = itk::RGBPixel<ComponentType>;
-    using RGBImageType = itk::Image<PixelType, 2 >;
-    using ImageType = itk::Image<ComponentType, 2 >;
-    using ReaderType = itk::ImageFileReader<RGBImageType>;
-    using ImageAdaptorType = itk::NthElementImageAdaptor<RGBImageType, unsigned char>;
-    using ComposeType = itk::ComposeImageFilter<ImageType, RGBImageType>;
-    using CurvatureFlowType = itk::CurvatureFlowImageFilter<ImageAdaptorType, ImageType>;
+  // Setup types
+  using ComponentType = float;
+  using PixelType = itk::RGBPixel<ComponentType>;
+  using RGBImageType = itk::Image<PixelType, 2>;
+  using ImageType = itk::Image<ComponentType, 2>;
+  using ReaderType = itk::ImageFileReader<RGBImageType>;
+  using ImageAdaptorType = itk::NthElementImageAdaptor<RGBImageType, unsigned char>;
+  using ComposeType = itk::ComposeImageFilter<ImageType, RGBImageType>;
+  using CurvatureFlowType = itk::CurvatureFlowImageFilter<ImageAdaptorType, ImageType>;
 
-    // Create and setup a reader
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFilename );
-    reader->Update();
+  // Create and setup a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename);
+  reader->Update();
 
-    // Run the filter for each component
-    ImageAdaptorType::Pointer rAdaptor =
-            ImageAdaptorType::New();
-    rAdaptor->SelectNthElement(0);
-    rAdaptor->SetImage(reader->GetOutput());
+  // Run the filter for each component
+  ImageAdaptorType::Pointer rAdaptor = ImageAdaptorType::New();
+  rAdaptor->SelectNthElement(0);
+  rAdaptor->SetImage(reader->GetOutput());
 
-    CurvatureFlowType::Pointer rCurvatureFilter =
-            CurvatureFlowType::New();
-    rCurvatureFilter->SetInput(rAdaptor);
-    rCurvatureFilter->SetNumberOfIterations(iterations);
-    rCurvatureFilter->Update();
+  CurvatureFlowType::Pointer rCurvatureFilter = CurvatureFlowType::New();
+  rCurvatureFilter->SetInput(rAdaptor);
+  rCurvatureFilter->SetNumberOfIterations(iterations);
+  rCurvatureFilter->Update();
 
-    ImageAdaptorType::Pointer gAdaptor =
-            ImageAdaptorType::New();
-    gAdaptor->SelectNthElement(1);
-    gAdaptor->SetImage(reader->GetOutput());
+  ImageAdaptorType::Pointer gAdaptor = ImageAdaptorType::New();
+  gAdaptor->SelectNthElement(1);
+  gAdaptor->SetImage(reader->GetOutput());
 
-    CurvatureFlowType::Pointer gCurvatureFilter =
-            CurvatureFlowType::New();
-    gCurvatureFilter->SetInput(gAdaptor);
-    gCurvatureFilter->SetNumberOfIterations(iterations);
-    gCurvatureFilter->Update();
+  CurvatureFlowType::Pointer gCurvatureFilter = CurvatureFlowType::New();
+  gCurvatureFilter->SetInput(gAdaptor);
+  gCurvatureFilter->SetNumberOfIterations(iterations);
+  gCurvatureFilter->Update();
 
-    ImageAdaptorType::Pointer bAdaptor =
-            ImageAdaptorType::New();
-    bAdaptor->SelectNthElement(2);
-    bAdaptor->SetImage(reader->GetOutput());
+  ImageAdaptorType::Pointer bAdaptor = ImageAdaptorType::New();
+  bAdaptor->SelectNthElement(2);
+  bAdaptor->SetImage(reader->GetOutput());
 
-    CurvatureFlowType::Pointer bCurvatureFilter =
-            CurvatureFlowType::New();
-    bCurvatureFilter->SetInput(bAdaptor);
-    bCurvatureFilter->SetNumberOfIterations(iterations);
-    bCurvatureFilter->Update();
+  CurvatureFlowType::Pointer bCurvatureFilter = CurvatureFlowType::New();
+  bCurvatureFilter->SetInput(bAdaptor);
+  bCurvatureFilter->SetNumberOfIterations(iterations);
+  bCurvatureFilter->Update();
 
-    // compose an RGB image from the three filtered images
+  // compose an RGB image from the three filtered images
 
-    ComposeType::Pointer compose =
-            ComposeType::New();
-    compose->SetInput1 (rCurvatureFilter->GetOutput());
-    compose->SetInput2 (gCurvatureFilter->GetOutput());
-    compose->SetInput3 (bCurvatureFilter->GetOutput());
+  ComposeType::Pointer compose = ComposeType::New();
+  compose->SetInput1(rCurvatureFilter->GetOutput());
+  compose->SetInput2(gCurvatureFilter->GetOutput());
+  compose->SetInput3(bCurvatureFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddRGBImage(
-            reader->GetOutput(),
-            true,
-            itksys::SystemTools::GetFilenameName(inputFilename));
+  QuickView viewer;
+  viewer.AddRGBImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFilename));
 
-    std::stringstream desc;
-    desc << "CurvatureFlow iterations = " << iterations;
-    viewer.AddRGBImage(
-            compose->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "CurvatureFlow iterations = " << iterations;
+  viewer.AddRGBImage(compose->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/Code.cxx
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/Code.cxx
@@ -27,101 +27,88 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " InputImageFile [iterations]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " InputImageFile [iterations]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    int iterations = 5;
-    if (argc > 2)
-    {
-        std::stringstream ss(argv[2]);
-        ss >> iterations;
-    }
-    std::string inputFilename = argv[1];
+  int iterations = 5;
+  if (argc > 2)
+  {
+    std::stringstream ss(argv[2]);
+    ss >> iterations;
+  }
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using ComponentType = float;
-    using PixelType = itk::RGBPixel<ComponentType>;
-    using RGBImageType = itk::Image<PixelType, 2 >;
-    using ImageType = itk::Image<ComponentType, 2 >;
-    using ReaderType = itk::ImageFileReader<RGBImageType>;
-    using ImageAdaptorType = itk::NthElementImageAdaptor<RGBImageType, unsigned char>;
-    using ComposeType = itk::ComposeImageFilter<ImageType, RGBImageType>;
-    using CurvatureFlowType = itk::MinMaxCurvatureFlowImageFilter<ImageAdaptorType, ImageType>;
+  // Setup types
+  using ComponentType = float;
+  using PixelType = itk::RGBPixel<ComponentType>;
+  using RGBImageType = itk::Image<PixelType, 2>;
+  using ImageType = itk::Image<ComponentType, 2>;
+  using ReaderType = itk::ImageFileReader<RGBImageType>;
+  using ImageAdaptorType = itk::NthElementImageAdaptor<RGBImageType, unsigned char>;
+  using ComposeType = itk::ComposeImageFilter<ImageType, RGBImageType>;
+  using CurvatureFlowType = itk::MinMaxCurvatureFlowImageFilter<ImageAdaptorType, ImageType>;
 
-    // Create and setup a reader
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFilename );
-    reader->Update();
+  // Create and setup a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename);
+  reader->Update();
 
-    // Run the filter for each component
-    ImageAdaptorType::Pointer rAdaptor =
-            ImageAdaptorType::New();
-    rAdaptor->SelectNthElement(0);
-    rAdaptor->SetImage(reader->GetOutput());
+  // Run the filter for each component
+  ImageAdaptorType::Pointer rAdaptor = ImageAdaptorType::New();
+  rAdaptor->SelectNthElement(0);
+  rAdaptor->SetImage(reader->GetOutput());
 
-    CurvatureFlowType::Pointer rCurvatureFilter =
-            CurvatureFlowType::New();
-    rCurvatureFilter->SetInput(rAdaptor);
-    rCurvatureFilter->SetNumberOfIterations(iterations);
-    rCurvatureFilter->Update();
+  CurvatureFlowType::Pointer rCurvatureFilter = CurvatureFlowType::New();
+  rCurvatureFilter->SetInput(rAdaptor);
+  rCurvatureFilter->SetNumberOfIterations(iterations);
+  rCurvatureFilter->Update();
 
-    ImageAdaptorType::Pointer gAdaptor =
-            ImageAdaptorType::New();
-    gAdaptor->SelectNthElement(1);
-    gAdaptor->SetImage(reader->GetOutput());
+  ImageAdaptorType::Pointer gAdaptor = ImageAdaptorType::New();
+  gAdaptor->SelectNthElement(1);
+  gAdaptor->SetImage(reader->GetOutput());
 
-    CurvatureFlowType::Pointer gCurvatureFilter =
-            CurvatureFlowType::New();
-    gCurvatureFilter->SetInput(gAdaptor);
-    gCurvatureFilter->SetNumberOfIterations(iterations);
-    gCurvatureFilter->Update();
+  CurvatureFlowType::Pointer gCurvatureFilter = CurvatureFlowType::New();
+  gCurvatureFilter->SetInput(gAdaptor);
+  gCurvatureFilter->SetNumberOfIterations(iterations);
+  gCurvatureFilter->Update();
 
-    ImageAdaptorType::Pointer bAdaptor =
-            ImageAdaptorType::New();
-    bAdaptor->SelectNthElement(2);
-    bAdaptor->SetImage(reader->GetOutput());
+  ImageAdaptorType::Pointer bAdaptor = ImageAdaptorType::New();
+  bAdaptor->SelectNthElement(2);
+  bAdaptor->SetImage(reader->GetOutput());
 
-    CurvatureFlowType::Pointer bCurvatureFilter =
-            CurvatureFlowType::New();
-    bCurvatureFilter->SetInput(bAdaptor);
-    bCurvatureFilter->SetNumberOfIterations(iterations);
-    bCurvatureFilter->Update();
+  CurvatureFlowType::Pointer bCurvatureFilter = CurvatureFlowType::New();
+  bCurvatureFilter->SetInput(bAdaptor);
+  bCurvatureFilter->SetNumberOfIterations(iterations);
+  bCurvatureFilter->Update();
 
-    // compose an RGB image from the three filtered images
+  // compose an RGB image from the three filtered images
 
-    ComposeType::Pointer compose =
-            ComposeType::New();
-    compose->SetInput1 (rCurvatureFilter->GetOutput());
-    compose->SetInput2 (gCurvatureFilter->GetOutput());
-    compose->SetInput3 (bCurvatureFilter->GetOutput());
+  ComposeType::Pointer compose = ComposeType::New();
+  compose->SetInput1(rCurvatureFilter->GetOutput());
+  compose->SetInput2(gCurvatureFilter->GetOutput());
+  compose->SetInput3(bCurvatureFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddRGBImage(
-            reader->GetOutput(),
-            true,
-            itksys::SystemTools::GetFilenameName(inputFilename));
+  QuickView viewer;
+  viewer.AddRGBImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFilename));
 
-    std::stringstream desc;
-    desc << "MinMaxCurvatureFlow iterations = " << iterations;
-    viewer.AddRGBImage(
-            compose->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "MinMaxCurvatureFlow iterations = " << iterations;
+  viewer.AddRGBImage(compose->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/Code.cxx
@@ -23,77 +23,76 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    if (argc < 2)
-    {
-        CreateImage(image);
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<UnsignedCharImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-        image = reader->GetOutput();
-    }
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  if (argc < 2)
+  {
+    CreateImage(image);
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<UnsignedCharImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+  }
 
-    using ApproximateSignedDistanceMapImageFilterType = itk::ApproximateSignedDistanceMapImageFilter< UnsignedCharImageType, FloatImageType  >;
-    ApproximateSignedDistanceMapImageFilterType::Pointer approximateSignedDistanceMapImageFilter =
-            ApproximateSignedDistanceMapImageFilterType::New();
-    approximateSignedDistanceMapImageFilter->SetInput(image);
-    approximateSignedDistanceMapImageFilter->SetInsideValue(255);
-    approximateSignedDistanceMapImageFilter->SetOutsideValue(0);
+  using ApproximateSignedDistanceMapImageFilterType =
+    itk::ApproximateSignedDistanceMapImageFilter<UnsignedCharImageType, FloatImageType>;
+  ApproximateSignedDistanceMapImageFilterType::Pointer approximateSignedDistanceMapImageFilter =
+    ApproximateSignedDistanceMapImageFilterType::New();
+  approximateSignedDistanceMapImageFilter->SetInput(image);
+  approximateSignedDistanceMapImageFilter->SetInsideValue(255);
+  approximateSignedDistanceMapImageFilter->SetOutsideValue(0);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),true,
-            argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
+  QuickView viewer;
+  viewer.AddImage(
+    image.GetPointer(), true, argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
 
-    std::stringstream desc;
-    desc << "Approximate Signed Distance";
-    viewer.AddImage(
-            approximateSignedDistanceMapImageFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Approximate Signed Distance";
+  viewer.AddImage(approximateSignedDistanceMapImageFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    // Create an image
-    itk::Index<2> start;
-    start.Fill(0);
+  // Create an image
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start, size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  itk::ImageRegion<2> region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Create a line of white pixels
-    for(unsigned int i = 40; i < 60; ++i)
-    {
-        itk::Index<2> pixel;
-        pixel.Fill(i);
-        image->SetPixel(pixel, 255);
-    }
-
+  // Create a line of white pixels
+  for (unsigned int i = 40; i < 60; ++i)
+  {
+    itk::Index<2> pixel;
+    pixel.Fill(i);
+    image->SetPixel(pixel, 255);
+  }
 }

--- a/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/Code.cxx
@@ -23,75 +23,74 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    if (argc < 2)
-    {
-        CreateImage(image);
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<UnsignedCharImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-        image = reader->GetOutput();
-    }
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  if (argc < 2)
+  {
+    CreateImage(image);
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<UnsignedCharImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+  }
 
-    using SignedMaurerDistanceMapImageFilterType = itk::SignedMaurerDistanceMapImageFilter< UnsignedCharImageType, FloatImageType  >;
-    SignedMaurerDistanceMapImageFilterType::Pointer distanceMapImageFilter =
-            SignedMaurerDistanceMapImageFilterType::New();
-    distanceMapImageFilter->SetInput(image);
+  using SignedMaurerDistanceMapImageFilterType =
+    itk::SignedMaurerDistanceMapImageFilter<UnsignedCharImageType, FloatImageType>;
+  SignedMaurerDistanceMapImageFilterType::Pointer distanceMapImageFilter =
+    SignedMaurerDistanceMapImageFilterType::New();
+  distanceMapImageFilter->SetInput(image);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),true,
-            argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
+  QuickView viewer;
+  viewer.AddImage(
+    image.GetPointer(), true, argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
 
-    std::stringstream desc;
-    desc << "Signed Maurer Distance";
-    viewer.AddImage(
-            distanceMapImageFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Signed Maurer Distance";
+  viewer.AddImage(distanceMapImageFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    // Create an image
-    itk::Index<2> start;
-    start.Fill(0);
+  // Create an image
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start, size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  itk::ImageRegion<2> region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Create a line of white pixels
-    for(unsigned int i = 40; i < 60; ++i)
-    {
-        itk::Index<2> pixel;
-        pixel.Fill(i);
-        image->SetPixel(pixel, 255);
-    }
-
+  // Create a line of white pixels
+  for (unsigned int i = 40; i < 60; ++i)
+  {
+    itk::Index<2> pixel;
+    pixel.Fill(i);
+    image->SetPixel(pixel, 255);
+  }
 }

--- a/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/Code.cxx
+++ b/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/Code.cxx
@@ -20,96 +20,100 @@
 #include "itkContourMeanDistanceImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-template<typename TImage>
-static void CreateImage1(TImage* const);
+template <typename TImage>
+static void
+CreateImage1(TImage * const);
 
-template<typename TImage>
-static void CreateImage2(TImage* const);
+template <typename TImage>
+static void
+CreateImage2(TImage * const);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using ImageType = itk::Image<unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
 
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1.GetPointer());
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1.GetPointer());
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2.GetPointer());
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2.GetPointer());
 
-    using ContourMeanDistanceImageFilterType = itk::ContourMeanDistanceImageFilter <ImageType, ImageType >;
+  using ContourMeanDistanceImageFilterType = itk::ContourMeanDistanceImageFilter<ImageType, ImageType>;
 
-    ContourMeanDistanceImageFilterType::Pointer contourMeanDistanceImageFilter =
-            ContourMeanDistanceImageFilterType::New();
-    contourMeanDistanceImageFilter->SetInput1(image1);
-    contourMeanDistanceImageFilter->SetInput2(image2);
-    contourMeanDistanceImageFilter->Update();
+  ContourMeanDistanceImageFilterType::Pointer contourMeanDistanceImageFilter =
+    ContourMeanDistanceImageFilterType::New();
+  contourMeanDistanceImageFilter->SetInput1(image1);
+  contourMeanDistanceImageFilter->SetInput2(image2);
+  contourMeanDistanceImageFilter->Update();
 
-    std::cout << "Mean distance: " << contourMeanDistanceImageFilter->GetMeanDistance() << std::endl;
+  std::cout << "Mean distance: " << contourMeanDistanceImageFilter->GetMeanDistance() << std::endl;
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(image1.GetPointer());
-    viewer.AddImage(image2.GetPointer());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage(image1.GetPointer());
+  viewer.AddImage(image2.GetPointer());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-template<typename TImage>
-void CreateImage1(TImage* const image)
+template <typename TImage>
+void
+CreateImage1(TImage * const image)
 {
-    // Create an image bigger than the input image and that has dimensions which are powers of two
-    typename TImage::IndexType start = {{0,0}};
+  // Create an image bigger than the input image and that has dimensions which are powers of two
+  typename TImage::IndexType start = { { 0, 0 } };
 
-    typename TImage::SizeType size = {{20,20}};
+  typename TImage::SizeType size = { { 20, 20 } };
 
-    itk::ImageRegion<2> region(start, size);
+  itk::ImageRegion<2> region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Create a diagonal white line through the image
-    for(typename TImage::IndexValueType i = 0; i < 20; i++)
+  // Create a diagonal white line through the image
+  for (typename TImage::IndexValueType i = 0; i < 20; i++)
+  {
+    for (typename TImage::IndexValueType j = 0; j < 20; j++)
     {
-        for(typename TImage::IndexValueType j = 0; j < 20; j++)
-        {
-            if(i == j)
-            {
-                itk::Index<2> pixel = {{i,j}};
-                image->SetPixel(pixel, 255);
-            }
-        }
+      if (i == j)
+      {
+        itk::Index<2> pixel = { { i, j } };
+        image->SetPixel(pixel, 255);
+      }
     }
+  }
 }
 
-template<typename TImage>
-void CreateImage2(TImage* const image)
+template <typename TImage>
+void
+CreateImage2(TImage * const image)
 {
-    typename TImage::IndexType start = {{0,0}};
+  typename TImage::IndexType start = { { 0, 0 } };
 
-    typename TImage::SizeType size = {{20,20}};
+  typename TImage::SizeType size = { { 20, 20 } };
 
-    itk::ImageRegion<2> region(start, size);
+  itk::ImageRegion<2> region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Create a vertical line of white pixels down the center of the image
-    for(typename TImage::IndexValueType i = 0; i < 20; i++)
+  // Create a vertical line of white pixels down the center of the image
+  for (typename TImage::IndexValueType i = 0; i < 20; i++)
+  {
+    for (typename TImage::IndexValueType j = 0; j < 20; j++)
     {
-        for(typename TImage::IndexValueType j = 0; j < 20; j++)
-        {
-            if(i == 10)
-            {
-                itk::Index<2> pixel = {{i,j}};
-                image->SetPixel(pixel, 255);
-            }
-        }
+      if (i == 10)
+      {
+        itk::Index<2> pixel = { { i, j } };
+        image->SetPixel(pixel, 255);
+      }
     }
+  }
 }
-

--- a/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/Code.cxx
@@ -23,74 +23,74 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    if (argc < 2)
-    {
-        CreateImage(image);
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<UnsignedCharImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-        image = reader->GetOutput();
-    }
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  if (argc < 2)
+  {
+    CreateImage(image);
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<UnsignedCharImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+  }
 
-    using SignedDanielssonDistanceMapImageFilterType = itk::SignedDanielssonDistanceMapImageFilter< UnsignedCharImageType, FloatImageType  >;
-    SignedDanielssonDistanceMapImageFilterType::Pointer distanceMapImageFilter =
-            SignedDanielssonDistanceMapImageFilterType::New();
-    distanceMapImageFilter->SetInput(image);
+  using SignedDanielssonDistanceMapImageFilterType =
+    itk::SignedDanielssonDistanceMapImageFilter<UnsignedCharImageType, FloatImageType>;
+  SignedDanielssonDistanceMapImageFilterType::Pointer distanceMapImageFilter =
+    SignedDanielssonDistanceMapImageFilterType::New();
+  distanceMapImageFilter->SetInput(image);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),true,
-            argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
+  QuickView viewer;
+  viewer.AddImage(
+    image.GetPointer(), true, argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
 
-    std::stringstream desc;
-    desc << "Signed Danielsson Distance";
-    viewer.AddImage(
-            distanceMapImageFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Signed Danielsson Distance";
+  viewer.AddImage(distanceMapImageFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    // Create an image
-    itk::Index<2> start;
-    start.Fill(0);
+  // Create an image
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start, size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  itk::ImageRegion<2> region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Create a line of white pixels
-    for(unsigned int i = 40; i < 60; ++i)
-    {
-        itk::Index<2> pixel;
-        pixel.Fill(i);
-        image->SetPixel(pixel, 255);
-    }
+  // Create a line of white pixels
+  for (unsigned int i = 40; i < 60; ++i)
+  {
+    itk::Index<2> pixel;
+    pixel.Fill(i);
+    image->SetPixel(pixel, 255);
+  }
 }

--- a/src/Filtering/FFT/ComputeForwardFFT/Code.cxx
+++ b/src/Filtering/FFT/ComputeForwardFFT/Code.cxx
@@ -26,16 +26,17 @@
 #include "itkComplexToModulusImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <Real filename> <Imaginary filename> <Modulus filename>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * realFileName = argv[2];
@@ -45,103 +46,103 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 3;
 
   using FloatPixelType = float;
-  using FloatImageType = itk::Image< FloatPixelType, Dimension >;
+  using FloatImageType = itk::Image<FloatPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< FloatImageType >;
+  using ReaderType = itk::ImageFileReader<FloatImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   using UnsignedCharPixelType = unsigned char;
-  using UnsignedCharImageType = itk::Image< UnsignedCharPixelType, Dimension >;
+  using UnsignedCharImageType = itk::Image<UnsignedCharPixelType, Dimension>;
 
   // Some FFT filter implementations, like VNL's, need the image size to be a
   // multiple of small prime numbers.
-  using PadFilterType = itk::WrapPadImageFilter< FloatImageType, FloatImageType >;
+  using PadFilterType = itk::WrapPadImageFilter<FloatImageType, FloatImageType>;
   PadFilterType::Pointer padFilter = PadFilterType::New();
-  padFilter->SetInput( reader->GetOutput() );
+  padFilter->SetInput(reader->GetOutput());
   PadFilterType::SizeType padding;
   // Input size is [48, 62, 42].  Pad to [48, 64, 48].
   padding[0] = 0;
   padding[1] = 2;
   padding[2] = 6;
-  padFilter->SetPadUpperBound( padding );
+  padFilter->SetPadUpperBound(padding);
 
-  using FFTType = itk::ForwardFFTImageFilter< FloatImageType >;
+  using FFTType = itk::ForwardFFTImageFilter<FloatImageType>;
   FFTType::Pointer fftFilter = FFTType::New();
-  fftFilter->SetInput( padFilter->GetOutput() );
+  fftFilter->SetInput(padFilter->GetOutput());
 
   using FFTOutputImageType = FFTType::OutputImageType;
 
   // Extract the real part
-  using RealFilterType = itk::ComplexToRealImageFilter< FFTOutputImageType, FloatImageType>;
+  using RealFilterType = itk::ComplexToRealImageFilter<FFTOutputImageType, FloatImageType>;
   RealFilterType::Pointer realFilter = RealFilterType::New();
   realFilter->SetInput(fftFilter->GetOutput());
 
-  using RescaleFilterType = itk::RescaleIntensityImageFilter< FloatImageType, UnsignedCharImageType >;
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
   RescaleFilterType::Pointer realRescaleFilter = RescaleFilterType::New();
   realRescaleFilter->SetInput(realFilter->GetOutput());
-  realRescaleFilter->SetOutputMinimum( itk::NumericTraits< UnsignedCharPixelType >::min() );
-  realRescaleFilter->SetOutputMaximum( itk::NumericTraits< UnsignedCharPixelType >::max() );
+  realRescaleFilter->SetOutputMinimum(itk::NumericTraits<UnsignedCharPixelType>::min());
+  realRescaleFilter->SetOutputMaximum(itk::NumericTraits<UnsignedCharPixelType>::max());
 
-  using WriterType = itk::ImageFileWriter< UnsignedCharImageType >;
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
   WriterType::Pointer realWriter = WriterType::New();
-  realWriter->SetFileName( realFileName );
-  realWriter->SetInput( realRescaleFilter->GetOutput() );
+  realWriter->SetFileName(realFileName);
+  realWriter->SetInput(realRescaleFilter->GetOutput());
   try
-    {
+  {
     realWriter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Extract the imaginary part
-  using ImaginaryFilterType = itk::ComplexToImaginaryImageFilter< FFTOutputImageType, FloatImageType>;
+  using ImaginaryFilterType = itk::ComplexToImaginaryImageFilter<FFTOutputImageType, FloatImageType>;
   ImaginaryFilterType::Pointer imaginaryFilter = ImaginaryFilterType::New();
   imaginaryFilter->SetInput(fftFilter->GetOutput());
 
   RescaleFilterType::Pointer imaginaryRescaleFilter = RescaleFilterType::New();
   imaginaryRescaleFilter->SetInput(imaginaryFilter->GetOutput());
-  imaginaryRescaleFilter->SetOutputMinimum( itk::NumericTraits< UnsignedCharPixelType >::min() );
-  imaginaryRescaleFilter->SetOutputMaximum( itk::NumericTraits< UnsignedCharPixelType >::max() );
+  imaginaryRescaleFilter->SetOutputMinimum(itk::NumericTraits<UnsignedCharPixelType>::min());
+  imaginaryRescaleFilter->SetOutputMaximum(itk::NumericTraits<UnsignedCharPixelType>::max());
 
   WriterType::Pointer complexWriter = WriterType::New();
-  complexWriter->SetFileName( imaginaryFileName );
-  complexWriter->SetInput( imaginaryRescaleFilter->GetOutput() );
+  complexWriter->SetFileName(imaginaryFileName);
+  complexWriter->SetInput(imaginaryRescaleFilter->GetOutput());
   try
-    {
+  {
     complexWriter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Compute the magnitude
-  using ModulusFilterType = itk::ComplexToModulusImageFilter< FFTOutputImageType, FloatImageType>;
+  using ModulusFilterType = itk::ComplexToModulusImageFilter<FFTOutputImageType, FloatImageType>;
   ModulusFilterType::Pointer modulusFilter = ModulusFilterType::New();
   modulusFilter->SetInput(fftFilter->GetOutput());
 
   RescaleFilterType::Pointer magnitudeRescaleFilter = RescaleFilterType::New();
   magnitudeRescaleFilter->SetInput(modulusFilter->GetOutput());
-  magnitudeRescaleFilter->SetOutputMinimum( itk::NumericTraits< UnsignedCharPixelType >::min() );
-  magnitudeRescaleFilter->SetOutputMaximum( itk::NumericTraits< UnsignedCharPixelType >::max() );
+  magnitudeRescaleFilter->SetOutputMinimum(itk::NumericTraits<UnsignedCharPixelType>::min());
+  magnitudeRescaleFilter->SetOutputMaximum(itk::NumericTraits<UnsignedCharPixelType>::max());
 
   WriterType::Pointer magnitudeWriter = WriterType::New();
-  magnitudeWriter->SetFileName( modulusFileName );
-  magnitudeWriter->SetInput( magnitudeRescaleFilter->GetOutput() );
+  magnitudeWriter->SetFileName(modulusFileName);
+  magnitudeWriter->SetInput(magnitudeRescaleFilter->GetOutput());
   try
-    {
+  {
     magnitudeWriter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/FFT/ComputeInverseFFTOfImage/Code.cxx
+++ b/src/Filtering/FFT/ComputeInverseFFTOfImage/Code.cxx
@@ -25,81 +25,84 @@
 
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage(FloatImageType* const image);
+static void
+CreateImage(FloatImageType * const image);
 
-int main(int argc, char*argv[])
+int
+main(int argc, char * argv[])
 {
-    FloatImageType::Pointer image;
-    // Verify input
-    if(argc < 2)
-    {
-        image = FloatImageType::New();
-        CreateImage(image);
-        //std::cerr << "Required: filename" << std::endl;
-        //return EXIT_FAILURE;
-    }
-    else
-    {
-        // Read the image
-        using ReaderType = itk::ImageFileReader<FloatImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
+  FloatImageType::Pointer image;
+  // Verify input
+  if (argc < 2)
+  {
+    image = FloatImageType::New();
+    CreateImage(image);
+    // std::cerr << "Required: filename" << std::endl;
+    // return EXIT_FAILURE;
+  }
+  else
+  {
+    // Read the image
+    using ReaderType = itk::ImageFileReader<FloatImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
 
-        image = reader->GetOutput();
-    }
+    image = reader->GetOutput();
+  }
 
-    // Define some types
-    using UnsignedCharImageType = itk::Image<unsigned char, 2>;
+  // Define some types
+  using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-    // Compute the FFT
-    using FFTType = itk::ForwardFFTImageFilter<FloatImageType>;
-    FFTType::Pointer fftFilter = FFTType::New();
-    fftFilter->SetInput(image);
-    fftFilter->Update();
+  // Compute the FFT
+  using FFTType = itk::ForwardFFTImageFilter<FloatImageType>;
+  FFTType::Pointer fftFilter = FFTType::New();
+  fftFilter->SetInput(image);
+  fftFilter->Update();
 
-    // Compute the IFFT
-    //using IFFTType = itk::InverseFFTImageFilter<FFTType::OutputImageType, UnsignedCharImageType>; // This does not work - output type seems to need to be float, but it is just an error, not a concept check error...
-    using IFFTType = itk::InverseFFTImageFilter<FFTType::OutputImageType, FloatImageType>;
-    IFFTType::Pointer ifftFilter = IFFTType::New();
-    ifftFilter->SetInput(fftFilter->GetOutput());
-    ifftFilter->Update();
+  // Compute the IFFT
+  // using IFFTType = itk::InverseFFTImageFilter<FFTType::OutputImageType, UnsignedCharImageType>; // This does not work
+  // - output type seems to need to be float, but it is just an error, not a concept check error...
+  using IFFTType = itk::InverseFFTImageFilter<FFTType::OutputImageType, FloatImageType>;
+  IFFTType::Pointer ifftFilter = IFFTType::New();
+  ifftFilter->SetInput(fftFilter->GetOutput());
+  ifftFilter->Update();
 
-    using CastFilterType = itk::CastImageFilter< FloatImageType, UnsignedCharImageType >;
-    CastFilterType::Pointer castFilter = CastFilterType::New();
-    castFilter->SetInput(ifftFilter->GetOutput());
-    castFilter->Update();
+  using CastFilterType = itk::CastImageFilter<FloatImageType, UnsignedCharImageType>;
+  CastFilterType::Pointer castFilter = CastFilterType::New();
+  castFilter->SetInput(ifftFilter->GetOutput());
+  castFilter->Update();
 
-    using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
 
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("ifft.png");
-    writer->SetInput(castFilter->GetOutput());
-    writer->Update();
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("ifft.png");
+  writer->SetInput(castFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(FloatImageType* const image)
+void
+CreateImage(FloatImageType * const image)
 {
-    itk::Index<2> corner = {{0,0}};
+  itk::Index<2> corner = { { 0, 0 } };
 
-    itk::Size<2> size = {{200,200}};
+  itk::Size<2> size = { { 200, 200 } };
 
-    itk::ImageRegion<2> region(corner, size);
+  itk::ImageRegion<2> region(corner, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(FloatImageType::IndexValueType r = 40; r < 100; r++)
+  // Make a square
+  for (FloatImageType::IndexValueType r = 40; r < 100; r++)
+  {
+    for (FloatImageType::IndexValueType c = 40; c < 100; c++)
     {
-        for(FloatImageType::IndexValueType c = 40; c < 100; c++)
-        {
-            FloatImageType::IndexType pixelIndex = {{r,c}};
+      FloatImageType::IndexType pixelIndex = { { r, c } };
 
-            image->SetPixel(pixelIndex, 100);
-        }
+      image->SetPixel(pixelIndex, 100);
     }
+  }
 }
-

--- a/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/Code.cxx
+++ b/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/Code.cxx
@@ -23,83 +23,82 @@
 #include "itkMeshFileReader.h"
 #include "itkMeshFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if(  argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Usage: " << argv[0] << std::endl;
     std::cerr << " <input filename> <output filename>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   using PixelType = float;
   using CoordType = double;
 
   constexpr unsigned int Dimension = 3;
 
-  using Traits = itk::QuadEdgeMeshExtendedTraits <
-    PixelType,  // type of data for vertices
-    Dimension,  // geometrical dimension of space
-    2,          // Mac topological dimension of a cell
-    CoordType,  // type for point coordinate
-    CoordType,  // type for interpolation weight
-    PixelType,  // type of data for cell
-    bool,       // type of data for primal edges
-    bool        // type of data for dual edges
-  >;
+  using Traits = itk::QuadEdgeMeshExtendedTraits<PixelType, // type of data for vertices
+                                                 Dimension, // geometrical dimension of space
+                                                 2,         // Mac topological dimension of a cell
+                                                 CoordType, // type for point coordinate
+                                                 CoordType, // type for interpolation weight
+                                                 PixelType, // type of data for cell
+                                                 bool,      // type of data for primal edges
+                                                 bool       // type of data for dual edges
+                                                 >;
 
-  using MeshType = itk::QuadEdgeMesh< PixelType, Dimension, Traits >;
+  using MeshType = itk::QuadEdgeMesh<PixelType, Dimension, Traits>;
 
-  using ReaderType = itk::MeshFileReader< MeshType >;
+  using ReaderType = itk::MeshFileReader<MeshType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using FastMarchingType = itk::FastMarchingQuadEdgeMeshFilterBase< MeshType, MeshType >;
+  using FastMarchingType = itk::FastMarchingQuadEdgeMeshFilterBase<MeshType, MeshType>;
 
   MeshType::Pointer mesh = reader->GetOutput();
 
-  MeshType::PointsContainerConstPointer points =
-      mesh->GetPoints();
+  MeshType::PointsContainerConstPointer points = mesh->GetPoints();
 
   MeshType::PointsContainerConstIterator pIt = points->Begin();
   MeshType::PointsContainerConstIterator pEnd = points->End();
 
-  while( pIt != pEnd )
-    {
-    mesh->SetPointData( pIt->Index(), 1. );
+  while (pIt != pEnd)
+  {
+    mesh->SetPointData(pIt->Index(), 1.);
     ++pIt;
-    }
+  }
 
   using NodePairType = FastMarchingType::NodePairType;
   using NodePairContainerType = FastMarchingType::NodePairContainerType;
 
   NodePairContainerType::Pointer trial = NodePairContainerType::New();
 
-  NodePairType nodePair( 0, 0. );
-  trial->push_back( nodePair );
+  NodePairType nodePair(0, 0.);
+  trial->push_back(nodePair);
 
-  using CriterionType = itk::FastMarchingThresholdStoppingCriterion< MeshType, MeshType >;
+  using CriterionType = itk::FastMarchingThresholdStoppingCriterion<MeshType, MeshType>;
   CriterionType::Pointer criterion = CriterionType::New();
-  criterion->SetThreshold( 100. );
+  criterion->SetThreshold(100.);
 
   FastMarchingType::Pointer fmmFilter = FastMarchingType::New();
-  fmmFilter->SetInput( mesh );
-  fmmFilter->SetTrialPoints( trial );
-  fmmFilter->SetStoppingCriterion( criterion );
+  fmmFilter->SetInput(mesh);
+  fmmFilter->SetTrialPoints(trial);
+  fmmFilter->SetStoppingCriterion(criterion);
 
-  using WriterType = itk::MeshFileWriter< MeshType >;
+  using WriterType = itk::MeshFileWriter<MeshType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( fmmFilter->GetOutput() );
-  writer->SetFileName( argv[2] );
+  writer->SetInput(fmmFilter->GetOutput());
+  writer->SetFileName(argv[2]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/Code.cxx
+++ b/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/Code.cxx
@@ -21,116 +21,115 @@
 #include "itkFastMarchingThresholdStoppingCriterion.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage:" << std::endl;
     std::cerr << argv[0] << " <OutputFileName>" << std::endl;
 
     return EXIT_FAILURE;
-    }
+  }
 
   // create a fastmarching object
   using PixelType = float;
   constexpr unsigned int Dimension = 2;
 
-  using FloatImageType = itk::Image< PixelType, Dimension >;
+  using FloatImageType = itk::Image<PixelType, Dimension>;
 
-  using CriterionType = itk::FastMarchingThresholdStoppingCriterion< FloatImageType,
-    FloatImageType >;
+  using CriterionType = itk::FastMarchingThresholdStoppingCriterion<FloatImageType, FloatImageType>;
 
-  using FastMarchingType = itk::FastMarchingImageFilterBase< FloatImageType, FloatImageType >;
+  using FastMarchingType = itk::FastMarchingImageFilterBase<FloatImageType, FloatImageType>;
 
   CriterionType::Pointer criterion = CriterionType::New();
-  criterion->SetThreshold( 100. );
+  criterion->SetThreshold(100.);
 
   FastMarchingType::Pointer marcher = FastMarchingType::New();
-  marcher->SetStoppingCriterion( criterion );
+  marcher->SetStoppingCriterion(criterion);
 
   // specify the size of the output image
-  FloatImageType::SizeType size = {{64,64}};
-  marcher->SetOutputSize( size );
+  FloatImageType::SizeType size = { { 64, 64 } };
+  marcher->SetOutputSize(size);
 
   // setup a speed image of ones
   FloatImageType::Pointer speedImage = FloatImageType::New();
 
   FloatImageType::RegionType region;
-  region.SetSize( size );
+  region.SetSize(size);
 
-  speedImage->SetLargestPossibleRegion( region );
-  speedImage->SetBufferedRegion( region );
+  speedImage->SetLargestPossibleRegion(region);
+  speedImage->SetBufferedRegion(region);
   speedImage->Allocate();
-  speedImage->FillBuffer( 1.0 );
+  speedImage->FillBuffer(1.0);
 
   // setup a 'alive image'
   FloatImageType::Pointer AliveImage = FloatImageType::New();
-  AliveImage->SetLargestPossibleRegion( region );
-  AliveImage->SetBufferedRegion( region );
+  AliveImage->SetLargestPossibleRegion(region);
+  AliveImage->SetBufferedRegion(region);
   AliveImage->Allocate();
-  AliveImage->FillBuffer( 0.0 );
+  AliveImage->FillBuffer(0.0);
 
-  FloatImageType::OffsetType offset0 = {{28,35}};
+  FloatImageType::OffsetType offset0 = { { 28, 35 } };
 
   FloatImageType::IndexType index;
   index.Fill(0);
   index += offset0;
 
-  AliveImage->SetPixel( index, 1.0 );
+  AliveImage->SetPixel(index, 1.0);
 
   // setup a 'trial image'
   FloatImageType::Pointer TrialImage = FloatImageType::New();
-  TrialImage->SetLargestPossibleRegion( region );
-  TrialImage->SetBufferedRegion( region );
+  TrialImage->SetLargestPossibleRegion(region);
+  TrialImage->SetBufferedRegion(region);
   TrialImage->Allocate();
-  TrialImage->FillBuffer( 0.0 );
+  TrialImage->FillBuffer(0.0);
 
   index[0] += 1;
-  TrialImage->SetPixel( index, 1.0 );
+  TrialImage->SetPixel(index, 1.0);
 
   index[0] -= 1;
   index[1] += 1;
-  TrialImage->SetPixel( index, 1.0 );
+  TrialImage->SetPixel(index, 1.0);
 
   index[0] -= 1;
   index[1] -= 1;
-  TrialImage->SetPixel( index, 1.0 );
+  TrialImage->SetPixel(index, 1.0);
 
   index[0] += 1;
   index[1] -= 1;
-  TrialImage->SetPixel( index, 1.0 );
+  TrialImage->SetPixel(index, 1.0);
 
-  marcher->SetInput( speedImage );
+  marcher->SetInput(speedImage);
 
-  using AdaptorType = itk::FastMarchingImageToNodePairContainerAdaptor< FloatImageType,
-      FloatImageType, FloatImageType >;
+  using AdaptorType = itk::FastMarchingImageToNodePairContainerAdaptor<FloatImageType, FloatImageType, FloatImageType>;
 
   AdaptorType::Pointer adaptor = AdaptorType::New();
 
-  adaptor->SetAliveImage( AliveImage.GetPointer() );
-  adaptor->SetAliveValue( 0.0 );
+  adaptor->SetAliveImage(AliveImage.GetPointer());
+  adaptor->SetAliveValue(0.0);
 
-  adaptor->SetTrialImage( TrialImage.GetPointer() );
-  adaptor->SetTrialValue( 1.0 );
+  adaptor->SetTrialImage(TrialImage.GetPointer());
+  adaptor->SetTrialValue(1.0);
   adaptor->Update();
 
-  marcher->SetAlivePoints( adaptor->GetAlivePoints() );
-  marcher->SetTrialPoints( adaptor->GetTrialPoints() );
+  marcher->SetAlivePoints(adaptor->GetAlivePoints());
+  marcher->SetTrialPoints(adaptor->GetTrialPoints());
 
-  using WriterType = itk::ImageFileWriter< FloatImageType >;
+  using WriterType = itk::ImageFileWriter<FloatImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( marcher->GetOutput() );
-  writer->SetFileName( argv[1] );
+  writer->SetInput(marcher->GetOutput());
+  writer->SetFileName(argv[1]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageCompare/AbsValueOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageCompare/AbsValueOfTwoImages/Code.cxx
@@ -22,79 +22,82 @@
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage1(UnsignedCharImageType::Pointer image);
-static void CreateImage2(UnsignedCharImageType::Pointer image);
+static void
+CreateImage1(UnsignedCharImageType::Pointer image);
+static void
+CreateImage2(UnsignedCharImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    UnsignedCharImageType::Pointer image1 = UnsignedCharImageType::New();
-    CreateImage1(image1);
+  UnsignedCharImageType::Pointer image1 = UnsignedCharImageType::New();
+  CreateImage1(image1);
 
-    UnsignedCharImageType::Pointer image2 = UnsignedCharImageType::New();
-    CreateImage2(image2);
+  UnsignedCharImageType::Pointer image2 = UnsignedCharImageType::New();
+  CreateImage2(image2);
 
-    using AbsoluteValueDifferenceImageFilterType = itk::AbsoluteValueDifferenceImageFilter <UnsignedCharImageType, UnsignedCharImageType,
-            FloatImageType>;
+  using AbsoluteValueDifferenceImageFilterType =
+    itk::AbsoluteValueDifferenceImageFilter<UnsignedCharImageType, UnsignedCharImageType, FloatImageType>;
 
-    AbsoluteValueDifferenceImageFilterType::Pointer absoluteValueDifferenceFilter
-            = AbsoluteValueDifferenceImageFilterType::New ();
-    absoluteValueDifferenceFilter->SetInput1(image1);
-    absoluteValueDifferenceFilter->SetInput2(image2);
-    absoluteValueDifferenceFilter->Update();
+  AbsoluteValueDifferenceImageFilterType::Pointer absoluteValueDifferenceFilter =
+    AbsoluteValueDifferenceImageFilterType::New();
+  absoluteValueDifferenceFilter->SetInput1(image1);
+  absoluteValueDifferenceFilter->SetInput2(image2);
+  absoluteValueDifferenceFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(UnsignedCharImageType::Pointer image)
+void
+CreateImage1(UnsignedCharImageType::Pointer image)
 {
-    UnsignedCharImageType::IndexType start;
-    start.Fill(0);
+  UnsignedCharImageType::IndexType start;
+  start.Fill(0);
 
-    UnsignedCharImageType::SizeType size;
-    size.Fill(10);
+  UnsignedCharImageType::SizeType size;
+  size.Fill(10);
 
-    UnsignedCharImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  UnsignedCharImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(255);
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(255);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 }
 
 
-void CreateImage2(UnsignedCharImageType::Pointer image)
+void
+CreateImage2(UnsignedCharImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    UnsignedCharImageType::IndexType start;
-    start.Fill(0);
+  // Create an image with 2 connected components
+  UnsignedCharImageType::IndexType start;
+  start.Fill(0);
 
-    UnsignedCharImageType::SizeType size;
-    size.Fill(10);
+  UnsignedCharImageType::SizeType size;
+  size.Fill(10);
 
-    UnsignedCharImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  UnsignedCharImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(100);
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(100);
 
-        ++imageIterator;
-    }
-
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/Code.cxx
+++ b/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/Code.cxx
@@ -20,19 +20,20 @@
 #include "itkCheckerBoardImageFilter.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
+  if (argc != 2)
+  {
     std::cerr << "Usage:" << std::endl;
     std::cerr << argv[0] << " <OutputImage>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::IndexType start;
   start.Fill(0);
@@ -47,33 +48,32 @@ int main(int argc, char *argv[])
   ImageType::Pointer image1 = ImageType::New();
   image1->SetRegions(region);
   image1->Allocate();
-  image1->FillBuffer( 0 );
+  image1->FillBuffer(0);
 
   ImageType::Pointer image2 = ImageType::New();
   image2->SetRegions(region);
   image2->Allocate();
-  image2->FillBuffer( 255 );
+  image2->FillBuffer(255);
 
-  using CheckerBoardFilterType = itk::CheckerBoardImageFilter< ImageType >;
-  CheckerBoardFilterType::Pointer checkerBoardFilter =
-    CheckerBoardFilterType::New();
+  using CheckerBoardFilterType = itk::CheckerBoardImageFilter<ImageType>;
+  CheckerBoardFilterType::Pointer checkerBoardFilter = CheckerBoardFilterType::New();
   checkerBoardFilter->SetInput1(image1);
   checkerBoardFilter->SetInput2(image2);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( checkerBoardFilter->GetOutput() );
-  writer->SetFileName( argv[1] );
+  writer->SetInput(checkerBoardFilter->GetOutput());
+  writer->SetFileName(argv[1]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Code.cxx
@@ -22,78 +22,81 @@
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage1(UnsignedCharImageType::Pointer image);
-static void CreateImage2(UnsignedCharImageType::Pointer image);
+static void
+CreateImage1(UnsignedCharImageType::Pointer image);
+static void
+CreateImage2(UnsignedCharImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    UnsignedCharImageType::Pointer image1 = UnsignedCharImageType::New();
-    CreateImage1(image1);
+  UnsignedCharImageType::Pointer image1 = UnsignedCharImageType::New();
+  CreateImage1(image1);
 
-    UnsignedCharImageType::Pointer image2 = UnsignedCharImageType::New();
-    CreateImage2(image2);
+  UnsignedCharImageType::Pointer image2 = UnsignedCharImageType::New();
+  CreateImage2(image2);
 
-    using SquaredDifferenceImageFilterType = itk::SquaredDifferenceImageFilter <UnsignedCharImageType, UnsignedCharImageType,
-            FloatImageType>;
+  using SquaredDifferenceImageFilterType =
+    itk::SquaredDifferenceImageFilter<UnsignedCharImageType, UnsignedCharImageType, FloatImageType>;
 
-    SquaredDifferenceImageFilterType::Pointer squaredDifferenceFilter
-            = SquaredDifferenceImageFilterType::New ();
-    squaredDifferenceFilter->SetInput1(image1);
-    squaredDifferenceFilter->SetInput2(image2);
-    squaredDifferenceFilter->Update();
+  SquaredDifferenceImageFilterType::Pointer squaredDifferenceFilter = SquaredDifferenceImageFilterType::New();
+  squaredDifferenceFilter->SetInput1(image1);
+  squaredDifferenceFilter->SetInput2(image2);
+  squaredDifferenceFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(UnsignedCharImageType::Pointer image)
+void
+CreateImage1(UnsignedCharImageType::Pointer image)
 {
-    UnsignedCharImageType::IndexType start;
-    start.Fill(0);
+  UnsignedCharImageType::IndexType start;
+  start.Fill(0);
 
-    UnsignedCharImageType::SizeType size;
-    size.Fill(10);
+  UnsignedCharImageType::SizeType size;
+  size.Fill(10);
 
-    UnsignedCharImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  UnsignedCharImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(255);
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(255);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 }
 
 
-void CreateImage2(UnsignedCharImageType::Pointer image)
+void
+CreateImage2(UnsignedCharImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    UnsignedCharImageType::IndexType start;
-    start.Fill(0);
+  // Create an image with 2 connected components
+  UnsignedCharImageType::IndexType start;
+  start.Fill(0);
 
-    UnsignedCharImageType::SizeType size;
-    size.Fill(10);
+  UnsignedCharImageType::SizeType size;
+  size.Fill(10);
 
-    UnsignedCharImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  UnsignedCharImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(100);
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(100);
 
-        ++imageIterator;
-    }
-
+    ++imageIterator;
+  }
 }

--- a/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/Code.cxx
+++ b/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/Code.cxx
@@ -18,66 +18,68 @@
 #include "itkImageAdaptor.h"
 #include "itkImageRegionIterator.h"
 #if ITK_VERSION_MAJOR < 4
-#include "itkCompose3DCovariantVectorImageFilter.h"
+#  include "itkCompose3DCovariantVectorImageFilter.h"
 #else
-#include "itkComposeImageFilter.h"
+#  include "itkComposeImageFilter.h"
 #endif
 
-using VectorImageType = itk::Image<itk::CovariantVector< float, 3>, 2>;
+using VectorImageType = itk::Image<itk::CovariantVector<float, 3>, 2>;
 using ScalarImageType = itk::Image<float, 2>;
 
-static void CreateImage(ScalarImageType::Pointer image);
+static void
+CreateImage(ScalarImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ScalarImageType::Pointer image = ScalarImageType::New();
-    CreateImage(image);
+  ScalarImageType::Pointer image = ScalarImageType::New();
+  CreateImage(image);
 
 #if ITK_VERSION_MAJOR < 4
-    using ComposeCovariantVectorImageFilterType = itk::Compose3DCovariantVectorImageFilter<ScalarImageType,
-                              VectorImageType>;
+  using ComposeCovariantVectorImageFilterType =
+    itk::Compose3DCovariantVectorImageFilter<ScalarImageType, VectorImageType>;
 #else
-    using ComposeCovariantVectorImageFilterType = itk::ComposeImageFilter<ScalarImageType,
-            VectorImageType>;
+  using ComposeCovariantVectorImageFilterType = itk::ComposeImageFilter<ScalarImageType, VectorImageType>;
 #endif
-    ComposeCovariantVectorImageFilterType::Pointer composeFilter = ComposeCovariantVectorImageFilterType::New();
+  ComposeCovariantVectorImageFilterType::Pointer composeFilter = ComposeCovariantVectorImageFilterType::New();
 
-    composeFilter->SetInput1(image);
-    composeFilter->SetInput2(image);
-    composeFilter->SetInput3(image);
-    composeFilter->Update();
+  composeFilter->SetInput1(image);
+  composeFilter->SetInput2(image);
+  composeFilter->SetInput3(image);
+  composeFilter->Update();
 
-    itk::Index<2> index;
-    index.Fill(0);
+  itk::Index<2> index;
+  index.Fill(0);
 
-    std::cout << image->GetPixel(index) << std::endl;
+  std::cout << image->GetPixel(index) << std::endl;
 
-    std::cout << composeFilter->GetOutput()->GetPixel(index) << std::endl;
+  std::cout << composeFilter->GetOutput()->GetPixel(index) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ScalarImageType::Pointer image)
+void
+CreateImage(ScalarImageType::Pointer image)
 {
-    ScalarImageType::IndexType start;
-    start.Fill(0);
+  ScalarImageType::IndexType start;
+  start.Fill(0);
 
-    ScalarImageType::SizeType size;
-    size.Fill(2);
+  ScalarImageType::SizeType size;
+  size.Fill(2);
 
-    ScalarImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ScalarImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ScalarImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ScalarImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(1.2);
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(1.2);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 }

--- a/src/Filtering/ImageCompose/ConvertRealAndImaginaryToComplexImage/Code.cxx
+++ b/src/Filtering/ImageCompose/ConvertRealAndImaginaryToComplexImage/Code.cxx
@@ -18,33 +18,36 @@
 #include "itkImage.h"
 
 #if ITK_VERSION_MAJOR < 4
-#include "itkRealAndImaginaryToComplexImageFilter.h"
+#  include "itkRealAndImaginaryToComplexImageFilter.h"
 #else
-#include "itkComposeImageFilter.h"
+#  include "itkComposeImageFilter.h"
 #endif
 
 #include <complex>
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-    using ImageType = itk::Image<unsigned char, 2>;
-    using ComplexImageType = itk::Image<std::complex<float>, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
+  using ComplexImageType = itk::Image<std::complex<float>, 2>;
 
-    ImageType::Pointer realImage = ImageType::New();
-    ImageType::Pointer imaginaryImage = ImageType::New();
+  ImageType::Pointer realImage = ImageType::New();
+  ImageType::Pointer imaginaryImage = ImageType::New();
 
 #if ITK_VERSION_MAJOR < 4
-    using RealAndImaginaryToComplexImageFilterType = itk::RealAndImaginaryToComplexImageFilter<ImageType,ComplexImageType>;
+  using RealAndImaginaryToComplexImageFilterType =
+    itk::RealAndImaginaryToComplexImageFilter<ImageType, ComplexImageType>;
 #else
-    using RealAndImaginaryToComplexImageFilterType = itk::ComposeImageFilter<ImageType,ComplexImageType>;
+  using RealAndImaginaryToComplexImageFilterType = itk::ComposeImageFilter<ImageType, ComplexImageType>;
 #endif
-    RealAndImaginaryToComplexImageFilterType::Pointer realAndImaginaryToComplexImageFilter = RealAndImaginaryToComplexImageFilterType::New();
-    realAndImaginaryToComplexImageFilter->SetInput1(realImage);
-    realAndImaginaryToComplexImageFilter->SetInput2(imaginaryImage);
-    realAndImaginaryToComplexImageFilter->Update();
+  RealAndImaginaryToComplexImageFilterType::Pointer realAndImaginaryToComplexImageFilter =
+    RealAndImaginaryToComplexImageFilterType::New();
+  realAndImaginaryToComplexImageFilter->SetInput1(realImage);
+  realAndImaginaryToComplexImageFilter->SetInput2(imaginaryImage);
+  realAndImaginaryToComplexImageFilter->Update();
 
-    ComplexImageType* output = realAndImaginaryToComplexImageFilter->GetOutput();
-    output->Print(std::cout);
+  ComplexImageType * output = realAndImaginaryToComplexImageFilter->GetOutput();
+  output->Print(std::cout);
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/Code.cxx
+++ b/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/Code.cxx
@@ -21,47 +21,49 @@
 
 namespace
 {
-    using VectorImageType = itk::VectorImage<unsigned char, 2>;
-    using ScalarImageType = itk::Image<unsigned char, 2>;
+using VectorImageType = itk::VectorImage<unsigned char, 2>;
+using ScalarImageType = itk::Image<unsigned char, 2>;
+} // namespace
+
+static void
+CreateImage(ScalarImageType::Pointer image);
+
+int
+main(int, char *[])
+{
+  ScalarImageType::Pointer image0 = ScalarImageType::New();
+  CreateImage(image0);
+
+  ScalarImageType::Pointer image1 = ScalarImageType::New();
+  CreateImage(image1);
+
+  ScalarImageType::Pointer image2 = ScalarImageType::New();
+  CreateImage(image2);
+
+  using ImageToVectorImageFilterType = itk::ComposeImageFilter<ScalarImageType>;
+  ImageToVectorImageFilterType::Pointer imageToVectorImageFilter = ImageToVectorImageFilterType::New();
+  imageToVectorImageFilter->SetInput(0, image0);
+  imageToVectorImageFilter->SetInput(1, image1);
+  imageToVectorImageFilter->SetInput(2, image2);
+  imageToVectorImageFilter->Update();
+
+  VectorImageType::Pointer vectorImage = imageToVectorImageFilter->GetOutput();
+
+  return EXIT_SUCCESS;
 }
 
-static void CreateImage(ScalarImageType::Pointer image);
-
-int main(int, char *[])
+void
+CreateImage(ScalarImageType::Pointer image)
 {
-    ScalarImageType::Pointer image0 = ScalarImageType::New();
-    CreateImage(image0);
+  ScalarImageType::IndexType start;
+  start.Fill(0);
 
-    ScalarImageType::Pointer image1 = ScalarImageType::New();
-    CreateImage(image1);
+  ScalarImageType::SizeType size;
+  size.Fill(100);
 
-    ScalarImageType::Pointer image2 = ScalarImageType::New();
-    CreateImage(image2);
+  ScalarImageType::RegionType region(start, size);
 
-    using ImageToVectorImageFilterType = itk::ComposeImageFilter<ScalarImageType>;
-    ImageToVectorImageFilterType::Pointer imageToVectorImageFilter = ImageToVectorImageFilterType::New();
-    imageToVectorImageFilter->SetInput(0, image0);
-    imageToVectorImageFilter->SetInput(1, image1);
-    imageToVectorImageFilter->SetInput(2, image2);
-    imageToVectorImageFilter->Update();
-
-    VectorImageType::Pointer vectorImage = imageToVectorImageFilter->GetOutput();
-
-    return EXIT_SUCCESS;
-}
-
-void CreateImage(ScalarImageType::Pointer image)
-{
-    ScalarImageType::IndexType start;
-    start.Fill(0);
-
-    ScalarImageType::SizeType size;
-    size.Fill(100);
-
-    ScalarImageType::RegionType region(start,size);
-
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
-
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 }

--- a/src/Filtering/ImageCompose/JoinImages/Code.cxx
+++ b/src/Filtering/ImageCompose/JoinImages/Code.cxx
@@ -23,9 +23,11 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image, unsigned char value);
+static void
+CreateImage(ImageType::Pointer image, unsigned char value);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage(image1, 0);
@@ -43,14 +45,15 @@ int main(int, char *[])
   itk::Index<2> index;
   index[0] = 0;
   index[1] = 0;
-  
+
   std::cout << static_cast<int>(joinFilter->GetOutput()->GetPixel(index)[0]) << std::endl;
   std::cout << static_cast<int>(joinFilter->GetOutput()->GetPixel(index)[1]) << std::endl;
 
   return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image, unsigned char value)
+void
+CreateImage(ImageType::Pointer image, unsigned char value)
 {
   // Create an image
   ImageType::IndexType start;
@@ -59,10 +62,9 @@ void CreateImage(ImageType::Pointer image, unsigned char value)
   ImageType::SizeType size;
   size.Fill(100);
 
-  ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
   image->SetRegions(region);
   image->Allocate();
   image->FillBuffer(value);
-
 }

--- a/src/Filtering/ImageFeature/BilateralFilterAnImage/Code.cxx
+++ b/src/Filtering/ImageFeature/BilateralFilterAnImage/Code.cxx
@@ -21,77 +21,67 @@
 #include "itkSubtractImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " inputImageFile [domainSigma] [rangeSigma]" << std::endl;
-        return EXIT_FAILURE;
-    }
-    double rangeSigma = 2.0;
-    double domainSigma = 2.0;
-    if (argc > 2)
-    {
-        domainSigma = std::stod(argv[2]);
-    }
-    if (argc > 3)
-    {
-        rangeSigma = std::stod(argv[3]);
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " inputImageFile [domainSigma] [rangeSigma]" << std::endl;
+    return EXIT_FAILURE;
+  }
+  double rangeSigma = 2.0;
+  double domainSigma = 2.0;
+  if (argc > 2)
+  {
+    domainSigma = std::stod(argv[2]);
+  }
+  if (argc > 3)
+  {
+    rangeSigma = std::stod(argv[3]);
+  }
 
-    // Parse command line arguments
-    std::string inputFilename = argv[1];
+  // Parse command line arguments
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using ImageType = itk::Image< float, 2 >;
+  // Setup types
+  using ImageType = itk::Image<float, 2>;
 
-    using ReaderType = itk::ImageFileReader< ImageType >;
-    using FilterType = itk::BilateralImageFilter<
-            ImageType, ImageType >;
-    using SubtractImageFilterType = itk::SubtractImageFilter< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using FilterType = itk::BilateralImageFilter<ImageType, ImageType>;
+  using SubtractImageFilterType = itk::SubtractImageFilter<ImageType>;
 
-    // Create and setup a reader
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFilename.c_str() );
+  // Create and setup a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename.c_str());
 
-    // Create and setup a derivative filter
-    FilterType::Pointer bilateralFilter = FilterType::New();
-    bilateralFilter->SetInput( reader->GetOutput() );
-    bilateralFilter->SetDomainSigma(domainSigma);
-    bilateralFilter->SetRangeSigma(rangeSigma);
+  // Create and setup a derivative filter
+  FilterType::Pointer bilateralFilter = FilterType::New();
+  bilateralFilter->SetInput(reader->GetOutput());
+  bilateralFilter->SetDomainSigma(domainSigma);
+  bilateralFilter->SetRangeSigma(rangeSigma);
 
-    SubtractImageFilterType::Pointer diff = SubtractImageFilterType::New();
-    diff->SetInput1(reader->GetOutput());
-    diff->SetInput2(bilateralFilter->GetOutput());
+  SubtractImageFilterType::Pointer diff = SubtractImageFilterType::New();
+  diff->SetInput1(reader->GetOutput());
+  diff->SetInput2(bilateralFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    std::stringstream desc;
-    desc << "Bilateral\ndomainSigma = " << domainSigma
-         << " rangeSigma = " << rangeSigma;
-    viewer.AddImage(
-            bilateralFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Bilateral\ndomainSigma = " << domainSigma << " rangeSigma = " << rangeSigma;
+  viewer.AddImage(bilateralFilter->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Original - Bilateral";
-    viewer.AddImage(
-            diff->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "Original - Bilateral";
+  viewer.AddImage(diff->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageFeature/ComputeLaplacian/Code.cxx
+++ b/src/Filtering/ImageFeature/ComputeLaplacian/Code.cxx
@@ -21,16 +21,17 @@
 #include "itkLaplacianImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -38,38 +39,38 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = float;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::LaplacianImageFilter< InputImageType, InputImageType >;
+  using FilterType = itk::LaplacianImageFilter<InputImageType, InputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, OutputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, OutputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( filter->GetOutput() );
-  rescaler->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  rescaler->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  rescaler->SetInput(filter->GetOutput());
+  rescaler->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  rescaler->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(rescaler->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFeature/DerivativeImage/Code.cxx
+++ b/src/Filtering/ImageFeature/DerivativeImage/Code.cxx
@@ -20,47 +20,47 @@
 #include "itkDerivativeImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " inputImageFile" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " inputImageFile" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Parse command line arguments
-    std::string inputFilename = argv[1];
+  // Parse command line arguments
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using FloatImageType = itk::Image< float,  2 >;
-    using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
+  // Setup types
+  using FloatImageType = itk::Image<float, 2>;
+  using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-    using readerType = itk::ImageFileReader< UnsignedCharImageType >;
+  using readerType = itk::ImageFileReader<UnsignedCharImageType>;
 
-    using filterType = itk::DerivativeImageFilter<
-            UnsignedCharImageType, FloatImageType >;
+  using filterType = itk::DerivativeImageFilter<UnsignedCharImageType, FloatImageType>;
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    reader->SetFileName( inputFilename.c_str() );
+  // Create and setup a reader
+  readerType::Pointer reader = readerType::New();
+  reader->SetFileName(inputFilename.c_str());
 
-    // Create and setup a derivative filter
-    filterType::Pointer derivativeFilter = filterType::New();
-    derivativeFilter->SetInput( reader->GetOutput() );
-    derivativeFilter->SetDirection(0); // "x" axis
+  // Create and setup a derivative filter
+  filterType::Pointer derivativeFilter = filterType::New();
+  derivativeFilter->SetInput(reader->GetOutput());
+  derivativeFilter->SetDirection(0); // "x" axis
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
+  QuickView viewer;
 
-    viewer.AddImage<UnsignedCharImageType>(reader->GetOutput());
-    viewer.AddImage<FloatImageType>(derivativeFilter->GetOutput());
-    viewer.Visualize();
+  viewer.AddImage<UnsignedCharImageType>(reader->GetOutput());
+  viewer.AddImage<FloatImageType>(derivativeFilter->GetOutput());
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFeature/DetectEdgesWithCannyFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/DetectEdgesWithCannyFilter/Code.cxx
@@ -22,62 +22,63 @@
 #include "itkCannyEdgeDetectionImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputImage> <OutputImage> ";
     std::cerr << "<Variance> <LowerThreshold> <UpperThreshold>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using InputPixelType = float;
   using OutputPixelType = unsigned char;
 
-  const char * inputImage = argv[1];
-  const char * outputImage = argv[2];
-  const InputPixelType variance = std::stod( argv[3] );
-  const InputPixelType lowerThreshold = std::stod( argv[4] );
-  const InputPixelType upperThreshold = std::stod( argv[5] );
+  const char *         inputImage = argv[1];
+  const char *         outputImage = argv[2];
+  const InputPixelType variance = std::stod(argv[3]);
+  const InputPixelType lowerThreshold = std::stod(argv[4]);
+  const InputPixelType upperThreshold = std::stod(argv[5]);
 
   using InputImageType = itk::Image<InputPixelType, Dimension>;
   using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using FilterType = itk::CannyEdgeDetectionImageFilter< InputImageType, InputImageType >;
+  using FilterType = itk::CannyEdgeDetectionImageFilter<InputImageType, InputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetVariance( variance );
-  filter->SetLowerThreshold( lowerThreshold );
-  filter->SetUpperThreshold( upperThreshold );
+  filter->SetInput(reader->GetOutput());
+  filter->SetVariance(variance);
+  filter->SetLowerThreshold(lowerThreshold);
+  filter->SetUpperThreshold(upperThreshold);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, OutputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, OutputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( filter->GetOutput() );
-  rescaler->SetOutputMinimum( 0 );
-  rescaler->SetOutputMaximum( 255 );
+  rescaler->SetInput(filter->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(255);
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputImage );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(outputImage);
+  writer->SetInput(rescaler->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFeature/FindZeroCrossings/Code.cxx
+++ b/src/Filtering/ImageFeature/FindZeroCrossings/Code.cxx
@@ -22,78 +22,76 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using ImageType = itk::Image<float, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image = ImageType::New();
-    if (argc < 2)
-    {
-        CreateImage(image);
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-        image = reader->GetOutput();
-    }
+  ImageType::Pointer image = ImageType::New();
+  if (argc < 2)
+  {
+    CreateImage(image);
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+  }
 
-    using FilterType = itk::ZeroCrossingImageFilter< ImageType, ImageType >;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(image);
-    filter->SetBackgroundValue(0);
-    filter->SetForegroundValue(255);
+  using FilterType = itk::ZeroCrossingImageFilter<ImageType, ImageType>;
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput(image);
+  filter->SetBackgroundValue(0);
+  filter->SetForegroundValue(255);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),true,
-            argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
+  QuickView viewer;
+  viewer.AddImage(
+    image.GetPointer(), true, argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
 
-    std::stringstream desc;
-    desc << "Zero Crossing";
-    viewer.AddImage(
-            filter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Zero Crossing";
+  viewer.AddImage(filter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    itk::Index<2> start;
-    start.Fill(0);
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start,size);
+  itk::ImageRegion<2> region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(-1);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(-1);
 
-    // Make half of the image negative
-    for(unsigned int i = 0; i < 100; ++i)
+  // Make half of the image negative
+  for (unsigned int i = 0; i < 100; ++i)
+  {
+    for (unsigned int j = 0; j < 50; ++j)
     {
-        for(unsigned int j = 0; j < 50; ++j)
-        {
-            itk::Index<2> index;
-            index[0] = i;
-            index[1] = j;
-            image->SetPixel(index, 1);
-        }
+      itk::Index<2> index;
+      index[0] = i;
+      index[1] = j;
+      image->SetPixel(index, 1);
     }
+  }
 }
-

--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Code.cxx
@@ -21,49 +21,49 @@
 #include "itkImageFileWriter.h"
 #include "itkLaplacianRecursiveGaussianImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
-  std::cerr << argv[0];
-  std::cerr << " <InputFileName> <OutputFileName>";
-  std::cerr << std::endl;
-  return EXIT_FAILURE;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0];
+    std::cerr << " <InputFileName> <OutputFileName>";
+    std::cerr << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
   using OutputPixelType = float;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using FilterType = itk::LaplacianRecursiveGaussianImageFilter< InputImageType,
-    OutputImageType >;
+  using FilterType = itk::LaplacianRecursiveGaussianImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
   filter->Update();
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFeature/RequestedRegion/Code.cxx
+++ b/src/Filtering/ImageFeature/RequestedRegion/Code.cxx
@@ -19,38 +19,38 @@
 #include "itkRandomImageSource.h"
 #include "itkDerivativeImageFilter.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using ImageType = itk::Image<float, 2>;
+  using ImageType = itk::Image<float, 2>;
 
-    itk::Size<2> smallSize;
-    smallSize.Fill(10);
+  itk::Size<2> smallSize;
+  smallSize.Fill(10);
 
-    itk::Index<2> index;
-    index.Fill(0);
+  itk::Index<2> index;
+  index.Fill(0);
 
-    itk::ImageRegion<2> region(index, smallSize);
+  itk::ImageRegion<2> region(index, smallSize);
 
-    itk::Size<2> bigSize;
-    bigSize.Fill(10000);
+  itk::Size<2> bigSize;
+  bigSize.Fill(10000);
 
-    itk::RandomImageSource<ImageType>::Pointer randomImageSource = itk::RandomImageSource<ImageType>::New();
-    randomImageSource->SetNumberOfWorkUnits(1); // to produce non-random results
-    randomImageSource->SetSize(bigSize);
-    randomImageSource->GetOutput()->SetRequestedRegion(smallSize);
-    randomImageSource->Update();
+  itk::RandomImageSource<ImageType>::Pointer randomImageSource = itk::RandomImageSource<ImageType>::New();
+  randomImageSource->SetNumberOfWorkUnits(1); // to produce non-random results
+  randomImageSource->SetSize(bigSize);
+  randomImageSource->GetOutput()->SetRequestedRegion(smallSize);
+  randomImageSource->Update();
 
-    std::cout << "Created random image." << std::endl;
+  std::cout << "Created random image." << std::endl;
 
-    using DerivativeImageFilterType = itk::DerivativeImageFilter<ImageType, ImageType >;
-    DerivativeImageFilterType::Pointer derivativeFilter = DerivativeImageFilterType::New();
-    derivativeFilter->SetInput( randomImageSource->GetOutput() );
-    derivativeFilter->SetDirection(0); // "x" axis
-    derivativeFilter->GetOutput()->SetRequestedRegion(smallSize);
-    derivativeFilter->Update();
+  using DerivativeImageFilterType = itk::DerivativeImageFilter<ImageType, ImageType>;
+  DerivativeImageFilterType::Pointer derivativeFilter = DerivativeImageFilterType::New();
+  derivativeFilter->SetInput(randomImageSource->GetOutput());
+  derivativeFilter->SetDirection(0); // "x" axis
+  derivativeFilter->GetOutput()->SetRequestedRegion(smallSize);
+  derivativeFilter->Update();
 
-    std::cout << "Computed derivative." << std::endl;
+  std::cout << "Computed derivative." << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageFeature/SegmentBloodVessels/Code.cxx
+++ b/src/Filtering/ImageFeature/SegmentBloodVessels/Code.cxx
@@ -21,64 +21,65 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 3 )
-    {
+  if (argc < 3)
+  {
     std::cerr << "Usage: <InputImage> <OutputImage> [Sigma] [Alpha1] [Alpha2]" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   const char * inputImage = argv[1];
   const char * outputImage = argv[2];
-  double sigma = 1.0;
-  if( argc > 3 )
-    {
-    sigma = std::atof( argv[3] );
-    }
+  double       sigma = 1.0;
+  if (argc > 3)
+  {
+    sigma = std::atof(argv[3]);
+  }
   double alpha1 = 0.5;
-  if( argc > 4 )
-    {
-    alpha1 = std::atof( argv[4] );
-    }
+  if (argc > 4)
+  {
+    alpha1 = std::atof(argv[4]);
+  }
   double alpha2 = 2.0;
-  if( argc > 5 )
-    {
-    alpha2 = std::atof( argv[5] );
-    }
+  if (argc > 5)
+  {
+    alpha2 = std::atof(argv[5]);
+  }
 
   constexpr unsigned int Dimension = 3;
   using PixelType = float;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using HessianFilterType = itk::HessianRecursiveGaussianImageFilter< ImageType >;
+  using HessianFilterType = itk::HessianRecursiveGaussianImageFilter<ImageType>;
   HessianFilterType::Pointer hessianFilter = HessianFilterType::New();
-  hessianFilter->SetInput( reader->GetOutput() );
-  hessianFilter->SetSigma( sigma );
+  hessianFilter->SetInput(reader->GetOutput());
+  hessianFilter->SetSigma(sigma);
 
-  using VesselnessMeasureFilterType = itk::Hessian3DToVesselnessMeasureImageFilter< PixelType >;
+  using VesselnessMeasureFilterType = itk::Hessian3DToVesselnessMeasureImageFilter<PixelType>;
   VesselnessMeasureFilterType::Pointer vesselnessFilter = VesselnessMeasureFilterType::New();
-  vesselnessFilter->SetInput( hessianFilter->GetOutput() );
-  vesselnessFilter->SetAlpha1( alpha1 );
-  vesselnessFilter->SetAlpha2( alpha2 );
+  vesselnessFilter->SetInput(hessianFilter->GetOutput());
+  vesselnessFilter->SetAlpha1(alpha1);
+  vesselnessFilter->SetAlpha2(alpha2);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( vesselnessFilter->GetOutput() );
-  writer->SetFileName( outputImage );
+  writer->SetInput(vesselnessFilter->GetOutput());
+  writer->SetFileName(outputImage);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFeature/SharpenImage/Code.cxx
+++ b/src/Filtering/ImageFeature/SharpenImage/Code.cxx
@@ -22,60 +22,53 @@
 #include "itkSubtractImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " inputImageFile" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " inputImageFile" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Parse command line arguments
-    std::string inputFilename = argv[1];
+  // Parse command line arguments
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using FloatImageType = itk::Image< float,  2 >;
+  // Setup types
+  using FloatImageType = itk::Image<float, 2>;
 
-    using readerType = itk::ImageFileReader< FloatImageType >;
-    readerType::Pointer reader = readerType::New();
-    reader->SetFileName(inputFilename);
+  using readerType = itk::ImageFileReader<FloatImageType>;
+  readerType::Pointer reader = readerType::New();
+  reader->SetFileName(inputFilename);
 
-    using LaplacianSharpeningImageFilterType = itk::LaplacianSharpeningImageFilter<FloatImageType, FloatImageType >;
-    LaplacianSharpeningImageFilterType::Pointer laplacianSharpeningImageFilter =
-            LaplacianSharpeningImageFilterType::New();
-    laplacianSharpeningImageFilter->SetInput( reader->GetOutput() );
+  using LaplacianSharpeningImageFilterType = itk::LaplacianSharpeningImageFilter<FloatImageType, FloatImageType>;
+  LaplacianSharpeningImageFilterType::Pointer laplacianSharpeningImageFilter =
+    LaplacianSharpeningImageFilterType::New();
+  laplacianSharpeningImageFilter->SetInput(reader->GetOutput());
 
-    using SubtractType = itk::SubtractImageFilter<FloatImageType>;
-    SubtractType::Pointer diff = SubtractType::New();
-    diff->SetInput1(reader->GetOutput());
-    diff->SetInput2(laplacianSharpeningImageFilter->GetOutput());
+  using SubtractType = itk::SubtractImageFilter<FloatImageType>;
+  SubtractType::Pointer diff = SubtractType::New();
+  diff->SetInput1(reader->GetOutput());
+  diff->SetInput2(laplacianSharpeningImageFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    std::stringstream desc;
-    desc << "LaplacianSharpeningImageFilter";
-    viewer.AddImage(
-            laplacianSharpeningImageFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "LaplacianSharpeningImageFilter";
+  viewer.AddImage(laplacianSharpeningImageFilter->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Original - LaplacianSharpening";
-    viewer.AddImage(
-            diff->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "Original - LaplacianSharpening";
+  viewer.AddImage(diff->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/Code.cxx
@@ -21,47 +21,48 @@
 #include "itkImageFileWriter.h"
 #include "itkSobelEdgeDetectionImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   using OutputPixelType = float;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using FilterType = itk::SobelEdgeDetectionImageFilter< InputImageType, OutputImageType >;
+  using FilterType = itk::SobelEdgeDetectionImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/Code.cxx
+++ b/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/Code.cxx
@@ -23,62 +23,55 @@
 #include "itksys/SystemTools.hxx"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " inputImageFile" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " inputImageFile" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    double var = 5.0;
-    if (argc > 2)
-    {
-        var = std::stod(argv[2]);
-    }
+  double var = 5.0;
+  if (argc > 2)
+  {
+    var = std::stod(argv[2]);
+  }
 
-    // Parse command line arguments
-    std::string inputFilename = argv[1];
+  // Parse command line arguments
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using FloatImageType = itk::Image< float,  2 >;
-    using ReaderType = itk::ImageFileReader< FloatImageType >;
+  // Setup types
+  using FloatImageType = itk::Image<float, 2>;
+  using ReaderType = itk::ImageFileReader<FloatImageType>;
 
-    using FilterType = itk::ZeroCrossingBasedEdgeDetectionImageFilter<
-            FloatImageType, FloatImageType >;
+  using FilterType = itk::ZeroCrossingBasedEdgeDetectionImageFilter<FloatImageType, FloatImageType>;
 
-    // Create and setup a reader
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFilename.c_str() );
+  // Create and setup a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename.c_str());
 
-    // Create and setup a derivative filter
-    FilterType::Pointer edgeDetector = FilterType::New();
-    edgeDetector->SetInput( reader->GetOutput() );
-    FilterType::ArrayType variance;
-    variance.Fill(var);
-    edgeDetector->SetVariance(variance);
+  // Create and setup a derivative filter
+  FilterType::Pointer edgeDetector = FilterType::New();
+  edgeDetector->SetInput(reader->GetOutput());
+  FilterType::ArrayType variance;
+  variance.Fill(var);
+  edgeDetector->SetVariance(variance);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(inputFilename));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFilename));
 
-    std::stringstream desc;
-    desc << "ZeroBasedEdgeDetection, variance = "
-         << edgeDetector->GetVariance();
-    viewer.AddImage(
-            edgeDetector->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "ZeroBasedEdgeDetection, variance = " << edgeDetector->GetVariance();
+  viewer.AddImage(edgeDetector->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
@@ -23,76 +23,79 @@
 
 using FloatImageType = itk::Image<float, 2>;
 
-void CreateImage(FloatImageType::Pointer image);
-void CastRescaleAndWrite(FloatImageType::Pointer image, const std::string& filename);
+void
+CreateImage(FloatImageType::Pointer image);
+void
+CastRescaleAndWrite(FloatImageType::Pointer image, const std::string & filename);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    FloatImageType::Pointer image = FloatImageType::New();
-    CreateImage(image);
-    CastRescaleAndWrite(image, "input.png");
+  FloatImageType::Pointer image = FloatImageType::New();
+  CreateImage(image);
+  CastRescaleAndWrite(image, "input.png");
 
-    using SobelOperatorType = itk::SobelOperator<float, 2>;
-    SobelOperatorType sobelOperator;
-    itk::Size<2> radius;
-    radius.Fill(1); // a radius of 1x1 creates a 3x3 operator
-    sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
-    sobelOperator.CreateToRadius(radius);
+  using SobelOperatorType = itk::SobelOperator<float, 2>;
+  SobelOperatorType sobelOperator;
+  itk::Size<2>      radius;
+  radius.Fill(1);                // a radius of 1x1 creates a 3x3 operator
+  sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
+  sobelOperator.CreateToRadius(radius);
 
-    using NeighborhoodOperatorImageFilterType = itk::NeighborhoodOperatorImageFilter<FloatImageType, FloatImageType>;
-    NeighborhoodOperatorImageFilterType::Pointer filter = NeighborhoodOperatorImageFilterType::New();
-    filter->SetOperator(sobelOperator);
-    filter->SetInput(image);
-    filter->Update();
+  using NeighborhoodOperatorImageFilterType = itk::NeighborhoodOperatorImageFilter<FloatImageType, FloatImageType>;
+  NeighborhoodOperatorImageFilterType::Pointer filter = NeighborhoodOperatorImageFilterType::New();
+  filter->SetOperator(sobelOperator);
+  filter->SetInput(image);
+  filter->Update();
 
-    CastRescaleAndWrite(filter->GetOutput(), "output.png");
+  CastRescaleAndWrite(filter->GetOutput(), "output.png");
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(FloatImageType::Pointer image)
+void
+CreateImage(FloatImageType::Pointer image)
 {
-    FloatImageType::IndexType start;
-    start.Fill(0);
+  FloatImageType::IndexType start;
+  start.Fill(0);
 
-    FloatImageType::SizeType size;
-    size.Fill(100);
+  FloatImageType::SizeType size;
+  size.Fill(100);
 
-    FloatImageType::RegionType region(start,size);
+  FloatImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 20; c < 80; c++)
     {
-        for(unsigned int c = 20; c < 80; c++)
-        {
-            FloatImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      FloatImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }
 
-void CastRescaleAndWrite(FloatImageType::Pointer image, const std::string& filename)
+void
+CastRescaleAndWrite(FloatImageType::Pointer image, const std::string & filename)
 {
-    using UnsignedCharImageType = itk::Image<unsigned char, 2>;
-    using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(image);
-    rescaleFilter->SetOutputMinimum(0);
-    rescaleFilter->SetOutputMaximum(255);
-    rescaleFilter->Update();
+  using UnsignedCharImageType = itk::Image<unsigned char, 2>;
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(image);
+  rescaleFilter->SetOutputMinimum(0);
+  rescaleFilter->SetOutputMaximum(255);
+  rescaleFilter->Update();
 
-    using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName(filename);
-    writer->SetInput(rescaleFilter->GetOutput());
-    writer->Update();
-
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(filename);
+  writer->SetInput(rescaleFilter->GetOutput());
+  writer->Update();
 }
-

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
@@ -24,125 +24,128 @@
 
 namespace
 {
-    using UnsignedCharImageType = itk::Image<unsigned char, 2>;
-    using FloatImageType = itk::Image<float, 2>;
+using UnsignedCharImageType = itk::Image<unsigned char, 2>;
+using FloatImageType = itk::Image<float, 2>;
+} // namespace
+
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateHalfMask(UnsignedCharImageType::Pointer image, UnsignedCharImageType::Pointer mask);
+
+int
+main(int, char *[])
+{
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  CreateImage(image);
+
+  UnsignedCharImageType::Pointer mask = UnsignedCharImageType::New();
+  CreateHalfMask(image, mask);
+
+  using SobelOperatorType = itk::SobelOperator<float, 2>;
+  SobelOperatorType sobelOperator;
+  itk::Size<2>      radius;
+  radius.Fill(1);                // a radius of 1x1 creates a 3x3 operator
+  sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
+  sobelOperator.CreateToRadius(radius);
+
+  // Visualize mask image
+  using MaskNeighborhoodOperatorImageFilterType =
+    itk::MaskNeighborhoodOperatorImageFilter<UnsignedCharImageType, UnsignedCharImageType, FloatImageType, float>;
+  MaskNeighborhoodOperatorImageFilterType::Pointer maskNeighborhoodOperatorImageFilter =
+    MaskNeighborhoodOperatorImageFilterType::New();
+  maskNeighborhoodOperatorImageFilter->SetInput(image);
+  maskNeighborhoodOperatorImageFilter->SetMaskImage(mask);
+  maskNeighborhoodOperatorImageFilter->SetOperator(sobelOperator);
+  maskNeighborhoodOperatorImageFilter->Update();
+
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(maskNeighborhoodOperatorImageFilter->GetOutput());
+  rescaleFilter->Update();
+
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(rescaleFilter->GetOutput());
+  writer->Update();
+
+  return EXIT_SUCCESS;
 }
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
-static void CreateHalfMask(UnsignedCharImageType::Pointer image, UnsignedCharImageType::Pointer mask);
 
-int main(int, char *[])
+void
+CreateHalfMask(UnsignedCharImageType::Pointer image, UnsignedCharImageType::Pointer mask)
 {
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    CreateImage(image);
+  itk::ImageRegion<2> region = image->GetLargestPossibleRegion();
 
-    UnsignedCharImageType::Pointer mask = UnsignedCharImageType::New();
-    CreateHalfMask(image, mask);
+  mask->SetRegions(region);
+  mask->Allocate();
+  mask->FillBuffer(0);
 
-    using SobelOperatorType = itk::SobelOperator<float, 2>;
-    SobelOperatorType sobelOperator;
-    itk::Size<2> radius;
-    radius.Fill(1); // a radius of 1x1 creates a 3x3 operator
-    sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
-    sobelOperator.CreateToRadius(radius);
+  itk::Size<2> regionSize = region.GetSize();
 
-    // Visualize mask image
-    using MaskNeighborhoodOperatorImageFilterType = itk::MaskNeighborhoodOperatorImageFilter< UnsignedCharImageType, UnsignedCharImageType, FloatImageType, float>;
-    MaskNeighborhoodOperatorImageFilterType::Pointer maskNeighborhoodOperatorImageFilter =
-            MaskNeighborhoodOperatorImageFilterType::New();
-    maskNeighborhoodOperatorImageFilter->SetInput(image);
-    maskNeighborhoodOperatorImageFilter->SetMaskImage(mask);
-    maskNeighborhoodOperatorImageFilter->SetOperator(sobelOperator);
-    maskNeighborhoodOperatorImageFilter->Update();
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(mask, region);
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< FloatImageType, UnsignedCharImageType >;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(maskNeighborhoodOperatorImageFilter->GetOutput());
-    rescaleFilter->Update();
-
-    using WriterType = itk::ImageFileWriter< UnsignedCharImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(rescaleFilter->GetOutput());
-    writer->Update();
-
-    return EXIT_SUCCESS;
-}
-
-
-void CreateHalfMask(UnsignedCharImageType::Pointer image, UnsignedCharImageType::Pointer mask)
-{
-    itk::ImageRegion<2> region = image->GetLargestPossibleRegion();
-
-    mask->SetRegions(region);
-    mask->Allocate();
-    mask->FillBuffer(0);
-
-    itk::Size<2> regionSize = region.GetSize();
-
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(mask,region);
-
-    // Make the left half of the mask white and the right half black
-    while(!imageIterator.IsAtEnd())
+  // Make the left half of the mask white and the right half black
+  while (!imageIterator.IsAtEnd())
+  {
+    if (static_cast<unsigned int>(imageIterator.GetIndex()[0]) > regionSize[0] / 2)
     {
-        if(static_cast<unsigned int>(imageIterator.GetIndex()[0]) > regionSize[0] / 2)
-        {
-            imageIterator.Set(0);
-        }
-        else
-        {
-            imageIterator.Set(1);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(0);
+    }
+    else
+    {
+      imageIterator.Set(1);
     }
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< UnsignedCharImageType, UnsignedCharImageType >;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(mask);
-    rescaleFilter->Update();
+    ++imageIterator;
+  }
 
-    using WriterType = itk::ImageFileWriter< UnsignedCharImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("mask.png");
-    writer->SetInput(rescaleFilter->GetOutput());
-    writer->Update();
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<UnsignedCharImageType, UnsignedCharImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(mask);
+  rescaleFilter->Update();
 
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("mask.png");
+  writer->SetInput(rescaleFilter->GetOutput());
+  writer->Update();
 }
 
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    itk::Index<2> start;
-    start.Fill(0);
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start,size);
+  itk::ImageRegion<2> region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a square
-    for(unsigned int r = 30; r < 70; r++)
+  // Make a square
+  for (unsigned int r = 30; r < 70; r++)
+  {
+    for (unsigned int c = 30; c < 70; c++)
     {
-        for(unsigned int c = 30; c < 70; c++)
-        {
-            FloatImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      FloatImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    using WriterType = itk::ImageFileWriter< UnsignedCharImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.png");
-    writer->SetInput(image);
-    writer->Update();
-
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 }
-

--- a/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/Code.cxx
+++ b/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/Code.cxx
@@ -22,16 +22,17 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkCastImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
@@ -40,37 +41,37 @@ int main( int argc, char* argv[] )
 
   using InputPixelType = float;
   using OutputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, InputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, InputImageType>;
   RescaleType::Pointer rescale = RescaleType::New();
-  rescale->SetInput( reader->GetOutput() );
-  rescale->SetOutputMinimum( 0 );
-  rescale->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  rescale->SetInput(reader->GetOutput());
+  rescale->SetOutputMinimum(0);
+  rescale->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
 
-  using FilterType = itk::CastImageFilter< InputImageType, OutputImageType >;
+  using FilterType = itk::CastImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( rescale->GetOutput() );
+  filter->SetInput(rescale->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputImage );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputImage);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageFilterBase/ComputeLocalNoise/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ComputeLocalNoise/Code.cxx
@@ -21,66 +21,68 @@
 
 using ImageType = itk::Image<float, 2>;
 
-void CreateImage(ImageType::Pointer image);
+void
+CreateImage(ImageType::Pointer image);
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using NoiseImageFilterType = itk::NoiseImageFilter< ImageType, ImageType >;
-    NoiseImageFilterType::Pointer noiseImageFilter = NoiseImageFilterType::New();
-    noiseImageFilter->SetInput(image);
-    noiseImageFilter->SetRadius(1);
-    noiseImageFilter->Update();
+  using NoiseImageFilterType = itk::NoiseImageFilter<ImageType, ImageType>;
+  NoiseImageFilterType::Pointer noiseImageFilter = NoiseImageFilterType::New();
+  noiseImageFilter->SetInput(image);
+  noiseImageFilter->SetRadius(1);
+  noiseImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.mhd");
-    writer->SetInput(noiseImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.mhd");
+  writer->SetInput(noiseImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image that is mostly constant but has some different kinds of objects.
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create an image that is mostly constant but has some different kinds of objects.
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    // Create a black image
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  // Create a black image
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Create a white square
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  // Create a white square
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70 && imageIterator.GetIndex()[1] > 50 &&
+        imageIterator.GetIndex()[1] < 70)
     {
-        if(imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70 &&
-           imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 70 )
-        {
-            imageIterator.Set(255);
-        }
-        ++imageIterator;
+      imageIterator.Set(255);
     }
+    ++imageIterator;
+  }
 
-    // Create a rogue white pixel
-    ImageType::IndexType pixel;
-    pixel.Fill(20);
-    image->SetPixel(pixel, 255);
+  // Create a rogue white pixel
+  ImageType::IndexType pixel;
+  pixel.Fill(20);
+  image->SetPixel(pixel, 255);
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.mhd");
-    writer->SetInput(image);
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.mhd");
+  writer->SetInput(image);
+  writer->Update();
 }
-

--- a/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/Code.cxx
+++ b/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/Code.cxx
@@ -22,81 +22,84 @@
 #include "itkBinaryFunctorImageFilter.h"
 
 using ImageType = itk::Image<float, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
 namespace Functor
 {
-    template< class TPixel>
-    class MySquaredDifference
-    {
-    public:
-        MySquaredDifference() = default;
-        ~MySquaredDifference() = default;
-        bool operator!=(const MySquaredDifference &) const
-        {
-            return false;
-        }
-
-        bool operator==(const MySquaredDifference & other) const
-        {
-            return !( *this != other );
-        }
-
-        inline TPixel operator()(const TPixel & A,
-                                 const TPixel & B) const
-        {
-            const auto dA = static_cast< double >( A );
-            const auto dB = static_cast< double >( B );
-            const double diff = dA - dB;
-
-            return static_cast< TPixel >( diff * diff );
-        }
-    };
-}
-
-int main(int, char *[])
+template <class TPixel>
+class MySquaredDifference
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage(image1);
-    image1->FillBuffer(2);
+public:
+  MySquaredDifference() = default;
+  ~MySquaredDifference() = default;
+  bool
+  operator!=(const MySquaredDifference &) const
+  {
+    return false;
+  }
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage(image2);
-    image2->FillBuffer(5);
+  bool
+  operator==(const MySquaredDifference & other) const
+  {
+    return !(*this != other);
+  }
 
-    using FilterType = itk::BinaryFunctorImageFilter< ImageType, ImageType, ImageType,
-            Functor::MySquaredDifference<ImageType::PixelType> >;
+  inline TPixel
+  operator()(const TPixel & A, const TPixel & B) const
+  {
+    const auto   dA = static_cast<double>(A);
+    const auto   dB = static_cast<double>(B);
+    const double diff = dA - dB;
 
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput1(image1);
-    filter->SetInput2(image2);
-    filter->Update();
+    return static_cast<TPixel>(diff * diff);
+  }
+};
+} // namespace Functor
 
-    itk::Index<2> pixelIndex;
-    pixelIndex.Fill(0);
-
-    ImageType::PixelType input1PixelValue = image1->GetPixel(pixelIndex);
-    ImageType::PixelType input2PixelValue = image2->GetPixel(pixelIndex);
-    ImageType::PixelType outputPixelValue = filter->GetOutput()->GetPixel(pixelIndex);
-
-    std::cout << "pixel1 was = " << input1PixelValue << std::endl;
-    std::cout << "pixel2 was = " << input2PixelValue << std::endl;
-    std::cout << "output is = " << outputPixelValue << std::endl;
-
-    return EXIT_SUCCESS;
-}
-
-void CreateImage(ImageType::Pointer image)
+int
+main(int, char *[])
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage(image1);
+  image1->FillBuffer(2);
 
-    ImageType::SizeType size;
-    size.Fill(10);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage(image2);
+  image2->FillBuffer(5);
 
-    ImageType::RegionType region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
+  using FilterType =
+    itk::BinaryFunctorImageFilter<ImageType, ImageType, ImageType, Functor::MySquaredDifference<ImageType::PixelType>>;
 
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput1(image1);
+  filter->SetInput2(image2);
+  filter->Update();
+
+  itk::Index<2> pixelIndex;
+  pixelIndex.Fill(0);
+
+  ImageType::PixelType input1PixelValue = image1->GetPixel(pixelIndex);
+  ImageType::PixelType input2PixelValue = image2->GetPixel(pixelIndex);
+  ImageType::PixelType outputPixelValue = filter->GetOutput()->GetPixel(pixelIndex);
+
+  std::cout << "pixel1 was = " << input1PixelValue << std::endl;
+  std::cout << "pixel2 was = " << input2PixelValue << std::endl;
+  std::cout << "output is = " << outputPixelValue << std::endl;
+
+  return EXIT_SUCCESS;
 }
 
+void
+CreateImage(ImageType::Pointer image)
+{
+  ImageType::IndexType start;
+  start.Fill(0);
+
+  ImageType::SizeType size;
+  size.Fill(10);
+
+  ImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+}

--- a/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/Code.cxx
+++ b/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/Code.cxx
@@ -20,51 +20,52 @@
 #include "itkAndImageFilter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage(image1);
-    image1->FillBuffer(2);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage(image1);
+  image1->FillBuffer(2);
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage(image2);
-    image2->FillBuffer(5);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage(image2);
+  image2->FillBuffer(5);
 
-    using FilterType = itk::BinaryFunctorImageFilter< ImageType, ImageType, ImageType,
-            itk::Functor::AND<ImageType::PixelType> >;
+  using FilterType =
+    itk::BinaryFunctorImageFilter<ImageType, ImageType, ImageType, itk::Functor::AND<ImageType::PixelType>>;
 
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput1(image1);
-    filter->SetInput2(image2);
-    filter->Update();
+  FilterType::Pointer filter = FilterType::New();
+  filter->SetInput1(image1);
+  filter->SetInput2(image2);
+  filter->Update();
 
-    itk::Index<2> pixelIndex;
-    pixelIndex.Fill(0);
+  itk::Index<2> pixelIndex;
+  pixelIndex.Fill(0);
 
-    ImageType::PixelType input1PixelValue = image1->GetPixel(pixelIndex);
-    ImageType::PixelType input2PixelValue = image2->GetPixel(pixelIndex);
-    ImageType::PixelType outputPixelValue = filter->GetOutput()->GetPixel(pixelIndex);
+  ImageType::PixelType input1PixelValue = image1->GetPixel(pixelIndex);
+  ImageType::PixelType input2PixelValue = image2->GetPixel(pixelIndex);
+  ImageType::PixelType outputPixelValue = filter->GetOutput()->GetPixel(pixelIndex);
 
-    std::cout << "pixel1 was = " << input1PixelValue << std::endl;
-    std::cout << "pixel2 was = " << input2PixelValue << std::endl;
-    std::cout << "output is = " << outputPixelValue << std::endl;
+  std::cout << "pixel1 was = " << input1PixelValue << std::endl;
+  std::cout << "pixel2 was = " << input2PixelValue << std::endl;
+  std::cout << "output is = " << outputPixelValue << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(10);
+  ImageType::SizeType size;
+  size.Fill(10);
 
-    ImageType::RegionType region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-
+  ImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
 }
-

--- a/src/Filtering/ImageFusion/ColorBoundariesOfRegions/Code.cxx
+++ b/src/Filtering/ImageFusion/ColorBoundariesOfRegions/Code.cxx
@@ -25,79 +25,83 @@
 
 namespace
 {
-    using ImageType = itk::Image<unsigned char, 2>;
+using ImageType = itk::Image<unsigned char, 2>;
 }
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
-    using RGBImageType = itk::Image<RGBPixelType>;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType>;
 
-    using LabelMapContourOverlayImageFilterType = itk::LabelMapContourOverlayImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType, RGBImageType>;
-    LabelMapContourOverlayImageFilterType::Pointer labelMapContourOverlayImageFilter = LabelMapContourOverlayImageFilterType::New();
-    labelMapContourOverlayImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
-    labelMapContourOverlayImageFilter->SetFeatureImage(image);
-    labelMapContourOverlayImageFilter->SetOpacity(.5);
-    labelMapContourOverlayImageFilter->Update();
+  using LabelMapContourOverlayImageFilterType =
+    itk::LabelMapContourOverlayImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType, RGBImageType>;
+  LabelMapContourOverlayImageFilterType::Pointer labelMapContourOverlayImageFilter =
+    LabelMapContourOverlayImageFilterType::New();
+  labelMapContourOverlayImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
+  labelMapContourOverlayImageFilter->SetFeatureImage(image);
+  labelMapContourOverlayImageFilter->SetOpacity(.5);
+  labelMapContourOverlayImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< RGBImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(labelMapContourOverlayImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(labelMapContourOverlayImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make two squares
-    while(!imageIterator.IsAtEnd())
+  // Make two squares
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20) )
-        {
-            imageIterator.Set(255);
-        }
-
-        if((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70) &&
-           (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 70) )
-        {
-            imageIterator.Set(255);
-        }
-        ++imageIterator;
+      imageIterator.Set(255);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
-}
+    if ((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70) &&
+        (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 70))
+    {
+      imageIterator.Set(255);
+    }
+    ++imageIterator;
+  }
 
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
+}

--- a/src/Filtering/ImageFusion/ColorLabeledRegions/Code.cxx
+++ b/src/Filtering/ImageFusion/ColorLabeledRegions/Code.cxx
@@ -24,75 +24,79 @@
 #include "itkRGBPixel.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
-    using RGBImageType = itk::Image<RGBPixelType>;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType>;
 
-    using LabelMapOverlayImageFilterType = itk::LabelMapOverlayImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType, RGBImageType>;
-    LabelMapOverlayImageFilterType::Pointer labelMapOverlayImageFilter = LabelMapOverlayImageFilterType::New();
-    labelMapOverlayImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
-    labelMapOverlayImageFilter->SetFeatureImage(image);
-    labelMapOverlayImageFilter->SetOpacity(.5);
-    labelMapOverlayImageFilter->Update();
+  using LabelMapOverlayImageFilterType =
+    itk::LabelMapOverlayImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType, RGBImageType>;
+  LabelMapOverlayImageFilterType::Pointer labelMapOverlayImageFilter = LabelMapOverlayImageFilterType::New();
+  labelMapOverlayImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
+  labelMapOverlayImageFilter->SetFeatureImage(image);
+  labelMapOverlayImageFilter->SetOpacity(.5);
+  labelMapOverlayImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< RGBImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(labelMapOverlayImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(labelMapOverlayImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make two squares
-    while(!imageIterator.IsAtEnd())
+  // Make two squares
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20) )
-        {
-            imageIterator.Set(255);
-        }
-
-        if((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70) &&
-           (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 70) )
-        {
-            imageIterator.Set(255);
-        }
-        ++imageIterator;
+      imageIterator.Set(255);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
+    if ((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70) &&
+        (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 70))
+    {
+      imageIterator.Set(255);
+    }
+    ++imageIterator;
+  }
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnImage/Code.cxx
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnImage/Code.cxx
@@ -24,80 +24,84 @@
 #include "itkRGBPixel.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType>;
-    LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
-    labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
-    labelMapToLabelImageFilter->Update();
+  using LabelMapToLabelImageFilterType =
+    itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType>;
+  LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
+  labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
+  labelMapToLabelImageFilter->Update();
 
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
-    using RGBImageType = itk::Image<RGBPixelType>;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType>;
 
-    using LabelOverlayImageFilterType = itk::LabelOverlayImageFilter<ImageType, ImageType, RGBImageType>;
-    LabelOverlayImageFilterType::Pointer labelOverlayImageFilter = LabelOverlayImageFilterType::New();
-    labelOverlayImageFilter->SetInput(image);
-    labelOverlayImageFilter->SetLabelImage(labelMapToLabelImageFilter->GetOutput());
-    labelOverlayImageFilter->SetOpacity(.5);
-    labelOverlayImageFilter->Update();
+  using LabelOverlayImageFilterType = itk::LabelOverlayImageFilter<ImageType, ImageType, RGBImageType>;
+  LabelOverlayImageFilterType::Pointer labelOverlayImageFilter = LabelOverlayImageFilterType::New();
+  labelOverlayImageFilter->SetInput(image);
+  labelOverlayImageFilter->SetLabelImage(labelMapToLabelImageFilter->GetOutput());
+  labelOverlayImageFilter->SetOpacity(.5);
+  labelOverlayImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< RGBImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(labelOverlayImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(labelOverlayImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make two squares
-    while(!imageIterator.IsAtEnd())
+  // Make two squares
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20) )
-        {
-            imageIterator.Set(255);
-        }
-
-        if((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70) &&
-           (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 70) )
-        {
-            imageIterator.Set(255);
-        }
-        ++imageIterator;
+      imageIterator.Set(255);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
+    if ((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70) &&
+        (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 70))
+    {
+      imageIterator.Set(255);
+    }
+    ++imageIterator;
+  }
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/Code.cxx
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/Code.cxx
@@ -23,16 +23,17 @@
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkLabelMapOverlayImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <LabelMap> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * labelFileName = argv[2];
@@ -41,45 +42,45 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   ReaderType::Pointer labelReader = ReaderType::New();
-  labelReader->SetFileName( labelFileName );
+  labelReader->SetFileName(labelFileName);
 
 
   using LabelType = PixelType;
-  using LabelObjectType = itk::LabelObject< LabelType, Dimension >;
-  using LabelMapType = itk::LabelMap< LabelObjectType >;
+  using LabelObjectType = itk::LabelObject<LabelType, Dimension>;
+  using LabelMapType = itk::LabelMap<LabelObjectType>;
 
-  using ConverterType = itk::LabelImageToLabelMapFilter< ImageType, LabelMapType >;
+  using ConverterType = itk::LabelImageToLabelMapFilter<ImageType, LabelMapType>;
   ConverterType::Pointer converter = ConverterType::New();
-  converter->SetInput( labelReader->GetOutput() );
+  converter->SetInput(labelReader->GetOutput());
 
-  using FilterType = itk::LabelMapOverlayImageFilter< LabelMapType, ImageType >;
+  using FilterType = itk::LabelMapOverlayImageFilter<LabelMapType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( converter->GetOutput() );
-  filter->SetFeatureImage( reader->GetOutput() );
-  filter->SetOpacity( 0.5 );
+  filter->SetInput(converter->GetOutput());
+  filter->SetFeatureImage(reader->GetOutput());
+  filter->SetOpacity(0.5);
 
 
-  using WriterType = itk::ImageFileWriter< FilterType::OutputImageType >;
+  using WriterType = itk::ImageFileWriter<FilterType::OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/Code.cxx
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/Code.cxx
@@ -24,23 +24,24 @@
 #include "itkVectorIndexSelectionCastImageFilter.h"
 #include "itkVectorMagnitudeImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileNameX> <OutputFileNameY> <OutputFileNameMagnitude>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const char * inputFileName =           argv[1];
-  const char * outputFileNameX =         argv[2];
-  const char * outputFileNameY =         argv[3];
+  const char * inputFileName = argv[1];
+  const char * outputFileNameX = argv[2];
+  const char * outputFileNameY = argv[3];
   const char * outputFileNameMagnitude = argv[4];
 
-  const char *filenames [2];
+  const char * filenames[2];
   filenames[0] = outputFileNameX;
   filenames[1] = outputFileNameY;
 
@@ -48,77 +49,77 @@ int main( int argc, char* argv[] )
 
   // Input and output are png files, use unsigned char
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
   // Double type for GradientRecursiveGaussianImageFilter
   using DoublePixelType = double;
-  using DoubleImageType = itk::Image< DoublePixelType, Dimension >;
+  using DoubleImageType = itk::Image<DoublePixelType, Dimension>;
   // The output of GradientRecursiveGaussianImageFilter
   // are images of the gradient along X and Y, so the type of
   // the output is a covariant vector of dimension 2 (X, Y)
-  using CovPixelType = itk::CovariantVector< DoublePixelType, Dimension >;
-  using CovImageType = itk::Image< CovPixelType, Dimension >;
+  using CovPixelType = itk::CovariantVector<DoublePixelType, Dimension>;
+  using CovImageType = itk::Image<CovPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::GradientRecursiveGaussianImageFilter< ImageType, CovImageType >;
+  using FilterType = itk::GradientRecursiveGaussianImageFilter<ImageType, CovImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
   // Allows to select the X or Y output images
-  using IndexSelectionType = itk::VectorIndexSelectionCastImageFilter< CovImageType, DoubleImageType >;
+  using IndexSelectionType = itk::VectorIndexSelectionCastImageFilter<CovImageType, DoubleImageType>;
   IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
-  indexSelectionFilter->SetInput( filter->GetOutput() );
+  indexSelectionFilter->SetInput(filter->GetOutput());
 
   // Rescale for png output
-  using RescalerType = itk::RescaleIntensityImageFilter< DoubleImageType, ImageType >;
+  using RescalerType = itk::RescaleIntensityImageFilter<DoubleImageType, ImageType>;
   RescalerType::Pointer rescaler = RescalerType::New();
-  rescaler->SetOutputMinimum( itk::NumericTraits< PixelType >::min() );
-  rescaler->SetOutputMaximum( itk::NumericTraits< PixelType >::max() );
-  rescaler->SetInput( indexSelectionFilter->GetOutput() );
+  rescaler->SetOutputMinimum(itk::NumericTraits<PixelType>::min());
+  rescaler->SetOutputMaximum(itk::NumericTraits<PixelType>::max());
+  rescaler->SetInput(indexSelectionFilter->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetInput(rescaler->GetOutput());
 
   // Write the X and Y images
-  for( int i = 0; i<2;++i )
+  for (int i = 0; i < 2; ++i)
   {
 
-    writer->SetFileName( filenames[i] );
-    indexSelectionFilter->SetIndex( i );
+    writer->SetFileName(filenames[i]);
+    indexSelectionFilter->SetIndex(i);
 
     try
-      {
+    {
       writer->Update();
-      }
-    catch( itk::ExceptionObject & error )
-      {
+    }
+    catch (itk::ExceptionObject & error)
+    {
       std::cerr << "Error: " << error << std::endl;
       return EXIT_FAILURE;
-      }
+    }
   }
 
   // Compute the magnitude of the vector and output the image
-  using MagnitudeType = itk::VectorMagnitudeImageFilter< CovImageType, DoubleImageType >;
+  using MagnitudeType = itk::VectorMagnitudeImageFilter<CovImageType, DoubleImageType>;
   MagnitudeType::Pointer magnitudeFilter = MagnitudeType::New();
-  magnitudeFilter->SetInput( filter->GetOutput() );
+  magnitudeFilter->SetInput(filter->GetOutput());
 
   // Rescale for png output
-  rescaler->SetInput( magnitudeFilter->GetOutput() );
+  rescaler->SetInput(magnitudeFilter->GetOutput());
 
-  writer->SetFileName( outputFileNameMagnitude );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(outputFileNameMagnitude);
+  writer->SetInput(rescaler->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Code.cxx
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Code.cxx
@@ -27,24 +27,25 @@
 #include "itkComposeImageFilter.h"
 #include "itkCastImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName1X> <OutputFileName1Y> <OutputFileName2X> <OutputFileName2Y>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const char * inputFileName =    argv[1];
+  const char * inputFileName = argv[1];
   const char * outputFileName1X = argv[2];
   const char * outputFileName1Y = argv[3];
   const char * outputFileName2X = argv[4];
   const char * outputFileName2Y = argv[5];
 
-  const char *filenames [4];
+  const char * filenames[4];
   filenames[0] = outputFileName1X;
   filenames[1] = outputFileName1Y;
   filenames[2] = outputFileName2X;
@@ -55,71 +56,71 @@ int main( int argc, char* argv[] )
   constexpr unsigned int CovDimension = 4;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, ImageDimension >;
+  using ImageType = itk::Image<PixelType, ImageDimension>;
   using DoublePixelType = double;
-  using DoubleImageType = itk::Image< DoublePixelType, ImageDimension >;
-  using VecPixelType = itk::Vector< DoublePixelType, VectorDimension >;
-  using VecImageType = itk::Image< VecPixelType, ImageDimension >;
-  using CovPixelType = itk::CovariantVector< DoublePixelType, CovDimension >;
-  using CovImageType = itk::Image< CovPixelType, ImageDimension >;
+  using DoubleImageType = itk::Image<DoublePixelType, ImageDimension>;
+  using VecPixelType = itk::Vector<DoublePixelType, VectorDimension>;
+  using VecImageType = itk::Image<VecPixelType, ImageDimension>;
+  using CovPixelType = itk::CovariantVector<DoublePixelType, CovDimension>;
+  using CovImageType = itk::Image<CovPixelType, ImageDimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   // Invert the input image
-  using InvertType = itk::InvertIntensityImageFilter< ImageType, ImageType >;
+  using InvertType = itk::InvertIntensityImageFilter<ImageType, ImageType>;
   InvertType::Pointer inverter = InvertType::New();
-  inverter->SetInput( reader->GetOutput() );
+  inverter->SetInput(reader->GetOutput());
 
   // Cast the image to double type.
-  using CasterType = itk::CastImageFilter< ImageType, DoubleImageType >;
+  using CasterType = itk::CastImageFilter<ImageType, DoubleImageType>;
   CasterType::Pointer caster = CasterType::New();
   CasterType::Pointer caster2 = CasterType::New();
 
   // Create an image, were each pixel has 2 values: first value is the value
   // coming from the input image, second value is coming from the inverted
   // image
-  using ComposeType = itk::ComposeImageFilter< DoubleImageType, VecImageType >;
+  using ComposeType = itk::ComposeImageFilter<DoubleImageType, VecImageType>;
   ComposeType::Pointer composer = ComposeType::New();
-  caster->SetInput( reader->GetOutput() );
-  composer->SetInput( 0, caster->GetOutput() );
-  caster2->SetInput( inverter->GetOutput() );
-  composer->SetInput( 1, caster2->GetOutput() );
+  caster->SetInput(reader->GetOutput());
+  composer->SetInput(0, caster->GetOutput());
+  caster2->SetInput(inverter->GetOutput());
+  composer->SetInput(1, caster2->GetOutput());
 
   // Apply the gradient filter on the two images, this will return and image
   // with 4 values per pixel: two X and Y gradients
-  using FilterType = itk::GradientRecursiveGaussianImageFilter< VecImageType, CovImageType >;
+  using FilterType = itk::GradientRecursiveGaussianImageFilter<VecImageType, CovImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( composer->GetOutput() );
+  filter->SetInput(composer->GetOutput());
 
   // Set up the filter to select each gradient
-  using IndexSelectionType = itk::VectorIndexSelectionCastImageFilter< CovImageType, DoubleImageType >;
+  using IndexSelectionType = itk::VectorIndexSelectionCastImageFilter<CovImageType, DoubleImageType>;
   IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
-  indexSelectionFilter->SetInput( filter->GetOutput() );
+  indexSelectionFilter->SetInput(filter->GetOutput());
 
   // Rescale for png output
-  using RescalerType = itk::RescaleIntensityImageFilter< DoubleImageType, ImageType >;
+  using RescalerType = itk::RescaleIntensityImageFilter<DoubleImageType, ImageType>;
   RescalerType::Pointer rescaler = RescalerType::New();
-  rescaler->SetOutputMinimum( itk::NumericTraits< PixelType >::min() );
-  rescaler->SetOutputMaximum( itk::NumericTraits< PixelType >::max() );
-  rescaler->SetInput( indexSelectionFilter->GetOutput() );
+  rescaler->SetOutputMinimum(itk::NumericTraits<PixelType>::min());
+  rescaler->SetOutputMaximum(itk::NumericTraits<PixelType>::max());
+  rescaler->SetInput(indexSelectionFilter->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetInput(rescaler->GetOutput());
 
   // Write the X and Y images
-  for( int i = 0; i<4;++i )
+  for (int i = 0; i < 4; ++i)
   {
-    indexSelectionFilter->SetIndex( i );
-    writer->SetFileName( filenames[i] );
+    indexSelectionFilter->SetIndex(i);
+    writer->SetFileName(filenames[i]);
 
     try
     {
       writer->Update();
     }
-    catch( itk::ExceptionObject & error )
+    catch (itk::ExceptionObject & error)
     {
       std::cerr << "Error: " << error << std::endl;
       return EXIT_FAILURE;

--- a/src/Filtering/ImageGradient/ComputeAndDisplayGradient/Code.cxx
+++ b/src/Filtering/ImageGradient/ComputeAndDisplayGradient/Code.cxx
@@ -36,35 +36,36 @@
 #include "vtkGlyph3DMapper.h"
 #include "vtkArrowSource.h"
 
-static void VectorImageToVTKImage(itk::Image<itk::CovariantVector<float, 2>, 2>::Pointer vectorImage, vtkImageData* VTKImage);
+static void
+VectorImageToVTKImage(itk::Image<itk::CovariantVector<float, 2>, 2>::Pointer vectorImage, vtkImageData * VTKImage);
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
   // Verify command line arguments
-  if( argc < 2 )
-    {
+  if (argc < 2)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << "inputImageFile" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Parse command line arguments
   std::string inputFilename = argv[1];
 
   // Setup types
-  using FloatImageType = itk::Image< float,  2 >;
-  using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
+  using FloatImageType = itk::Image<float, 2>;
+  using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
   // Create and setup a reader
-  using ReaderType = itk::ImageFileReader< UnsignedCharImageType >;
+  using ReaderType = itk::ImageFileReader<UnsignedCharImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFilename.c_str() );
+  reader->SetFileName(inputFilename.c_str());
 
   // Create and setup a gradient filter
-  using GradientFilterType = itk::GradientImageFilter<
-      UnsignedCharImageType, float>;
+  using GradientFilterType = itk::GradientImageFilter<UnsignedCharImageType, float>;
   GradientFilterType::Pointer gradientFilter = GradientFilterType::New();
-  gradientFilter->SetInput( reader->GetOutput() );
+  gradientFilter->SetInput(reader->GetOutput());
   gradientFilter->Update();
 
   // Visualize original image
@@ -72,60 +73,50 @@ int main(int argc, char * argv[])
   ConnectorType::Pointer originalConnector = ConnectorType::New();
   originalConnector->SetInput(reader->GetOutput());
 
-  vtkSmartPointer<vtkImageActor> originalActor =
-    vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> originalActor = vtkSmartPointer<vtkImageActor>::New();
   originalActor->SetInput(originalConnector->GetOutput());
 
   // Visualize gradient
-  vtkSmartPointer<vtkImageData> gradientImage =
-    vtkSmartPointer<vtkImageData>::New();
+  vtkSmartPointer<vtkImageData> gradientImage = vtkSmartPointer<vtkImageData>::New();
   VectorImageToVTKImage(gradientFilter->GetOutput(), gradientImage);
 
-  vtkSmartPointer<vtkArrowSource> arrowSource =
-    vtkSmartPointer<vtkArrowSource>::New();
+  vtkSmartPointer<vtkArrowSource> arrowSource = vtkSmartPointer<vtkArrowSource>::New();
 
-  vtkSmartPointer<vtkGlyph3DMapper> gradientMapper =
-    vtkSmartPointer<vtkGlyph3DMapper>::New();
+  vtkSmartPointer<vtkGlyph3DMapper> gradientMapper = vtkSmartPointer<vtkGlyph3DMapper>::New();
   gradientMapper->ScalingOn();
   gradientMapper->SetScaleFactor(.05);
   gradientMapper->SetSourceConnection(arrowSource->GetOutputPort());
   gradientMapper->SetInputConnection(gradientImage->GetProducerPort());
   gradientMapper->Update();
 
-  vtkSmartPointer<vtkActor> gradientActor =
-    vtkSmartPointer<vtkActor>::New();
+  vtkSmartPointer<vtkActor> gradientActor = vtkSmartPointer<vtkActor>::New();
   gradientActor->SetMapper(gradientMapper);
 
   // Visualize
   // Define viewport ranges
   // (xmin, ymin, xmax, ymax)
-  double leftViewport[4] = {0.0, 0.0, 0.5, 1.0};
-  double rightViewport[4] = {0.5, 0.0, 1.0, 1.0};
+  double leftViewport[4] = { 0.0, 0.0, 0.5, 1.0 };
+  double rightViewport[4] = { 0.5, 0.0, 1.0, 1.0 };
 
   // Setup both renderers
-  vtkSmartPointer<vtkRenderWindow> renderWindow =
-    vtkSmartPointer<vtkRenderWindow>::New();
-  renderWindow->SetSize(600,300);
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+  renderWindow->SetSize(600, 300);
 
-  vtkSmartPointer<vtkRenderer> leftRenderer =
-    vtkSmartPointer<vtkRenderer>::New();
+  vtkSmartPointer<vtkRenderer> leftRenderer = vtkSmartPointer<vtkRenderer>::New();
   renderWindow->AddRenderer(leftRenderer);
   leftRenderer->SetViewport(leftViewport);
 
-  vtkSmartPointer<vtkRenderer> rightRenderer =
-    vtkSmartPointer<vtkRenderer>::New();
+  vtkSmartPointer<vtkRenderer> rightRenderer = vtkSmartPointer<vtkRenderer>::New();
   renderWindow->AddRenderer(rightRenderer);
   rightRenderer->SetViewport(rightViewport);
-  rightRenderer->SetBackground(1,0,0);
+  rightRenderer->SetBackground(1, 0, 0);
 
   leftRenderer->AddActor(originalActor);
   rightRenderer->AddActor(gradientActor);
 
-  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor =
-    vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
 
-  vtkSmartPointer<vtkInteractorStyleImage> style =
-    vtkSmartPointer<vtkInteractorStyleImage>::New();
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
   renderWindowInteractor->SetInteractorStyle(style);
 
   renderWindowInteractor->SetRenderWindow(renderWindow);
@@ -136,23 +127,23 @@ int main(int argc, char * argv[])
   return EXIT_SUCCESS;
 }
 
-void VectorImageToVTKImage(itk::Image<itk::CovariantVector<float, 2>, 2>::Pointer vectorImage, vtkImageData* VTKImage)
+void
+VectorImageToVTKImage(itk::Image<itk::CovariantVector<float, 2>, 2>::Pointer vectorImage, vtkImageData * VTKImage)
 {
   itk::Image<itk::CovariantVector<float, 2>, 2>::RegionType region = vectorImage->GetLargestPossibleRegion();
-  itk::Image<itk::CovariantVector<float, 2>, 2>::SizeType imageSize = region.GetSize();
-  VTKImage->SetExtent(0, imageSize[0] -1, 0, imageSize[1] - 1, 0, 0);
+  itk::Image<itk::CovariantVector<float, 2>, 2>::SizeType   imageSize = region.GetSize();
+  VTKImage->SetExtent(0, imageSize[0] - 1, 0, imageSize[1] - 1, 0, 0);
 
-  vtkSmartPointer<vtkFloatArray> vectors =
-    vtkSmartPointer<vtkFloatArray>::New();
+  vtkSmartPointer<vtkFloatArray> vectors = vtkSmartPointer<vtkFloatArray>::New();
   vectors->SetNumberOfComponents(3);
   vectors->SetNumberOfTuples(imageSize[0] * imageSize[1]);
   vectors->SetName("GradientVectors");
 
   int counter = 0;
-  for(unsigned int j = 0; j < imageSize[1]; j++)
+  for (unsigned int j = 0; j < imageSize[1]; j++)
+  {
+    for (unsigned int i = 0; i < imageSize[0]; i++)
     {
-    for(unsigned int i = 0; i < imageSize[0]; i++)
-      {
       itk::Image<itk::CovariantVector<float, 2>, 2>::IndexType index;
       index[0] = i;
       index[1] = j;
@@ -165,9 +156,9 @@ void VectorImageToVTKImage(itk::Image<itk::CovariantVector<float, 2>, 2>::Pointe
       v[2] = 0;
       vectors->InsertTupleValue(counter, v);
       counter++;
-      }
     }
-  //std::cout << region << std::endl;
+  }
+  // std::cout << region << std::endl;
 
   VTKImage->GetPointData()->SetVectors(vectors);
 }

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitude/Code.cxx
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitude/Code.cxx
@@ -21,15 +21,16 @@
 #include "itkImageFileWriter.h"
 #include "itkGradientMagnitudeImageFilter.h"
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
   // Verify command line arguments
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " <InputImage> <OutputImage" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -37,37 +38,36 @@ int main(int argc, char * argv[])
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   using OutputPixelType = float;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
   // Create and setup a reader
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   // Create and setup a gradient filter
-  using FilterType = itk::GradientMagnitudeImageFilter<
-      InputImageType, OutputImageType >;
+  using FilterType = itk::GradientMagnitudeImageFilter<InputImageType, OutputImageType>;
 
   FilterType::Pointer gradientFilter = FilterType::New();
-  gradientFilter->SetInput( reader->GetOutput() );
+  gradientFilter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( gradientFilter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(gradientFilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/Code.cxx
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/Code.cxx
@@ -21,50 +21,50 @@
 #include "itkImageFileWriter.h"
 #include "itkGradientMagnitudeRecursiveGaussianImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName> <Sigma>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   const char * inputImage = argv[1];
   const char * outputImage = argv[2];
-  const double sigma = std::stod( argv[3] );
+  const double sigma = std::stod(argv[3]);
 
   constexpr unsigned int Dimension = 2;
   using PixelType = float;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using FilterType = itk::GradientMagnitudeRecursiveGaussianImageFilter<
-    ImageType, ImageType >;
+  using FilterType = itk::GradientMagnitudeRecursiveGaussianImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetSigma( sigma );
+  filter->SetInput(reader->GetOutput());
+  filter->SetSigma(sigma);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputImage );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputImage);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGradient/GradientOfVectorImage/Code.cxx
+++ b/src/Filtering/ImageGradient/GradientOfVectorImage/Code.cxx
@@ -20,41 +20,40 @@
 #include "itkGradientImageFilter.h"
 #include "itkImageRegionIterator.h"
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Setup types
-    using VectorType = itk::CovariantVector<float, 2>;
-    using VectorImageType = itk::Image<VectorType, 2>;
-    VectorImageType::Pointer image = VectorImageType::New();
+  // Setup types
+  using VectorType = itk::CovariantVector<float, 2>;
+  using VectorImageType = itk::Image<VectorType, 2>;
+  VectorImageType::Pointer image = VectorImageType::New();
 
-    itk::Size<2> size;
-    size[0] = 5;
-    size[1] = 5;
+  itk::Size<2> size;
+  size[0] = 5;
+  size[1] = 5;
 
-    itk::Index<2> index;
-    index[0] = 0;
-    index[1] = 0;
+  itk::Index<2> index;
+  index[0] = 0;
+  index[1] = 0;
 
-    VectorImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(index);
+  VectorImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(index);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<VectorImageType> iterator(image, region);
+  itk::ImageRegionIterator<VectorImageType> iterator(image, region);
 
-    while(!iterator.IsAtEnd())
-    {
-    }
+  while (!iterator.IsAtEnd())
+  {
+  }
 
-    // Create and setup a gradient filter
-    using GradientFilterType = itk::GradientImageFilter<
-            VectorImageType, VectorType>;
-    GradientFilterType::Pointer gradientFilter = GradientFilterType::New();
-    gradientFilter->SetInput(image);
-    gradientFilter->Update();
+  // Create and setup a gradient filter
+  using GradientFilterType = itk::GradientImageFilter<VectorImageType, VectorType>;
+  GradientFilterType::Pointer gradientFilter = GradientFilterType::New();
+  gradientFilter->SetInput(image);
+  gradientFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageGradient/ImplementationOfSnakes/Code.cxx
+++ b/src/Filtering/ImageGradient/ImplementationOfSnakes/Code.cxx
@@ -31,264 +31,259 @@
 
 namespace
 {
-    using ImageType = itk::Image< unsigned char, 2 >;
-    using FloatImageType = itk::Image< float,  2 >;
-    using IndexType = ImageType::IndexType;
-    using OutputPixelType = itk::CovariantVector< float, 2  >;
-    using OutputImageType = itk::Image< OutputPixelType, 2 >;
-    using FilterType = itk::GradientRecursiveGaussianImageFilter<
-            FloatImageType, OutputImageType>;
-    using GradMagfilterType = itk::GradientMagnitudeImageFilter<
-            ImageType, FloatImageType >;
-    using ReaderType = itk::ImageFileReader< ImageType >;
-}
+using ImageType = itk::Image<unsigned char, 2>;
+using FloatImageType = itk::Image<float, 2>;
+using IndexType = ImageType::IndexType;
+using OutputPixelType = itk::CovariantVector<float, 2>;
+using OutputImageType = itk::Image<OutputPixelType, 2>;
+using FilterType = itk::GradientRecursiveGaussianImageFilter<FloatImageType, OutputImageType>;
+using GradMagfilterType = itk::GradientMagnitudeImageFilter<ImageType, FloatImageType>;
+using ReaderType = itk::ImageFileReader<ImageType>;
+} // namespace
 
-vnl_vector<double> generateCircle(double cx, double cy,
-                                  double rx, double ry, int n);
-void createImage(ImageType::Pointer image,
-                 int w, int h, double cx, double cy, double rx, double ry);
-vnl_matrix<double> computeP(double alpha, double beta, double gamma,
-                            double N) throw();
-vnl_vector<double> sampleImage(vnl_vector<double> x, vnl_vector<double> y,
-                               OutputImageType::Pointer gradient,
-                               int position);
+vnl_vector<double>
+generateCircle(double cx, double cy, double rx, double ry, int n);
+void
+createImage(ImageType::Pointer image, int w, int h, double cx, double cy, double rx, double ry);
+vnl_matrix<double>
+computeP(double alpha, double beta, double gamma, double N) throw();
+vnl_vector<double>
+sampleImage(vnl_vector<double> x, vnl_vector<double> y, OutputImageType::Pointer gradient, int position);
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-    // Image dimensions
-    int w = 300;
-    int h = 300;
-    ImageType::Pointer image;
-    if( argc < 7 )
-    {
-        std::cout << "Usage " << argv[0]
-                  << " points alpha beta gamma sigma iterations [image]"
-                  << std::endl;
-        return EXIT_FAILURE;
-    }
-    else if( argc < 8 )
-    {
-        //Synthesize the image
-        image = ImageType::New();
-        createImage(image, w, h, 150, 150, 50, 50);
-    }
-    else if( argc == 8 )
-    {
-        //Open the image
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName( argv[7] );
-        try
-        {
-            reader->Update();
-            image = reader->GetOutput();
-            w = image->GetLargestPossibleRegion().GetSize()[0];
-            h = image->GetLargestPossibleRegion().GetSize()[1];
-        }
-        catch( itk::ExceptionObject & err )
-        {
-            std::cerr << "Caught unexpected exception " << err;
-            return EXIT_FAILURE;
-        }
-    }
-
-    // Snake parameters
-    double alpha = 0.001;
-    double beta = 0.4;
-    double gamma = 100;
-    double iterations = 1;
-    int nPoints = 20;
-    double sigma;
-
-    nPoints = std::stoi(argv[1]);
-    alpha = std::stod(argv[2]);
-    beta = std::stod(argv[3]);
-    gamma = std::stod(argv[4]);
-    sigma = std::stod(argv[5]);
-    iterations = std::stoi(argv[6]);
-
-    // Temporal variables
-    vnl_matrix<double> P;
-    vnl_vector<double> v;
-    double N;
-
-    // Generate initial snake circle
-    v = generateCircle(130, 130, 50, 50, nPoints);
-
-    // Compute P matrix.
-    N = v.size()/2;
+  // Image dimensions
+  int                w = 300;
+  int                h = 300;
+  ImageType::Pointer image;
+  if (argc < 7)
+  {
+    std::cout << "Usage " << argv[0] << " points alpha beta gamma sigma iterations [image]" << std::endl;
+    return EXIT_FAILURE;
+  }
+  else if (argc < 8)
+  {
+    // Synthesize the image
+    image = ImageType::New();
+    createImage(image, w, h, 150, 150, 50, 50);
+  }
+  else if (argc == 8)
+  {
+    // Open the image
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[7]);
     try
     {
-        P = computeP(alpha, beta, gamma, N);
+      reader->Update();
+      image = reader->GetOutput();
+      w = image->GetLargestPossibleRegion().GetSize()[0];
+      h = image->GetLargestPossibleRegion().GetSize()[1];
     }
-    catch(...)
+    catch (itk::ExceptionObject & err)
     {
-        return EXIT_FAILURE;
+      std::cerr << "Caught unexpected exception " << err;
+      return EXIT_FAILURE;
     }
+  }
 
-    // Compute the magnitude gradient
-    GradMagfilterType::Pointer gradientMagnitudeFilter =
-            GradMagfilterType::New();
-    gradientMagnitudeFilter->SetInput( image );
-    gradientMagnitudeFilter->Update();
+  // Snake parameters
+  double alpha = 0.001;
+  double beta = 0.4;
+  double gamma = 100;
+  double iterations = 1;
+  int    nPoints = 20;
+  double sigma;
 
-    // Compute the gradient of the gradient magnitude
-    FilterType::Pointer gradientFilter = FilterType::New();
-    gradientFilter->SetInput( gradientMagnitudeFilter->GetOutput() );
-    gradientFilter->SetSigma( sigma );
-    gradientFilter->Update();
+  nPoints = std::stoi(argv[1]);
+  alpha = std::stod(argv[2]);
+  beta = std::stod(argv[3]);
+  gamma = std::stod(argv[4]);
+  sigma = std::stod(argv[5]);
+  iterations = std::stoi(argv[6]);
 
-    // Loop
-    vnl_vector<double> x(N);
-    vnl_vector<double> y(N);
+  // Temporal variables
+  vnl_matrix<double> P;
+  vnl_vector<double> v;
+  double             N;
 
-    std::cout << "Initial snake" << std::endl;
-    for (int i = 0; i < N; ++i )
-    {
-        x[i] = v[2*i];
-        y[i] = v[2*i + 1];
-        std::cout << "(" << x[i] << ", " << y[i] << ")" << std::endl;
-    }
+  // Generate initial snake circle
+  v = generateCircle(130, 130, 50, 50, nPoints);
 
-    for( int i = 0; i < iterations; ++i )
-    {
-        vnl_vector<double> fex;
-        vnl_vector<double> fey;
-        fex = sampleImage(x, y, gradientFilter->GetOutput(), 0);
-        fey = sampleImage(x, y, gradientFilter->GetOutput(), 1);
+  // Compute P matrix.
+  N = v.size() / 2;
+  try
+  {
+    P = computeP(alpha, beta, gamma, N);
+  }
+  catch (...)
+  {
+    return EXIT_FAILURE;
+  }
 
-        x = (x+gamma*fex).post_multiply(P);
-        y = (y+gamma*fey).post_multiply(P);
-    }
+  // Compute the magnitude gradient
+  GradMagfilterType::Pointer gradientMagnitudeFilter = GradMagfilterType::New();
+  gradientMagnitudeFilter->SetInput(image);
+  gradientMagnitudeFilter->Update();
 
-    // Display the answer
-    std::cout << "Final snake after " << iterations << " iterations" << std::endl;
-    vnl_vector<double> v2(2*N);
-    for( int i = 0; i < N; ++i )
-    {
-        v2[2*i] = x[i];
-        v2[2*i + 1] = y[i];
-        std::cout << "(" << x[i] << ", " << y[i] << ")" << std::endl;
-    }
+  // Compute the gradient of the gradient magnitude
+  FilterType::Pointer gradientFilter = FilterType::New();
+  gradientFilter->SetInput(gradientMagnitudeFilter->GetOutput());
+  gradientFilter->SetSigma(sigma);
+  gradientFilter->Update();
 
-    return EXIT_SUCCESS;
+  // Loop
+  vnl_vector<double> x(N);
+  vnl_vector<double> y(N);
+
+  std::cout << "Initial snake" << std::endl;
+  for (int i = 0; i < N; ++i)
+  {
+    x[i] = v[2 * i];
+    y[i] = v[2 * i + 1];
+    std::cout << "(" << x[i] << ", " << y[i] << ")" << std::endl;
+  }
+
+  for (int i = 0; i < iterations; ++i)
+  {
+    vnl_vector<double> fex;
+    vnl_vector<double> fey;
+    fex = sampleImage(x, y, gradientFilter->GetOutput(), 0);
+    fey = sampleImage(x, y, gradientFilter->GetOutput(), 1);
+
+    x = (x + gamma * fex).post_multiply(P);
+    y = (y + gamma * fey).post_multiply(P);
+  }
+
+  // Display the answer
+  std::cout << "Final snake after " << iterations << " iterations" << std::endl;
+  vnl_vector<double> v2(2 * N);
+  for (int i = 0; i < N; ++i)
+  {
+    v2[2 * i] = x[i];
+    v2[2 * i + 1] = y[i];
+    std::cout << "(" << x[i] << ", " << y[i] << ")" << std::endl;
+  }
+
+  return EXIT_SUCCESS;
 }
 
-vnl_vector<double> generateCircle(
-        double cx, double cy, double rx, double ry, int n)
+vnl_vector<double>
+generateCircle(double cx, double cy, double rx, double ry, int n)
 {
-    vnl_vector<double> v(2*(n+1));
+  vnl_vector<double> v(2 * (n + 1));
 
-    for( int i = 0; i < n; ++i )
-    {
-        v[2*i] = cx + rx*cos(2*itk::Math::pi*i/n);
-        v[2*i + 1] = cy + ry*sin(2*itk::Math::pi*i/n);
-    }
-    v[2*n] = v[0];
-    v[2*n + 1] = v[1];
-    return v;
+  for (int i = 0; i < n; ++i)
+  {
+    v[2 * i] = cx + rx * cos(2 * itk::Math::pi * i / n);
+    v[2 * i + 1] = cy + ry * sin(2 * itk::Math::pi * i / n);
+  }
+  v[2 * n] = v[0];
+  v[2 * n + 1] = v[1];
+  return v;
 }
 
-void createImage(ImageType::Pointer image,
-                 int w, int h, double cx, double cy, double rx, double ry)
+void
+createImage(ImageType::Pointer image, int w, int h, double cx, double cy, double rx, double ry)
 {
-    itk::Size<2> size;
-    size[0] = w;
-    size[1] = h;
+  itk::Size<2> size;
+  size[0] = w;
+  size[1] = h;
 
-    itk::RandomImageSource<ImageType>::Pointer randomImageSource = itk::RandomImageSource<ImageType>::New();
-    randomImageSource->SetNumberOfWorkUnits(1); // to produce non-random results
-    randomImageSource->SetSize(size);
-    randomImageSource->SetMin(200);
-    randomImageSource->SetMax(255);
-    randomImageSource->Update();
+  itk::RandomImageSource<ImageType>::Pointer randomImageSource = itk::RandomImageSource<ImageType>::New();
+  randomImageSource->SetNumberOfWorkUnits(1); // to produce non-random results
+  randomImageSource->SetSize(size);
+  randomImageSource->SetMin(200);
+  randomImageSource->SetMax(255);
+  randomImageSource->Update();
 
-    image->SetRegions(randomImageSource->GetOutput()->GetLargestPossibleRegion());
-    image->Allocate();
+  image->SetRegions(randomImageSource->GetOutput()->GetLargestPossibleRegion());
+  image->Allocate();
 
-    IndexType index;
+  IndexType index;
 
-    // Draw oval
-    for( int i = 0; i < w; ++i )
+  // Draw oval
+  for (int i = 0; i < w; ++i)
+  {
+    for (int j = 0; j < h; ++j)
     {
-        for(int j = 0; j < h; ++j )
-        {
-            index[0] = i;
-            index[1] = j;
-            if( ((i - cx)*(i - cx)/(rx*rx) + (j - cy)*(j - cy)/(ry*ry) ) < 1 )
-            {
-                image->SetPixel(index, randomImageSource->GetOutput()->GetPixel(index)-100);
-            }
-            else
-            {
-                image->SetPixel(index, randomImageSource->GetOutput()->GetPixel(index));
-            }
-
-        }
+      index[0] = i;
+      index[1] = j;
+      if (((i - cx) * (i - cx) / (rx * rx) + (j - cy) * (j - cy) / (ry * ry)) < 1)
+      {
+        image->SetPixel(index, randomImageSource->GetOutput()->GetPixel(index) - 100);
+      }
+      else
+      {
+        image->SetPixel(index, randomImageSource->GetOutput()->GetPixel(index));
+      }
     }
+  }
 }
 
-vnl_matrix<double> computeP(double alpha, double beta, double gamma, double N) throw ()
+vnl_matrix<double>
+computeP(double alpha, double beta, double gamma, double N) throw()
 {
 
-    double a = gamma*(2*alpha + 6*beta)+1;
-    double b = gamma*(-alpha - 4*beta);
-    double c = gamma*beta;
+  double a = gamma * (2 * alpha + 6 * beta) + 1;
+  double b = gamma * (-alpha - 4 * beta);
+  double c = gamma * beta;
 
-    vnl_matrix<double> P(N, N);
+  vnl_matrix<double> P(N, N);
 
-    P.fill(0);
+  P.fill(0);
 
-    // Fill diagonal
-    P.fill_diagonal(a);
+  // Fill diagonal
+  P.fill_diagonal(a);
 
-    // Fill next two diagonals
-    for( int i = 0; i < N - 1; ++i )
-    {
-        P(i + 1, i) = b;
-        P(i, i + 1) = b;
-    }
-    // Moreover
-    P(0, N-1) = b;
-    P(N-1, 0) = b;
+  // Fill next two diagonals
+  for (int i = 0; i < N - 1; ++i)
+  {
+    P(i + 1, i) = b;
+    P(i, i + 1) = b;
+  }
+  // Moreover
+  P(0, N - 1) = b;
+  P(N - 1, 0) = b;
 
-    // Fill next two diagonals
-    for( int i = 0; i < N- 2; ++i )
-    {
-        P(i + 2, i) = c;
-        P(i, i + 2) = c;
-    }
-    // Moreover
-    P(0, N - 2) = c;
-    P(1, N - 1) = c;
-    P(N - 2, 0) = c;
-    P(N - 1, 1) = c;
+  // Fill next two diagonals
+  for (int i = 0; i < N - 2; ++i)
+  {
+    P(i + 2, i) = c;
+    P(i, i + 2) = c;
+  }
+  // Moreover
+  P(0, N - 2) = c;
+  P(1, N - 1) = c;
+  P(N - 2, 0) = c;
+  P(N - 1, 1) = c;
 
-    if( vnl_determinant(P) == 0.0 )
-    {
-        std::cerr << "Singular matrix. Determinant is 0." << std::endl;
-        throw;
-    }
+  if (vnl_determinant(P) == 0.0)
+  {
+    std::cerr << "Singular matrix. Determinant is 0." << std::endl;
+    throw;
+  }
 
-    // Compute the inverse of the matrix P
-    vnl_matrix< double > Pinv;
-    Pinv = vnl_matrix_inverse< double >(P);
+  // Compute the inverse of the matrix P
+  vnl_matrix<double> Pinv;
+  Pinv = vnl_matrix_inverse<double>(P);
 
-    return Pinv.transpose();
+  return Pinv.transpose();
 }
 
-vnl_vector<double> sampleImage(vnl_vector<double> x, vnl_vector<double> y, OutputImageType::Pointer gradient, int position)
+vnl_vector<double>
+sampleImage(vnl_vector<double> x, vnl_vector<double> y, OutputImageType::Pointer gradient, int position)
 {
-    int size;
-    size = x.size();
-    vnl_vector<double> ans(size);
+  int size;
+  size = x.size();
+  vnl_vector<double> ans(size);
 
-    IndexType index;
-    for( int i = 0; i < size; ++i )
-    {
-        index[0] = x[i];
-        index[1] = y[i];
-        ans[i] = gradient->GetPixel(index)[position];
-    }
-    return ans;
+  IndexType index;
+  for (int i = 0; i < size; ++i)
+  {
+    index[0] = x[i];
+    index[1] = y[i];
+    ans[i] = gradient->GetPixel(index)[position];
+  }
+  return ans;
 }
-

--- a/src/Filtering/ImageGrid/AppendTwo3DVolumes/Code.cxx
+++ b/src/Filtering/ImageGrid/AppendTwo3DVolumes/Code.cxx
@@ -20,16 +20,17 @@
 #include "itkImageFileWriter.h"
 #include "itkTileImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName1> <InputFileName2> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   const char * inputFileName1 = argv[1];
   const char * inputFileName2 = argv[2];
   const char * outputFileName = argv[3];
@@ -37,39 +38,39 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 3;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader1 = ReaderType::New();
-  reader1->SetFileName( inputFileName1 );
+  reader1->SetFileName(inputFileName1);
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader2 = ReaderType::New();
-  reader2->SetFileName( inputFileName2 );
+  reader2->SetFileName(inputFileName2);
 
-  using TileFilterType = itk::TileImageFilter< ImageType, ImageType >;
+  using TileFilterType = itk::TileImageFilter<ImageType, ImageType>;
   TileFilterType::Pointer tileFilter = TileFilterType::New();
-  tileFilter->SetInput( 0, reader1->GetOutput() );
-  tileFilter->SetInput( 1, reader2->GetOutput() );
+  tileFilter->SetInput(0, reader1->GetOutput());
+  tileFilter->SetInput(1, reader2->GetOutput());
   TileFilterType::LayoutArrayType layout;
   layout[0] = 1;
   layout[1] = 1;
   layout[2] = 2;
-  tileFilter->SetLayout( layout );
+  tileFilter->SetLayout(layout);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( tileFilter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(tileFilter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/Code.cxx
+++ b/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/Code.cxx
@@ -21,71 +21,71 @@
 #include "itkVersor.h"
 #include "itkChangeInformationImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 2 )
-    {
-    std::cerr << "Usage: "
-              << argv[0] << " <inputFileName>"
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " <inputFileName>"
               << " [scalingFactor]"
               << " [translationX translationY translationZ]"
               << " [rotationZinDegrees]" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
-  double scalingFactor = 1.0;
-  if( argc > 3 )
-    {
-    scalingFactor = std::stod( argv[3] );
-    }
+  double       scalingFactor = 1.0;
+  if (argc > 3)
+  {
+    scalingFactor = std::stod(argv[3]);
+  }
   double translationX = 0.0;
-  if( argc > 3 )
-    {
-    translationX = std::stod( argv[3] );
-    }
+  if (argc > 3)
+  {
+    translationX = std::stod(argv[3]);
+  }
   double translationY = 0.0;
-  if( argc > 4 )
-    {
-    translationY = std::stod( argv[4] );
-    }
+  if (argc > 4)
+  {
+    translationY = std::stod(argv[4]);
+  }
   double translationZ = 0.0;
-  if( argc > 5 )
-    {
-    translationZ = std::stod( argv[5] );
-    }
+  if (argc > 5)
+  {
+    translationZ = std::stod(argv[5]);
+  }
   double rotationZ = 0.0;
-  if( argc > 6 )
-    {
-    rotationZ = std::stod( argv[6] );
-    }
+  if (argc > 6)
+  {
+    rotationZ = std::stod(argv[6]);
+  }
 
   constexpr unsigned int Dimension = 3;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
   try
-    {
+  {
     reader->UpdateOutputInformation();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   ImageType::ConstPointer inputImage = reader->GetOutput();
   std::cout << "Original image: " << inputImage << std::endl;
 
-  using FilterType = itk::ChangeInformationImageFilter< ImageType >;
+  using FilterType = itk::ChangeInformationImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-  const ImageType::SpacingType spacing( scalingFactor );
-  filter->SetOutputSpacing( spacing );
+  const ImageType::SpacingType spacing(scalingFactor);
+  filter->SetOutputSpacing(spacing);
   filter->ChangeSpacingOn();
 
   ImageType::PointType::VectorType translation;
@@ -94,27 +94,26 @@ int main( int argc, char* argv[] )
   translation[2] = translationZ;
   ImageType::PointType origin = inputImage->GetOrigin();
   origin += translation;
-  filter->SetOutputOrigin( origin );
+  filter->SetOutputOrigin(origin);
   filter->ChangeOriginOn();
 
-  itk::Versor< double > rotation;
-  const double angleInRadians = rotationZ * itk::Math::pi / 180.0;
-  rotation.SetRotationAroundZ( angleInRadians );
+  itk::Versor<double> rotation;
+  const double        angleInRadians = rotationZ * itk::Math::pi / 180.0;
+  rotation.SetRotationAroundZ(angleInRadians);
   const ImageType::DirectionType direction = inputImage->GetDirection();
-  const ImageType::DirectionType newDirection
-    = direction * rotation.GetMatrix();
-  filter->SetOutputDirection( newDirection );
+  const ImageType::DirectionType newDirection = direction * rotation.GetMatrix();
+  filter->SetOutputDirection(newDirection);
   filter->ChangeDirectionOn();
 
   try
-    {
+  {
     filter->UpdateOutputInformation();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   std::cout << "**************************************" << std::endl;
   ImageType::ConstPointer output = filter->GetOutput();
   std::cout << "Changed image: " << output << std::endl;

--- a/src/Filtering/ImageGrid/Create3DVolume/Code.cxx
+++ b/src/Filtering/ImageGrid/Create3DVolume/Code.cxx
@@ -21,75 +21,76 @@
 #include "itkImageFileWriter.h"
 #include "itkTileImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc < 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<input1> <input2> <input3> ... <output>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int InputDimension = 2;
   constexpr unsigned int OutputDimension = 3;
 
   using PixelType = unsigned char;
-  using InputImageType = itk::Image< PixelType, InputDimension >;
-  using OutputImageType = itk::Image< PixelType, OutputDimension >;
+  using InputImageType = itk::Image<PixelType, InputDimension>;
+  using OutputImageType = itk::Image<PixelType, OutputDimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
 
-  using FilterType = itk::TileImageFilter< InputImageType, OutputImageType >;
+  using FilterType = itk::TileImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
 
-  itk::FixedArray< unsigned int, OutputDimension > layout;
+  itk::FixedArray<unsigned int, OutputDimension> layout;
   layout[0] = 2;
   layout[1] = 2;
   layout[2] = 0;
 
-  filter->SetLayout( layout );
+  filter->SetLayout(layout);
 
-  for( int ii = 1; ii < argc - 1; ++ii )
-    {
-    reader->SetFileName( argv[ii] );
+  for (int ii = 1; ii < argc - 1; ++ii)
+  {
+    reader->SetFileName(argv[ii]);
 
     try
-      {
+    {
       reader->Update();
-      }
-    catch( itk::ExceptionObject & e )
-      {
+    }
+    catch (itk::ExceptionObject & e)
+    {
       std::cerr << e << std::endl;
       return EXIT_FAILURE;
-      }
+    }
 
     InputImageType::Pointer input = reader->GetOutput();
     input->DisconnectPipeline();
 
-    filter->SetInput( ii - 1, input );
-    }
+    filter->SetInput(ii - 1, input);
+  }
 
-  constexpr PixelType defaultValue  = 128;
+  constexpr PixelType defaultValue = 128;
 
-  filter->SetDefaultPixelValue( defaultValue );
+  filter->SetDefaultPixelValue(defaultValue);
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[ argc - 1 ] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[argc - 1]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/Code.cxx
+++ b/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/Code.cxx
@@ -23,112 +23,106 @@
 #include "itksys/SystemTools.hxx"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using PixelType = itk::RGBPixel<unsigned char>;
 using ImageType = itk::Image<PixelType, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image = ImageType::New();
-    ImageType::SizeType cropSize;
-    std::stringstream desc;
+  ImageType::Pointer  image = ImageType::New();
+  ImageType::SizeType cropSize;
+  std::stringstream   desc;
 
-    if (argc > 1)
+  if (argc > 1)
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    if (argc > 2)
     {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName( argv[1] );
-        if (argc > 2)
-        {
-            cropSize[0] = std::stoi(argv[2]);
-            cropSize[1] = std::stoi(argv[3]);
-        }
-        reader->Update();
-        image = reader->GetOutput();
-        desc << itksys::SystemTools::GetFilenameName(argv[1]);
+      cropSize[0] = std::stoi(argv[2]);
+      cropSize[1] = std::stoi(argv[3]);
     }
-    else
-    {
-        CreateImage(image);
-        cropSize[0] = 10;
-        cropSize[1] = 14;
-        desc << "Synthetic image";
-    }
+    reader->Update();
+    image = reader->GetOutput();
+    desc << itksys::SystemTools::GetFilenameName(argv[1]);
+  }
+  else
+  {
+    CreateImage(image);
+    cropSize[0] = 10;
+    cropSize[1] = 14;
+    desc << "Synthetic image";
+  }
 
-    using CropImageFilterType = itk::CropImageFilter <ImageType, ImageType>;
+  using CropImageFilterType = itk::CropImageFilter<ImageType, ImageType>;
 
-    CropImageFilterType::Pointer cropFilter
-            = CropImageFilterType::New();
-    cropFilter->SetInput(image);
-    // The SetBoundaryCropSize( cropSize ) method specifies the size of
-    // the boundary to be cropped at both the uppper & lower ends of the
-    // image eg. cropSize/2 pixels will be removed at both upper & lower
-    // extents
+  CropImageFilterType::Pointer cropFilter = CropImageFilterType::New();
+  cropFilter->SetInput(image);
+  // The SetBoundaryCropSize( cropSize ) method specifies the size of
+  // the boundary to be cropped at both the uppper & lower ends of the
+  // image eg. cropSize/2 pixels will be removed at both upper & lower
+  // extents
 
-    cropFilter->SetBoundaryCropSize(cropSize);
+  cropFilter->SetBoundaryCropSize(cropSize);
 
-    // The below three lines are equivalent to the above two lines:
-    //ImageType::SizeType halfCropSize = {5,7};
-    //cropFilter->SetUpperBoundaryCropSize(halfCropSize);
-    //cropFilter->SetLowerBoundaryCropSize(halfCropSize);
+  // The below three lines are equivalent to the above two lines:
+  // ImageType::SizeType halfCropSize = {5,7};
+  // cropFilter->SetUpperBoundaryCropSize(halfCropSize);
+  // cropFilter->SetLowerBoundaryCropSize(halfCropSize);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddRGBImage(
-            image.GetPointer(),
-            true,
-            desc.str());
+  QuickView viewer;
+  viewer.AddRGBImage(image.GetPointer(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "CropImageFilter, crop size = {"
-          << cropSize[0] << ", " << cropSize[1] << "}";
-    viewer.AddRGBImage(
-            cropFilter->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "CropImageFilter, crop size = {" << cropSize[0] << ", " << cropSize[1] << "}";
+  viewer.AddRGBImage(cropFilter->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer( itk::NumericTraits<ImageType::PixelType>::Zero);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(itk::NumericTraits<ImageType::PixelType>::Zero);
 
-    // Make a rectangle, centered at (100,150) with sides 160 & 240
-    // This provides a 20 x 30 border around the square for the crop filter to remove
-    for(unsigned int r = 20; r < 180; r++)
+  // Make a rectangle, centered at (100,150) with sides 160 & 240
+  // This provides a 20 x 30 border around the square for the crop filter to remove
+  for (unsigned int r = 20; r < 180; r++)
+  {
+    for (unsigned int c = 30; c < 270; c++)
     {
-        for(unsigned int c = 30; c < 270; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 200);
-        }
+      image->SetPixel(pixelIndex, 200);
     }
+  }
 }
-

--- a/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/Code.cxx
@@ -20,35 +20,36 @@
 #include "itkImageFileWriter.h"
 #include "itkRegionOfInterestImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 7 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 7)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << " <start x> <end x> <start y> <end y>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
 
-  const auto startx = static_cast< itk::IndexValueType >( std::stoi( argv[3] ) );
-  const auto endx = static_cast< itk::IndexValueType >( std::stoi( argv[4] ) );
+  const auto startx = static_cast<itk::IndexValueType>(std::stoi(argv[3]));
+  const auto endx = static_cast<itk::IndexValueType>(std::stoi(argv[4]));
 
-  const auto starty = static_cast< itk::IndexValueType >( std::stoi( argv[5] ) );
-  const auto endy = static_cast< itk::IndexValueType >( std::stoi( argv[6] ) );
+  const auto starty = static_cast<itk::IndexValueType>(std::stoi(argv[5]));
+  const auto endy = static_cast<itk::IndexValueType>(std::stoi(argv[6]));
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   ImageType::IndexType start;
   start[0] = startx;
@@ -59,27 +60,27 @@ int main( int argc, char* argv[] )
   end[1] = endy;
 
   ImageType::RegionType region;
-  region.SetIndex( start );
-  region.SetUpperIndex( end );
+  region.SetIndex(start);
+  region.SetUpperIndex(end);
 
-  using FilterType = itk::RegionOfInterestImageFilter< ImageType, ImageType >;
+  using FilterType = itk::RegionOfInterestImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetRegionOfInterest( region );
+  filter->SetInput(reader->GetOutput());
+  filter->SetRegionOfInterest(region);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/FitSplineIntoPointSet/Code.cxx
+++ b/src/Filtering/ImageGrid/FitSplineIntoPointSet/Code.cxx
@@ -21,72 +21,77 @@
 #include "itkVectorImage.h"
 #include "itkImageFileWriter.h"
 
-int main ()
+int
+main()
 {
   constexpr unsigned int ParametricDimension = 1;
   constexpr unsigned int DataDimension = 2;
 
-  using DataType = itk::Vector< float, DataDimension >;
+  using DataType = itk::Vector<float, DataDimension>;
 
-  using PointSetType = itk::PointSet< DataType, ParametricDimension >;
+  using PointSetType = itk::PointSet<DataType, ParametricDimension>;
 
   PointSetType::Pointer pointSet = PointSetType::New();
 
   PointSetType::PointType param0, param1, param2;
 
-   param0[0] = 0.0;
+  param0[0] = 0.0;
   DataType p0;
-  p0[0] =  10.0; p0[1]= 10.0;
+  p0[0] = 10.0;
+  p0[1] = 10.0;
 
   pointSet->SetPoint(0, param0);
-  pointSet->SetPointData( 0, p0 );
+  pointSet->SetPointData(0, p0);
 
   param1[0] = 1.0;
   DataType p1;
-  p1[0] =  80.0; p1[1]= 50.0;
+  p1[0] = 80.0;
+  p1[1] = 50.0;
   pointSet->SetPoint(1, param1);
-  pointSet->SetPointData( 1, p1 );
+  pointSet->SetPointData(1, p1);
 
   param2[0] = 2.0;
   DataType p2;
-  p2[0] =  180.0; p2[1]= 180.0;
+  p2[0] = 180.0;
+  p2[1] = 180.0;
   pointSet->SetPoint(2, param2);
-  pointSet->SetPointData( 2, p2 );
+  pointSet->SetPointData(2, p2);
 
-   using ImageType = itk::Image<DataType, ParametricDimension>;
-  using SplineFilterType = itk::BSplineScatteredDataPointSetToImageFilter < PointSetType, ImageType >;
+  using ImageType = itk::Image<DataType, ParametricDimension>;
+  using SplineFilterType = itk::BSplineScatteredDataPointSetToImageFilter<PointSetType, ImageType>;
   SplineFilterType::Pointer splineFilter = SplineFilterType::New();
 
-  int splineorder=2; // complexity of the spline
+  int splineorder = 2; // complexity of the spline
 
   SplineFilterType::ArrayType ncontrol;
-  ncontrol[0]=splineorder + 1;
+  ncontrol[0] = splineorder + 1;
   SplineFilterType::ArrayType closedim;
-  closedim[0]= 0;
+  closedim[0] = 0;
 
   ImageType::PointType parametricDomainOrigin;
   parametricDomainOrigin[0] = 0.0;
 
   ImageType::SpacingType parametricDomainSpacing;
-  parametricDomainSpacing[0] = 0.0001;  // this determines the sampling of the continuous B-spline object.
+  parametricDomainSpacing[0] = 0.0001; // this determines the sampling of the continuous B-spline object.
 
   ImageType::SizeType parametricDomainSize;
   parametricDomainSize[0] = 2.0 / parametricDomainSpacing[0] + 1;
-  splineFilter->SetGenerateOutputImage( true );   // the only reason to turn this off is if one only wants to use the control point lattice for further processing
-  splineFilter->SetInput ( pointSet );
-  splineFilter->SetSplineOrder ( splineorder );
-  splineFilter->SetNumberOfControlPoints ( ncontrol );
-  splineFilter->SetNumberOfLevels( 3 );
-  splineFilter->SetCloseDimension ( closedim );
-  splineFilter->SetSize( parametricDomainSize );
-  splineFilter->SetSpacing( parametricDomainSpacing );
-  splineFilter->SetOrigin( parametricDomainOrigin );
+  splineFilter->SetGenerateOutputImage(true); // the only reason to turn this off is if one only wants to use the
+                                              // control point lattice for further processing
+  splineFilter->SetInput(pointSet);
+  splineFilter->SetSplineOrder(splineorder);
+  splineFilter->SetNumberOfControlPoints(ncontrol);
+  splineFilter->SetNumberOfLevels(3);
+  splineFilter->SetCloseDimension(closedim);
+  splineFilter->SetSize(parametricDomainSize);
+  splineFilter->SetSpacing(parametricDomainSpacing);
+  splineFilter->SetOrigin(parametricDomainOrigin);
   splineFilter->Update();
 
   // The output will consist of a 1-D image where each voxel contains the
   // (x,y,z) locations of the points
   using OutputImageType = itk::Image<unsigned char, 2>;
-  OutputImageType::Pointer outputImage = OutputImageType::New();
+  OutputImageType::Pointer  outputImage = OutputImageType::New();
   OutputImageType::SizeType size;
   size.Fill(200);
 
@@ -98,8 +103,8 @@ int main ()
   outputImage->Allocate();
   outputImage->FillBuffer(0);
 
-  for(unsigned int i = 0; i < splineFilter->GetOutput()->GetLargestPossibleRegion().GetSize()[0]; ++i)
-    {
+  for (unsigned int i = 0; i < splineFilter->GetOutput()->GetLargestPossibleRegion().GetSize()[0]; ++i)
+  {
     ImageType::IndexType splineIndex;
     splineIndex[0] = i;
 
@@ -109,10 +114,10 @@ int main ()
     index[0] = outputPixel[0];
     index[1] = outputPixel[1];
 
-    outputImage->SetPixel(index, 255 );
-    }
+    outputImage->SetPixel(index, 255);
+  }
 
-  using WriterType = itk::ImageFileWriter< OutputImageType  >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName("spline.png");
   writer->SetInput(outputImage);

--- a/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/Code.cxx
+++ b/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/Code.cxx
@@ -21,59 +21,59 @@
 #include "itkImageFileWriter.h"
 #include "itkFlipImageFilter.h"
 
-int main(int argc, char* argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
+  if (argc != 4)
+  {
     std::cerr << "Usage: " << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <AxisToFlip>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  constexpr unsigned Dimension  = 2;
+  constexpr unsigned Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using FlipImageFilterType = itk::FlipImageFilter< ImageType >;
+  using FlipImageFilterType = itk::FlipImageFilter<ImageType>;
 
-  FlipImageFilterType::Pointer flipFilter
-          = FlipImageFilterType::New ();
-  flipFilter->SetInput( reader->GetOutput() );
+  FlipImageFilterType::Pointer flipFilter = FlipImageFilterType::New();
+  flipFilter->SetInput(reader->GetOutput());
 
   FlipImageFilterType::FlipAxesArrayType flipAxes;
-  if( std::stoi( argv[3] ) == 0 )
-    {
+  if (std::stoi(argv[3]) == 0)
+  {
     flipAxes[0] = true;
     flipAxes[1] = false;
-    }
+  }
   else
-    {
+  {
     flipAxes[0] = false;
     flipAxes[1] = true;
-    }
+  }
 
-  flipFilter->SetFlipAxes( flipAxes );
+  flipFilter->SetFlipAxes(flipAxes);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( flipFilter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(flipFilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/PadAnImageByMirroring/Code.cxx
+++ b/src/Filtering/ImageGrid/PadAnImageByMirroring/Code.cxx
@@ -21,25 +21,26 @@
 #include "itkImageFileWriter.h"
 #include "itkMirrorPadImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   ImageType::SizeType lowerBound;
   lowerBound[0] = 20;
@@ -49,26 +50,26 @@ int main( int argc, char* argv[] )
   upperBound[0] = 50;
   upperBound[1] = 40;
 
-  using FilterType = itk::MirrorPadImageFilter< ImageType, ImageType >;
+  using FilterType = itk::MirrorPadImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetPadLowerBound( lowerBound );
-  filter->SetPadUpperBound( upperBound );
+  filter->SetInput(reader->GetOutput());
+  filter->SetPadLowerBound(lowerBound);
+  filter->SetPadUpperBound(upperBound);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/PadAnImageWithAConstant/Code.cxx
+++ b/src/Filtering/ImageGrid/PadAnImageWithAConstant/Code.cxx
@@ -21,54 +21,55 @@
 #include "itkImageFileWriter.h"
 #include "itkConstantPadImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName> <LowerExtendSize> ";
     std::cerr << "<UpperExtendSize> <ConstantValue>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   ImageType::SizeType lowerExtendRegion;
-  lowerExtendRegion.Fill( std::stoi( argv[3] ) );
+  lowerExtendRegion.Fill(std::stoi(argv[3]));
 
   ImageType::SizeType upperExtendRegion;
-  upperExtendRegion.Fill( std::stoi( argv[4] ) );
+  upperExtendRegion.Fill(std::stoi(argv[4]));
 
-  using FilterType = itk::ConstantPadImageFilter< ImageType, ImageType >;
+  using FilterType = itk::ConstantPadImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
   filter->SetPadLowerBound(lowerExtendRegion);
   filter->SetPadUpperBound(upperExtendRegion);
-  filter->SetConstant( std::stoi( argv[5] ) );
+  filter->SetConstant(std::stoi(argv[5]));
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/PadImageByWrapping/Code.cxx
+++ b/src/Filtering/ImageGrid/PadImageByWrapping/Code.cxx
@@ -23,56 +23,57 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using WrapPadImageFilterType = itk::WrapPadImageFilter <ImageType, ImageType>;
+  using WrapPadImageFilterType = itk::WrapPadImageFilter<ImageType, ImageType>;
 
-    ImageType::SizeType lowerBound;
-    lowerBound[0] = 20;
-    lowerBound[1] = 30;
+  ImageType::SizeType lowerBound;
+  lowerBound[0] = 20;
+  lowerBound[1] = 30;
 
-    ImageType::SizeType upperBound;
-    upperBound[0] = 50;
-    upperBound[1] = 40;
+  ImageType::SizeType upperBound;
+  upperBound[0] = 50;
+  upperBound[1] = 40;
 
-    WrapPadImageFilterType::Pointer padFilter
-            = WrapPadImageFilterType::New();
-    padFilter->SetInput(image);
-    padFilter->SetPadLowerBound(lowerBound);
-    padFilter->SetPadUpperBound(upperBound);
-    padFilter->Update();
+  WrapPadImageFilterType::Pointer padFilter = WrapPadImageFilterType::New();
+  padFilter->SetInput(image);
+  padFilter->SetPadLowerBound(lowerBound);
+  padFilter->SetPadUpperBound(upperBound);
+  padFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    size[0] = 200;
-    size[1] = 100;
+  ImageType::SizeType size;
+  size[0] = 200;
+  size[1] = 100;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  image->SetRegions(region);
+  image->Allocate();
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(imageIterator.GetIndex()[0]);
-        ++imageIterator;
-    }
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(imageIterator.GetIndex()[0]);
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/Code.cxx
+++ b/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/Code.cxx
@@ -20,61 +20,62 @@
 #include "itkImageFileWriter.h"
 #include "itkPasteImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <SourceFileName> <DestinationFileName> <OutputFileName> <start x> <start y>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const char * sourceFileName       = argv[1];
-  const char * destinationFileName  = argv[2];
-  const char * outputFileName       = argv[3];
+  const char * sourceFileName = argv[1];
+  const char * destinationFileName = argv[2];
+  const char * outputFileName = argv[3];
 
-  int startX = std::stoi( argv[4] );
-  int startY = std::stoi( argv[5] );
+  int startX = std::stoi(argv[4]);
+  int startY = std::stoi(argv[5]);
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::IndexType index;
   index[0] = startX;
   index[1] = startY;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer sourceReader = ReaderType::New();
-  sourceReader->SetFileName( sourceFileName );
+  sourceReader->SetFileName(sourceFileName);
   sourceReader->Update();
 
   ReaderType::Pointer destinationReader = ReaderType::New();
-  destinationReader->SetFileName( destinationFileName );
+  destinationReader->SetFileName(destinationFileName);
 
-  using FilterType = itk::PasteImageFilter< ImageType, ImageType >;
+  using FilterType = itk::PasteImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetSourceImage( sourceReader->GetOutput() );
-  filter->SetSourceRegion( sourceReader->GetOutput()->GetLargestPossibleRegion() );
-  filter->SetDestinationImage( destinationReader->GetOutput() );
-  filter->SetDestinationIndex( index );
+  filter->SetSourceImage(sourceReader->GetOutput());
+  filter->SetSourceRegion(sourceReader->GetOutput()->GetLargestPossibleRegion());
+  filter->SetDestinationImage(destinationReader->GetOutput());
+  filter->SetDestinationIndex(index);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/PermuteAxesOfAnImage/Code.cxx
+++ b/src/Filtering/ImageGrid/PermuteAxesOfAnImage/Code.cxx
@@ -20,16 +20,17 @@
 #include "itkImageFileWriter.h"
 #include "itkPermuteAxesImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -37,35 +38,35 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::PermuteAxesImageFilter< ImageType >;
+  using FilterType = itk::PermuteAxesImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
   FilterType::PermuteOrderArrayType order;
   order[0] = 1;
   order[1] = 0;
 
-  filter->SetOrder( order );
+  filter->SetOrder(order);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/ResampleAVectorImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ResampleAVectorImage/Code.cxx
@@ -24,16 +24,17 @@
 #include "itkLinearInterpolateImageFunction.h"
 #include "itkRGBPixel.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -41,68 +42,68 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelComponentType = unsigned char;
-  using PixelType = itk::RGBPixel< PixelComponentType >;
-  using ImageType = itk::Image< PixelType,  Dimension >;
+  using PixelType = itk::RGBPixel<PixelComponentType>;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::ResampleImageFilter< ImageType, ImageType >;
+  using FilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
   FilterType::Pointer filter = FilterType::New();
 
-  using InterpolatorType = itk::LinearInterpolateImageFunction< ImageType, double >;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double>;
 
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
 
-  filter->SetInterpolator( interpolator );
+  filter->SetInterpolator(interpolator);
 
-  using TransformType = itk::IdentityTransform< double, Dimension >;
+  using TransformType = itk::IdentityTransform<double, Dimension>;
   TransformType::Pointer transform = TransformType::New();
 
-  filter->SetTransform( transform );
+  filter->SetTransform(transform);
 
   PixelType defaultValue;
   defaultValue.Fill(50);
-  filter->SetDefaultPixelValue( defaultValue );
+  filter->SetDefaultPixelValue(defaultValue);
 
   ImageType::SpacingType spacing;
   spacing[0] = .5; // pixel spacing in millimeters along X
   spacing[1] = .5; // pixel spacing in millimeters along Y
 
-  filter->SetOutputSpacing( spacing );
+  filter->SetOutputSpacing(spacing);
 
   ImageType::PointType origin;
-  origin[0] = 30.0;  // X space coordinate of origin
-  origin[1] = 40.0;  // Y space coordinate of origin
-  filter->SetOutputOrigin( origin );
+  origin[0] = 30.0; // X space coordinate of origin
+  origin[1] = 40.0; // Y space coordinate of origin
+  filter->SetOutputOrigin(origin);
 
   ImageType::DirectionType direction;
   direction.SetIdentity();
-  filter->SetOutputDirection( direction );
+  filter->SetOutputDirection(direction);
 
-  ImageType::SizeType   size;
+  ImageType::SizeType size;
 
-  size[0] = 300;  // number of pixels along X
-  size[1] = 300;  // number of pixels along Y
+  size[0] = 300; // number of pixels along X
+  size[1] = 300; // number of pixels along Y
 
-  filter->SetSize( size );
-  filter->SetInput( reader->GetOutput() );
+  filter->SetSize(size);
+  filter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/ResampleAnImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ResampleAnImage/Code.cxx
@@ -22,82 +22,83 @@
 #include "itkResampleImageFilter.h"
 #include "itkScaleTransform.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << " <numberOfIterations> <timeStep> <conductance>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const float scale = std::stod( argv[3] );
+  const float  scale = std::stod(argv[3]);
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
   using ScalarType = double;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
   reader->Update();
 
   ImageType::Pointer inputImage = reader->GetOutput();
 
-  ImageType::RegionType region = inputImage->GetLargestPossibleRegion();
-  ImageType::SizeType size = region.GetSize();
+  ImageType::RegionType  region = inputImage->GetLargestPossibleRegion();
+  ImageType::SizeType    size = region.GetSize();
   ImageType::SpacingType spacing = inputImage->GetSpacing();
 
-  itk::Index< Dimension > centralPixel;
+  itk::Index<Dimension> centralPixel;
   centralPixel[0] = size[0] / 2;
   centralPixel[1] = size[1] / 2;
-  itk::Point< ScalarType, Dimension > centralPoint;
+  itk::Point<ScalarType, Dimension> centralPoint;
   centralPoint[0] = centralPixel[0];
   centralPoint[1] = centralPixel[1];
 
-  using ScaleTransformType = itk::ScaleTransform< ScalarType, Dimension >;
+  using ScaleTransformType = itk::ScaleTransform<ScalarType, Dimension>;
   ScaleTransformType::Pointer scaleTransform = ScaleTransformType::New();
 
   ScaleTransformType::ParametersType parameters = scaleTransform->GetParameters();
   parameters[0] = scale;
   parameters[1] = scale;
 
-  scaleTransform->SetParameters( parameters );
-  scaleTransform->SetCenter( centralPoint );
+  scaleTransform->SetParameters(parameters);
+  scaleTransform->SetCenter(centralPoint);
 
-  using LinearInterpolatorType = itk::LinearInterpolateImageFunction< ImageType, ScalarType >;
+  using LinearInterpolatorType = itk::LinearInterpolateImageFunction<ImageType, ScalarType>;
   LinearInterpolatorType::Pointer interpolator = LinearInterpolatorType::New();
 
-  using ResampleFilterType = itk::ResampleImageFilter< ImageType, ImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
   ResampleFilterType::Pointer resampleFilter = ResampleFilterType::New();
 
-  resampleFilter->SetInput( inputImage );
-  resampleFilter->SetTransform( scaleTransform );
-  resampleFilter->SetInterpolator( interpolator );
-  resampleFilter->SetSize( size );
-  resampleFilter->SetOutputSpacing( spacing );
+  resampleFilter->SetInput(inputImage);
+  resampleFilter->SetTransform(scaleTransform);
+  resampleFilter->SetInterpolator(interpolator);
+  resampleFilter->SetSize(size);
+  resampleFilter->SetOutputSpacing(spacing);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( resampleFilter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(resampleFilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/Code.cxx
+++ b/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/Code.cxx
@@ -26,91 +26,81 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " InputImageFile [radius]" << std::endl;
-        return EXIT_FAILURE;
-    }
-    std::string inputFilename = argv[1];
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " InputImageFile [radius]" << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using ImageType = itk::Image<float, 2 >;
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    using FilterType = itk::MedianImageFilter<ImageType, ImageType >;
-    using SubtractType = itk::SubtractImageFilter<ImageType>;
-    using PasteType = itk::PasteImageFilter<ImageType, ImageType >;
+  // Setup types
+  using ImageType = itk::Image<float, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using FilterType = itk::MedianImageFilter<ImageType, ImageType>;
+  using SubtractType = itk::SubtractImageFilter<ImageType>;
+  using PasteType = itk::PasteImageFilter<ImageType, ImageType>;
 
-    // Create and setup a reader
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFilename );
+  // Create and setup a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename);
 
-    // Create and setup a median filter
-    FilterType::Pointer medianFilter = FilterType::New();
-    FilterType::InputSizeType radius;
-    radius.Fill(2);
-    if (argc > 2)
-    {
-        radius.Fill(atoi(argv[2]));
-    }
+  // Create and setup a median filter
+  FilterType::Pointer       medianFilter = FilterType::New();
+  FilterType::InputSizeType radius;
+  radius.Fill(2);
+  if (argc > 2)
+  {
+    radius.Fill(atoi(argv[2]));
+  }
 
-    reader->Update();
+  reader->Update();
 
-    itk::Size<2> processSize;
-    processSize[0] =
-            reader->GetOutput()->GetLargestPossibleRegion().GetSize()[0] / 2;
-    processSize[1] =
-            reader->GetOutput()->GetLargestPossibleRegion().GetSize()[1] / 2;
+  itk::Size<2> processSize;
+  processSize[0] = reader->GetOutput()->GetLargestPossibleRegion().GetSize()[0] / 2;
+  processSize[1] = reader->GetOutput()->GetLargestPossibleRegion().GetSize()[1] / 2;
 
-    itk::Index<2> processIndex;
-    processIndex[0] = processSize[0] / 2;
-    processIndex[1] = processSize[1] / 2;
+  itk::Index<2> processIndex;
+  processIndex[0] = processSize[0] / 2;
+  processIndex[1] = processSize[1] / 2;
 
-    itk::ImageRegion<2> processRegion(processIndex, processSize);
+  itk::ImageRegion<2> processRegion(processIndex, processSize);
 
-    medianFilter->SetRadius(radius);
-    medianFilter->SetInput( reader->GetOutput() );
-    medianFilter->GetOutput()->SetRequestedRegion( processRegion );
+  medianFilter->SetRadius(radius);
+  medianFilter->SetInput(reader->GetOutput());
+  medianFilter->GetOutput()->SetRequestedRegion(processRegion);
 
-    PasteType::Pointer pasteFilter = PasteType::New();
+  PasteType::Pointer pasteFilter = PasteType::New();
 
-    pasteFilter->SetSourceImage(medianFilter->GetOutput());
-    pasteFilter->SetSourceRegion(medianFilter->GetOutput()->GetRequestedRegion());
-    pasteFilter->SetDestinationImage(reader->GetOutput());
-    pasteFilter->SetDestinationIndex(processIndex);
+  pasteFilter->SetSourceImage(medianFilter->GetOutput());
+  pasteFilter->SetSourceRegion(medianFilter->GetOutput()->GetRequestedRegion());
+  pasteFilter->SetDestinationImage(reader->GetOutput());
+  pasteFilter->SetDestinationIndex(processIndex);
 
-    SubtractType::Pointer diff = SubtractType::New();
-    diff->SetInput1(reader->GetOutput());
-    diff->SetInput2(pasteFilter->GetOutput());
+  SubtractType::Pointer diff = SubtractType::New();
+  diff->SetInput1(reader->GetOutput());
+  diff->SetInput2(pasteFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(inputFilename));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFilename));
 
-    std::stringstream desc;
-    desc << "Median/PasteImageFilter, radius = " << radius;
-    viewer.AddImage(
-            pasteFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Median/PasteImageFilter, radius = " << radius;
+  viewer.AddImage(pasteFilter->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Original - Median/Paste";
-    viewer.AddImage(
-            diff->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "Original - Median/Paste";
+  viewer.AddImage(diff->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
@@ -22,54 +22,56 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    std::cout << "Original size: " << image->GetLargestPossibleRegion().GetSize() << std::endl;
+  std::cout << "Original size: " << image->GetLargestPossibleRegion().GetSize() << std::endl;
 
-    using ShrinkImageFilterType = itk::ShrinkImageFilter <ImageType, ImageType>;
+  using ShrinkImageFilterType = itk::ShrinkImageFilter<ImageType, ImageType>;
 
-    ShrinkImageFilterType::Pointer shrinkFilter
-            = ShrinkImageFilterType::New();
-    shrinkFilter->SetInput(image);
-    shrinkFilter->SetShrinkFactor(0, 2); // shrink the first dimension by a factor of 2 (i.e. 100 gets changed to 50)
-    shrinkFilter->SetShrinkFactor(1, 3); // shrink the second dimension by a factor of 3 (i.e. 100 gets changed to 33)
-    shrinkFilter->Update();
+  ShrinkImageFilterType::Pointer shrinkFilter = ShrinkImageFilterType::New();
+  shrinkFilter->SetInput(image);
+  shrinkFilter->SetShrinkFactor(0, 2); // shrink the first dimension by a factor of 2 (i.e. 100 gets changed to 50)
+  shrinkFilter->SetShrinkFactor(1, 3); // shrink the second dimension by a factor of 3 (i.e. 100 gets changed to 33)
+  shrinkFilter->Update();
 
-    std::cout << "New size: " << shrinkFilter->GetOutput()->GetLargestPossibleRegion().GetSize() << std::endl;
+  std::cout << "New size: " << shrinkFilter->GetOutput()->GetLargestPossibleRegion().GetSize() << std::endl;
 
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create an image with 2 connected components
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region(start, size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  ImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a white square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a white square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 20; c < 30; c++)
     {
-        for(unsigned int c = 20; c < 30; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }

--- a/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/Code.cxx
+++ b/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/Code.cxx
@@ -20,73 +20,74 @@
 #include "itkImageFileWriter.h"
 #include "itkImage.h"
 
-int main(int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
 
-    using PixelType = unsigned char;
-    constexpr unsigned int InputImageDimension = 2;
-    constexpr unsigned int OutputImageDimension = 3;
+  using PixelType = unsigned char;
+  constexpr unsigned int InputImageDimension = 2;
+  constexpr unsigned int OutputImageDimension = 3;
 
-    using InputImageType = itk::Image< PixelType, InputImageDimension  >;
-    using OutputImageType = itk::Image< PixelType, OutputImageDimension >;
+  using InputImageType = itk::Image<PixelType, InputImageDimension>;
+  using OutputImageType = itk::Image<PixelType, OutputImageDimension>;
 
-    using ImageReaderType = itk::ImageFileReader< InputImageType >;
+  using ImageReaderType = itk::ImageFileReader<InputImageType>;
 
-    using TilerType = itk::TileImageFilter< InputImageType, OutputImageType >;
+  using TilerType = itk::TileImageFilter<InputImageType, OutputImageType>;
 
-    using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-    if (argc < 4)
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << "input1 input2 ... inputn output" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 4)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << "input1 input2 ... inputn output" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    TilerType::Pointer tiler = TilerType::New();
+  TilerType::Pointer tiler = TilerType::New();
 
-    itk::FixedArray< unsigned int, OutputImageDimension > layout;
+  itk::FixedArray<unsigned int, OutputImageDimension> layout;
 
-    layout[0] = 1;
-    layout[1] = 1;
-    layout[2] = 0;
+  layout[0] = 1;
+  layout[1] = 1;
+  layout[2] = 0;
 
-    tiler->SetLayout( layout );
+  tiler->SetLayout(layout);
 
-    unsigned int inputImageNumber = 0;
+  unsigned int inputImageNumber = 0;
 
-    ImageReaderType::Pointer reader = ImageReaderType::New();
+  ImageReaderType::Pointer reader = ImageReaderType::New();
 
-    InputImageType::Pointer inputImageTile;
+  InputImageType::Pointer inputImageTile;
 
-    for (int i = 1; i < argc - 1; i++)
-    {
-        reader->SetFileName( argv[i] );
-        reader->UpdateLargestPossibleRegion();
-        inputImageTile = reader->GetOutput();
-        inputImageTile->DisconnectPipeline();
-        tiler->SetInput( inputImageNumber++, inputImageTile );
-    }
+  for (int i = 1; i < argc - 1; i++)
+  {
+    reader->SetFileName(argv[i]);
+    reader->UpdateLargestPossibleRegion();
+    inputImageTile = reader->GetOutput();
+    inputImageTile->DisconnectPipeline();
+    tiler->SetInput(inputImageNumber++, inputImageTile);
+  }
 
-    PixelType filler = 128;
+  PixelType filler = 128;
 
-    tiler->SetDefaultPixelValue( filler );
+  tiler->SetDefaultPixelValue(filler);
 
-    tiler->Update();
+  tiler->Update();
 
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput( tiler->GetOutput() );
-    writer->SetFileName( argv[argc-1] );
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(tiler->GetOutput());
+  writer->SetFileName(argv[argc - 1]);
 
-    try
-    {
-        writer->Update();
-    }
-    catch( itk::ExceptionObject & excp )
-    {
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/TileImagesSideBySide/Code.cxx
+++ b/src/Filtering/ImageGrid/TileImagesSideBySide/Code.cxx
@@ -20,66 +20,69 @@
 #include "itkImageFileWriter.h"
 #include "itkTileImageFilter.h"
 
-int main(int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-    // Verify arguments
-    if (argc < 4)
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << "input1 input2 output" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify arguments
+  if (argc < 4)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << "input1 input2 output" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Parse arguments
-    std::string input1FileName = argv[1];
-    std::string input2FileName = argv[2];
-    std::string outputFileName = argv[3];
+  // Parse arguments
+  std::string input1FileName = argv[1];
+  std::string input2FileName = argv[2];
+  std::string outputFileName = argv[3];
 
-    // Output arguments
-    std::cout << "input1FileName " << input1FileName << std::endl;
-    std::cout << "input2FileName " << input2FileName << std::endl;;
-    std::cout << "outputFileName " << outputFileName << std::endl;;
+  // Output arguments
+  std::cout << "input1FileName " << input1FileName << std::endl;
+  std::cout << "input2FileName " << input2FileName << std::endl;
+  ;
+  std::cout << "outputFileName " << outputFileName << std::endl;
+  ;
 
-    using ImageType = itk::Image< unsigned char, 2>;
+  using ImageType = itk::Image<unsigned char, 2>;
 
-    // Read images
-    using ImageReaderType = itk::ImageFileReader< ImageType >;
-    ImageReaderType::Pointer reader1 = ImageReaderType::New();
-    reader1->SetFileName(input1FileName);
-    reader1->Update();
+  // Read images
+  using ImageReaderType = itk::ImageFileReader<ImageType>;
+  ImageReaderType::Pointer reader1 = ImageReaderType::New();
+  reader1->SetFileName(input1FileName);
+  reader1->Update();
 
-    ImageReaderType::Pointer reader2 = ImageReaderType::New();
-    reader2->SetFileName(input2FileName);
-    reader2->Update();
+  ImageReaderType::Pointer reader2 = ImageReaderType::New();
+  reader2->SetFileName(input2FileName);
+  reader2->Update();
 
-    // Tile the images side-by-side
-    using TileFilterType = itk::TileImageFilter< ImageType, ImageType >;
+  // Tile the images side-by-side
+  using TileFilterType = itk::TileImageFilter<ImageType, ImageType>;
 
-    TileFilterType::Pointer tileFilter = TileFilterType::New();
+  TileFilterType::Pointer tileFilter = TileFilterType::New();
 
-    itk::FixedArray< unsigned int, 2 > layout;
+  itk::FixedArray<unsigned int, 2> layout;
 
-    layout[0] = 2;
-    layout[1] = 0;
+  layout[0] = 2;
+  layout[1] = 0;
 
-    tileFilter->SetLayout( layout );
+  tileFilter->SetLayout(layout);
 
-    tileFilter->SetInput(0, reader1->GetOutput());
-    tileFilter->SetInput(1, reader2->GetOutput());
+  tileFilter->SetInput(0, reader1->GetOutput());
+  tileFilter->SetInput(1, reader2->GetOutput());
 
-    // Set the value of output pixels which are created by mismatched size input images.
-    // If the two images are the same height, this will not be used.
-    unsigned char fillerValue = 128;
-    tileFilter->SetDefaultPixelValue( fillerValue );
+  // Set the value of output pixels which are created by mismatched size input images.
+  // If the two images are the same height, this will not be used.
+  unsigned char fillerValue = 128;
+  tileFilter->SetDefaultPixelValue(fillerValue);
 
-    tileFilter->Update();
+  tileFilter->Update();
 
-    // Write the output image
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput( tileFilter->GetOutput() );
-    writer->SetFileName( outputFileName );
-    writer->Update();
+  // Write the output image
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(tileFilter->GetOutput());
+  writer->SetFileName(outputFileName);
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/UpsampleAnImage/Code.cxx
+++ b/src/Filtering/ImageGrid/UpsampleAnImage/Code.cxx
@@ -25,141 +25,137 @@
 
 #include <iostream>
 
-int main( int argc, char * argv[] )
+int
+main(int argc, char * argv[])
 {
-    if( argc != 5 )
-    {
-        std::cerr << "Usage: "
-                  << std::endl
-                  << argv[0]
-                  << " inputImageFile outputImageFile nNewWidth nNewHeight"
-                  << std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl
+              << argv[0] << " inputImageFile outputImageFile nNewWidth nNewHeight" << std::endl;
 
-        return EXIT_FAILURE;
-    }
+    return EXIT_FAILURE;
+  }
 
-    // Typedef's for pixel, image, reader and writer types
-    using T_InputPixel = unsigned char;
+  // Typedef's for pixel, image, reader and writer types
+  using T_InputPixel = unsigned char;
 
-    // Doesn't work for RGB pixels
-    //using T_OutputPixel = unsigned char;
-    //using T_InputPixel = itk::CovariantVector<unsigned char, 3>;
-    //using T_OutputPixel = itk::CovariantVector<unsigned char, 3>;
+  // Doesn't work for RGB pixels
+  // using T_OutputPixel = unsigned char;
+  // using T_InputPixel = itk::CovariantVector<unsigned char, 3>;
+  // using T_OutputPixel = itk::CovariantVector<unsigned char, 3>;
 
-    using T_Image = itk::Image<T_InputPixel, 2>;
-    using T_Reader = itk::ImageFileReader<T_Image>;
+  using T_Image = itk::Image<T_InputPixel, 2>;
+  using T_Reader = itk::ImageFileReader<T_Image>;
 
-    using T_WritePixel = unsigned char;
-    using T_WriteImage = itk::Image<T_WritePixel, 2>;
-    using T_Writer = itk::ImageFileWriter<T_WriteImage>;
+  using T_WritePixel = unsigned char;
+  using T_WriteImage = itk::Image<T_WritePixel, 2>;
+  using T_Writer = itk::ImageFileWriter<T_WriteImage>;
 
-    // Typedefs for the different (numerous!) elements of the "resampling"
+  // Typedefs for the different (numerous!) elements of the "resampling"
 
-    // Identity transform.
-    // We don't want any transform on our image except rescaling which is not
-    // specified by a transform but by the input/output spacing as we will see
-    // later.
-    // So no transform will be specified.
-    using T_Transform = itk::IdentityTransform<double, 2>;
+  // Identity transform.
+  // We don't want any transform on our image except rescaling which is not
+  // specified by a transform but by the input/output spacing as we will see
+  // later.
+  // So no transform will be specified.
+  using T_Transform = itk::IdentityTransform<double, 2>;
 
-    // If ITK resampler determines there is something to interpolate which is
-    // usually the case when upscaling (!) then we must specify the interpolation
-    // algorithm. In our case, we want bicubic interpolation. One way to implement
-    // it is with a third order b-spline. So the type is specified here and the
-    // order will be specified with a method call later on.
-    using T_Interpolator = itk::BSplineInterpolateImageFunction<T_Image, double, double>;
+  // If ITK resampler determines there is something to interpolate which is
+  // usually the case when upscaling (!) then we must specify the interpolation
+  // algorithm. In our case, we want bicubic interpolation. One way to implement
+  // it is with a third order b-spline. So the type is specified here and the
+  // order will be specified with a method call later on.
+  using T_Interpolator = itk::BSplineInterpolateImageFunction<T_Image, double, double>;
 
-    // The resampler type itself.
-    using T_ResampleFilter = itk::ResampleImageFilter<T_Image, T_Image>;
+  // The resampler type itself.
+  using T_ResampleFilter = itk::ResampleImageFilter<T_Image, T_Image>;
 
 
-    // Prepare the reader and update it right away to know the sizes beforehand.
+  // Prepare the reader and update it right away to know the sizes beforehand.
 
-    T_Reader::Pointer pReader = T_Reader::New();
-    pReader->SetFileName( argv[1] );
-    pReader->Update();
+  T_Reader::Pointer pReader = T_Reader::New();
+  pReader->SetFileName(argv[1]);
+  pReader->Update();
 
-    // Prepare the resampler.
+  // Prepare the resampler.
 
-    // Instantiate the transform and specify it should be the id transform.
-    T_Transform::Pointer _pTransform = T_Transform::New();
-    _pTransform->SetIdentity();
+  // Instantiate the transform and specify it should be the id transform.
+  T_Transform::Pointer _pTransform = T_Transform::New();
+  _pTransform->SetIdentity();
 
-    // Instantiate the b-spline interpolator and set it as the third order
-    // for bicubic.
-    T_Interpolator::Pointer _pInterpolator = T_Interpolator::New();
-    _pInterpolator->SetSplineOrder(3);
+  // Instantiate the b-spline interpolator and set it as the third order
+  // for bicubic.
+  T_Interpolator::Pointer _pInterpolator = T_Interpolator::New();
+  _pInterpolator->SetSplineOrder(3);
 
-    // Instantiate the resampler. Wire in the transform and the interpolator.
-    T_ResampleFilter::Pointer _pResizeFilter = T_ResampleFilter::New();
-    _pResizeFilter->SetTransform(_pTransform);
-    _pResizeFilter->SetInterpolator(_pInterpolator);
+  // Instantiate the resampler. Wire in the transform and the interpolator.
+  T_ResampleFilter::Pointer _pResizeFilter = T_ResampleFilter::New();
+  _pResizeFilter->SetTransform(_pTransform);
+  _pResizeFilter->SetInterpolator(_pInterpolator);
 
-    // Set the output origin. You may shift the original image "inside" the
-    // new image size by specifying something else than 0.0, 0.0 here.
+  // Set the output origin. You may shift the original image "inside" the
+  // new image size by specifying something else than 0.0, 0.0 here.
 
-    const double vfOutputOrigin[2]  = { 0.0, 0.0 };
-    _pResizeFilter->SetOutputOrigin(vfOutputOrigin);
+  const double vfOutputOrigin[2] = { 0.0, 0.0 };
+  _pResizeFilter->SetOutputOrigin(vfOutputOrigin);
 
-    //     Compute and set the output spacing
-    //     Compute the output spacing from input spacing and old and new sizes.
-    //
-    //     The computation must be so that the following holds:
-    //
-    //     new width         old x spacing
-    //     ----------   =   ---------------
-    //     old width         new x spacing
-    //
-    //
-    //     new height         old y spacing
-    //    ------------  =   ---------------
-    //     old height         new y spacing
-    //
-    //     So either we specify new height and width and compute new spacings (as
-    //     we do here) or we specify new spacing and compute new height and width
-    //     and computations that follows need to be modified a little (as it is
-    //     done at step 2 there:
-    //       http://itk.org/Wiki/ITK/Examples/DICOM/ResampleDICOM)
-    //
-    unsigned int nNewWidth = std::stoi(argv[3]);
-    unsigned int nNewHeight = std::stoi(argv[4]);
+  //     Compute and set the output spacing
+  //     Compute the output spacing from input spacing and old and new sizes.
+  //
+  //     The computation must be so that the following holds:
+  //
+  //     new width         old x spacing
+  //     ----------   =   ---------------
+  //     old width         new x spacing
+  //
+  //
+  //     new height         old y spacing
+  //    ------------  =   ---------------
+  //     old height         new y spacing
+  //
+  //     So either we specify new height and width and compute new spacings (as
+  //     we do here) or we specify new spacing and compute new height and width
+  //     and computations that follows need to be modified a little (as it is
+  //     done at step 2 there:
+  //       http://itk.org/Wiki/ITK/Examples/DICOM/ResampleDICOM)
+  //
+  unsigned int nNewWidth = std::stoi(argv[3]);
+  unsigned int nNewHeight = std::stoi(argv[4]);
 
-    // Fetch original image size.
-    const T_Image::RegionType& inputRegion =
-            pReader->GetOutput()->GetLargestPossibleRegion();
-    const T_Image::SizeType& vnInputSize = inputRegion.GetSize();
-    unsigned int nOldWidth = vnInputSize[0];
-    unsigned int nOldHeight = vnInputSize[1];
+  // Fetch original image size.
+  const T_Image::RegionType & inputRegion = pReader->GetOutput()->GetLargestPossibleRegion();
+  const T_Image::SizeType &   vnInputSize = inputRegion.GetSize();
+  unsigned int                nOldWidth = vnInputSize[0];
+  unsigned int                nOldHeight = vnInputSize[1];
 
-    // Fetch original image spacing.
-    const T_Image::SpacingType& vfInputSpacing =
-            pReader->GetOutput()->GetSpacing();
-    // Will be {1.0, 1.0} in the usual
-    // case.
+  // Fetch original image spacing.
+  const T_Image::SpacingType & vfInputSpacing = pReader->GetOutput()->GetSpacing();
+  // Will be {1.0, 1.0} in the usual
+  // case.
 
-    double vfOutputSpacing[2];
-    vfOutputSpacing[0] = vfInputSpacing[0] * (double) nOldWidth / (double) nNewWidth;
-    vfOutputSpacing[1] = vfInputSpacing[1] * (double) nOldHeight / (double) nNewHeight;
+  double vfOutputSpacing[2];
+  vfOutputSpacing[0] = vfInputSpacing[0] * (double)nOldWidth / (double)nNewWidth;
+  vfOutputSpacing[1] = vfInputSpacing[1] * (double)nOldHeight / (double)nNewHeight;
 
-    // Set the output spacing. If you comment out the following line, the original
-    // image will be simply put in the upper left corner of the new image without
-    // any scaling.
-    _pResizeFilter->SetOutputSpacing(vfOutputSpacing);
+  // Set the output spacing. If you comment out the following line, the original
+  // image will be simply put in the upper left corner of the new image without
+  // any scaling.
+  _pResizeFilter->SetOutputSpacing(vfOutputSpacing);
 
-    // Set the output size as specified on the command line.
+  // Set the output size as specified on the command line.
 
-    itk::Size<2> vnOutputSize = { {nNewWidth, nNewHeight} };
-    _pResizeFilter->SetSize(vnOutputSize);
+  itk::Size<2> vnOutputSize = { { nNewWidth, nNewHeight } };
+  _pResizeFilter->SetSize(vnOutputSize);
 
-    // Specify the input.
+  // Specify the input.
 
-    _pResizeFilter->SetInput(pReader->GetOutput());
+  _pResizeFilter->SetInput(pReader->GetOutput());
 
-    // Write the result
-    T_Writer::Pointer pWriter = T_Writer::New();
-    pWriter->SetFileName(argv[2]);
-    pWriter->SetInput(_pResizeFilter->GetOutput());
-    pWriter->Update();
+  // Write the result
+  T_Writer::Pointer pWriter = T_Writer::New();
+  pWriter->SetFileName(argv[2]);
+  pWriter->SetInput(_pResizeFilter->GetOutput());
+  pWriter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/UpsampleOrDownsampleScalarImage/Code.cxx
+++ b/src/Filtering/ImageGrid/UpsampleOrDownsampleScalarImage/Code.cxx
@@ -21,78 +21,80 @@
 #include "itkResampleImageFilter.h"
 #include "itkIdentityTransform.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <size X> <size Y>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
 
   ImageType::SizeType outputSize;
 
-  for( unsigned int dim = 0, k = 3; dim < Dimension; dim++ )
-    {
-    outputSize[dim] = std::stoi( argv[k++] );
-    }
+  for (unsigned int dim = 0, k = 3; dim < Dimension; dim++)
+  {
+    outputSize[dim] = std::stoi(argv[k++]);
+  }
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
   reader->UpdateOutputInformation();
 
   ImageType::Pointer inputImage = reader->GetOutput();
 
-  ImageType::SizeType     inputSize     = inputImage->GetLargestPossibleRegion().GetSize();
+  ImageType::SizeType inputSize = inputImage->GetLargestPossibleRegion().GetSize();
   std::cout << "Input Size: " << inputSize << std::endl;
 
-  ImageType::SpacingType  inputSpacing  = inputImage->GetSpacing();
+  ImageType::SpacingType inputSpacing = inputImage->GetSpacing();
   std::cout << "Input Spacing: " << inputSpacing << std::endl;
 
-  ImageType::SpacingType  outputSpacing;
+  ImageType::SpacingType outputSpacing;
 
-  for( unsigned int dim = 0; dim < Dimension; dim++ )
-    {
-    outputSpacing[dim] = static_cast< double >( inputSpacing[dim] ) * static_cast< double >( inputSize[dim] ) / static_cast< double >( outputSize[dim] );
-    }
+  for (unsigned int dim = 0; dim < Dimension; dim++)
+  {
+    outputSpacing[dim] = static_cast<double>(inputSpacing[dim]) * static_cast<double>(inputSize[dim]) /
+                         static_cast<double>(outputSize[dim]);
+  }
 
   std::cout << "Output Size: " << outputSize << std::endl;
   std::cout << "Output Spacing: " << outputSpacing << std::endl;
 
   using TransformPrecisionType = double;
-  using TransformType = itk::IdentityTransform< TransformPrecisionType, Dimension >;
-  using FilterType = itk::ResampleImageFilter< ImageType, ImageType >;
+  using TransformType = itk::IdentityTransform<TransformPrecisionType, Dimension>;
+  using FilterType = itk::ResampleImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( inputImage );
-  filter->SetSize( outputSize );
-  filter->SetOutputSpacing( outputSpacing );
-  filter->SetOutputOrigin( inputImage->GetOrigin() );
-  filter->SetTransform( TransformType::New() );
+  filter->SetInput(inputImage);
+  filter->SetSize(outputSize);
+  filter->SetOutputSpacing(outputSpacing);
+  filter->SetOutputOrigin(inputImage->GetOrigin());
+  filter->SetTransform(TransformType::New());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/Code.cxx
+++ b/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/Code.cxx
@@ -22,16 +22,14 @@
 #include "itkVector.h"
 #include "itkWarpImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 4)
-    {
-    std::cerr << "Usage: \n"
-              << argv[0]
-              << "<InputFileName> <DisplacementFieldFileName> <OutputFileName>"
-              << std::endl;
+  if (argc < 4)
+  {
+    std::cerr << "Usage: \n" << argv[0] << "<InputFileName> <DisplacementFieldFileName> <OutputFileName>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * displacementFieldFileName = argv[2];
@@ -40,58 +38,58 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using VectorComponentType = float;
-  using VectorPixelType = itk::Vector< VectorComponentType, Dimension >;
+  using VectorPixelType = itk::Vector<VectorComponentType, Dimension>;
 
-  using DisplacementFieldType = itk::Image< VectorPixelType, Dimension >;
+  using DisplacementFieldType = itk::Image<VectorPixelType, Dimension>;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
-  using FieldReaderType = itk::ImageFileReader< DisplacementFieldType >;
+  using FieldReaderType = itk::ImageFileReader<DisplacementFieldType>;
 
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   FieldReaderType::Pointer fieldReader = FieldReaderType::New();
-  fieldReader->SetFileName( displacementFieldFileName );
+  fieldReader->SetFileName(displacementFieldFileName);
   fieldReader->Update();
 
   DisplacementFieldType::ConstPointer deformationField = fieldReader->GetOutput();
 
-  using FilterType = itk::WarpImageFilter< ImageType, ImageType, DisplacementFieldType >;
+  using FilterType = itk::WarpImageFilter<ImageType, ImageType, DisplacementFieldType>;
 
   FilterType::Pointer filter = FilterType::New();
 
-  using InterpolatorType = itk::LinearInterpolateImageFunction< ImageType, double >;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double>;
 
   InterpolatorType::Pointer interpolator = InterpolatorType::New();
 
-  filter->SetInterpolator( interpolator );
+  filter->SetInterpolator(interpolator);
 
-  filter->SetOutputSpacing( deformationField->GetSpacing() );
-  filter->SetOutputOrigin( deformationField->GetOrigin() );
-  filter->SetOutputDirection( deformationField->GetDirection() );
+  filter->SetOutputSpacing(deformationField->GetSpacing());
+  filter->SetOutputOrigin(deformationField->GetOrigin());
+  filter->SetOutputDirection(deformationField->GetDirection());
 
-  filter->SetDisplacementField( deformationField );
+  filter->SetDisplacementField(deformationField);
 
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( filter->GetOutput() );
-  writer->SetFileName( outputFileName );
+  writer->SetInput(filter->GetOutput());
+  writer->SetFileName(outputFileName);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/AbsValueOfImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/AbsValueOfImage/Code.cxx
@@ -21,60 +21,60 @@
 #include "itkAbsImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage(FloatImageType::Pointer image);
+static void
+CreateImage(FloatImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    FloatImageType::Pointer image = FloatImageType::New();
-    CreateImage(image);
+  FloatImageType::Pointer image = FloatImageType::New();
+  CreateImage(image);
 
-    // Take the absolute value of the image
-    using AbsImageFilterType = itk::AbsImageFilter <FloatImageType, FloatImageType>;
+  // Take the absolute value of the image
+  using AbsImageFilterType = itk::AbsImageFilter<FloatImageType, FloatImageType>;
 
-    AbsImageFilterType::Pointer absFilter
-            = AbsImageFilterType::New ();
-    absFilter->SetInput(image);
+  AbsImageFilterType::Pointer absFilter = AbsImageFilterType::New();
+  absFilter->SetInput(image);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage<FloatImageType>(image);
-    viewer.AddImage<FloatImageType>(absFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage<FloatImageType>(image);
+  viewer.AddImage<FloatImageType>(absFilter->GetOutput());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(FloatImageType::Pointer image)
+void
+CreateImage(FloatImageType::Pointer image)
 {
-    // Create an image with negative values
-    FloatImageType::RegionType region;
-    FloatImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with negative values
+  FloatImageType::RegionType region;
+  FloatImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    FloatImageType::SizeType size;
-    size[0] = 200;
-    size[1] = 300;
+  FloatImageType::SizeType size;
+  size[0] = 200;
+  size[1] = 300;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<FloatImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<FloatImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(imageIterator.GetIndex()[0] - imageIterator.GetIndex()[1]);
-        ++imageIterator;
-    }
-
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(imageIterator.GetIndex()[0] - imageIterator.GetIndex()[1]);
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/AddConstantToEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/AddConstantToEveryPixel/Code.cxx
@@ -20,57 +20,59 @@
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using AddImageFilterType = itk::AddImageFilter <ImageType, ImageType, ImageType>;
-    AddImageFilterType::Pointer addImageFilter = AddImageFilterType::New();
-    addImageFilter->SetInput(image);
-    addImageFilter->SetConstant2(2);
-    addImageFilter->Update();
+  using AddImageFilterType = itk::AddImageFilter<ImageType, ImageType, ImageType>;
+  AddImageFilterType::Pointer addImageFilter = AddImageFilterType::New();
+  addImageFilter->SetInput(image);
+  addImageFilter->SetConstant2(2);
+  addImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(addImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(addImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 70)
     {
-        if(imageIterator.GetIndex()[0] < 70)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }

--- a/src/Filtering/ImageIntensity/AddTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/AddTwoImages/Code.cxx
@@ -32,183 +32,178 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage1(ImageType::Pointer image);
-static void CreateImage2(ImageType::Pointer image);
+static void
+CreateImage1(ImageType::Pointer image);
+static void
+CreateImage2(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1);
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2);
 
-    using AddImageFilterType = itk::AddImageFilter <ImageType, ImageType >;
+  using AddImageFilterType = itk::AddImageFilter<ImageType, ImageType>;
 
-    AddImageFilterType::Pointer addFilter
-            = AddImageFilterType::New ();
-    addFilter->SetInput1(image1);
-    addFilter->SetInput2(image2);
-    addFilter->Update();
+  AddImageFilterType::Pointer addFilter = AddImageFilterType::New();
+  addFilter->SetInput1(image1);
+  addFilter->SetInput2(image2);
+  addFilter->Update();
 
-    // Visualize first image
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector1 = ConnectorType::New();
-    connector1->SetInput(image1);
+  // Visualize first image
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector1 = ConnectorType::New();
+  connector1->SetInput(image1);
 
-    vtkSmartPointer<vtkImageActor> actor1 =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor1 = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor1->SetInput(connector1->GetOutput());
+  actor1->SetInput(connector1->GetOutput());
 #else
-    connector1->Update();
+  connector1->Update();
   actor1->GetMapper()->SetInputData(connector1->GetOutput());
 #endif
-    // Visualize first image
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector2 = ConnectorType::New();
-    connector2->SetInput(image2);
+  // Visualize first image
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector2 = ConnectorType::New();
+  connector2->SetInput(image2);
 
-    vtkSmartPointer<vtkImageActor> actor2 =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor2 = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor2->SetInput(connector2->GetOutput());
+  actor2->SetInput(connector2->GetOutput());
 #else
-    connector2->Update();
+  connector2->Update();
   actor2->GetMapper()->SetInputData(connector2->GetOutput());
 #endif
 
-    // Visualize joined image
-    ConnectorType::Pointer addConnector = ConnectorType::New();
-    addConnector->SetInput(addFilter->GetOutput());
+  // Visualize joined image
+  ConnectorType::Pointer addConnector = ConnectorType::New();
+  addConnector->SetInput(addFilter->GetOutput());
 
-    vtkSmartPointer<vtkImageActor> addActor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> addActor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    addActor->SetInput(addConnector->GetOutput());
+  addActor->SetInput(addConnector->GetOutput());
 #else
-    addConnector->Update();
+  addConnector->Update();
   addActor->GetMapper()->SetInputData(addConnector->GetOutput());
 #endif
-    // There will be one render window
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
-    renderWindow->SetSize(900, 300);
+  // There will be one render window
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+  renderWindow->SetSize(900, 300);
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    // Define viewport ranges
-    // (xmin, ymin, xmax, ymax)
-    double leftViewport[4] = {0.0, 0.0, 0.33, 1.0};
-    double centerViewport[4] = {0.33, 0.0, 0.66, 1.0};
-    double rightViewport[4] = {0.66, 0.0, 1.0, 1.0};
+  // Define viewport ranges
+  // (xmin, ymin, xmax, ymax)
+  double leftViewport[4] = { 0.0, 0.0, 0.33, 1.0 };
+  double centerViewport[4] = { 0.33, 0.0, 0.66, 1.0 };
+  double rightViewport[4] = { 0.66, 0.0, 1.0, 1.0 };
 
-    // Setup both renderers
-    vtkSmartPointer<vtkRenderer> leftRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(leftRenderer);
-    leftRenderer->SetViewport(leftViewport);
-    leftRenderer->SetBackground(.6, .5, .4);
+  // Setup both renderers
+  vtkSmartPointer<vtkRenderer> leftRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(leftRenderer);
+  leftRenderer->SetViewport(leftViewport);
+  leftRenderer->SetBackground(.6, .5, .4);
 
-    vtkSmartPointer<vtkRenderer> centerRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(centerRenderer);
-    centerRenderer->SetViewport(centerViewport);
-    centerRenderer->SetBackground(.4, .5, .6);
+  vtkSmartPointer<vtkRenderer> centerRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(centerRenderer);
+  centerRenderer->SetViewport(centerViewport);
+  centerRenderer->SetBackground(.4, .5, .6);
 
-    vtkSmartPointer<vtkRenderer> rightRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(rightRenderer);
-    rightRenderer->SetViewport(rightViewport);
-    rightRenderer->SetBackground(.4, .5, .6);
+  vtkSmartPointer<vtkRenderer> rightRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(rightRenderer);
+  rightRenderer->SetViewport(rightViewport);
+  rightRenderer->SetBackground(.4, .5, .6);
 
-    // Add the sphere to the left and the cube to the right
-    leftRenderer->AddActor(actor1);
-    centerRenderer->AddActor(actor2);
-    rightRenderer->AddActor(addActor);
+  // Add the sphere to the left and the cube to the right
+  leftRenderer->AddActor(actor1);
+  centerRenderer->AddActor(actor2);
+  rightRenderer->AddActor(addActor);
 
-    leftRenderer->ResetCamera();
-    centerRenderer->ResetCamera();
-    rightRenderer->ResetCamera();
+  leftRenderer->ResetCamera();
+  centerRenderer->ResetCamera();
+  rightRenderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
-    interactor->SetInteractorStyle(style);
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType::Pointer image)
+void
+CreateImage1(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 20; c < 80; c++)
     {
-        for(unsigned int c = 20; c < 80; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }
 
 
-void CreateImage2(ImageType::Pointer image)
+void
+CreateImage2(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make another square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make another square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }

--- a/src/Filtering/ImageIntensity/ApplyAtanImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyAtanImageFilter/Code.cxx
@@ -21,53 +21,53 @@
 #include "itkImageFileWriter.h"
 #include "itkAtanImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using InputPixelType = unsigned char;
 
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   InputImageType::SizeType size;
-  size.Fill( 100 );
+  size.Fill(100);
 
-  using RandomImageSourceType = itk::RandomImageSource< InputImageType >;
+  using RandomImageSourceType = itk::RandomImageSource<InputImageType>;
 
-  RandomImageSourceType::Pointer randomImageSource =
-    RandomImageSourceType::New();
+  RandomImageSourceType::Pointer randomImageSource = RandomImageSourceType::New();
   randomImageSource->SetNumberOfWorkUnits(1); // to produce non-random results
   randomImageSource->SetSize(size);
 
   using OutputPixelType = float;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using FilterType = itk::AtanImageFilter< InputImageType, OutputImageType >;
+  using FilterType = itk::AtanImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( randomImageSource->GetOutput() );
+  filter->SetInput(randomImageSource->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[1] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[1]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/ApplyCosImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyCosImageFilter/Code.cxx
@@ -21,11 +21,12 @@
 #include "itkImageFileWriter.h"
 #include "itkCosImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << " <OutputFileName>";
@@ -38,30 +39,30 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = float;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::CosImageFilter< ImageType, ImageType >;
+  using FilterType = itk::CosImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/Code.cxx
@@ -20,47 +20,48 @@
 #include "itkImageFileWriter.h"
 #include "itkExpNegativeImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-   if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <K: ExpNegative parameter>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const double k = std::stod( argv[3] );
+  const double k = std::stod(argv[3]);
 
   constexpr unsigned int Dimension = 2;
   using PixelType = float;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::ExpNegativeImageFilter< ImageType, ImageType >;
+  using FilterType = itk::ExpNegativeImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetFactor( k );
+  filter->SetInput(reader->GetOutput());
+  filter->SetFactor(k);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/ApplySinImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplySinImageFilter/Code.cxx
@@ -21,47 +21,48 @@
 #include "itkImageFileWriter.h"
 #include "itkSinImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << " <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = float;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::SinImageFilter< ImageType, ImageType >;
+  using FilterType = itk::SinImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/BinaryANDTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryANDTwoImages/Code.cxx
@@ -22,105 +22,106 @@
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage1(ImageType::Pointer image);
-static void CreateImage2(ImageType::Pointer image);
+static void
+CreateImage1(ImageType::Pointer image);
+static void
+CreateImage2(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1);
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input1.png");
-    writer->SetInput(image1);
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input1.png");
+  writer->SetInput(image1);
+  writer->Update();
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2);
 
-    writer->SetFileName("input2.png");
-    writer->SetInput(image2);
-    writer->Update();
+  writer->SetFileName("input2.png");
+  writer->SetInput(image2);
+  writer->Update();
 
-    using AndImageFilterType = itk::AndImageFilter <ImageType>;
+  using AndImageFilterType = itk::AndImageFilter<ImageType>;
 
-    AndImageFilterType::Pointer andFilter
-            = AndImageFilterType::New();
-    andFilter->SetInput(0, image1);
-    andFilter->SetInput(1, image2);
-    andFilter->Update();
+  AndImageFilterType::Pointer andFilter = AndImageFilterType::New();
+  andFilter->SetInput(0, image1);
+  andFilter->SetInput(1, image2);
+  andFilter->Update();
 
-    writer->SetFileName("output.png");
-    writer->SetInput(andFilter->GetOutput());
-    writer->Update();
+  writer->SetFileName("output.png");
+  writer->SetInput(andFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType::Pointer image)
+void
+CreateImage1(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 70)
     {
-        if(imageIterator.GetIndex()[0] < 70)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
 
-void CreateImage2(ImageType::Pointer image)
+void
+CreateImage2(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 30)
     {
-        if(imageIterator.GetIndex()[0] > 30)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/BinaryORTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryORTwoImages/Code.cxx
@@ -22,15 +22,18 @@
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage1(ImageType::Pointer image);
-static void CreateImage2(ImageType::Pointer image);
+static void
+CreateImage1(ImageType::Pointer image);
+static void
+CreateImage2(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);
 
-  using WriterType = itk::ImageFileWriter< ImageType  >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName("input1.png");
   writer->SetInput(image1);
@@ -43,7 +46,7 @@ int main(int, char *[])
   writer->SetInput(image2);
   writer->Update();
 
-  using OrImageFilterType = itk::OrImageFilter <ImageType>;
+  using OrImageFilterType = itk::OrImageFilter<ImageType>;
   OrImageFilterType::Pointer orFilter = OrImageFilterType::New();
   orFilter->SetInput(0, image1);
   orFilter->SetInput(1, image2);
@@ -56,7 +59,8 @@ int main(int, char *[])
   return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType::Pointer image)
+void
+CreateImage1(ImageType::Pointer image)
 {
   ImageType::IndexType start;
   start.Fill(0);
@@ -71,25 +75,25 @@ void CreateImage1(ImageType::Pointer image)
   image->SetRegions(region);
   image->Allocate();
 
-  itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-  while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 70)
     {
-    if(imageIterator.GetIndex()[0] < 70)
-      {
       imageIterator.Set(255);
-      }
+    }
     else
-      {
+    {
       imageIterator.Set(0);
-      }
-
-    ++imageIterator;
     }
 
+    ++imageIterator;
+  }
 }
 
-void CreateImage2(ImageType::Pointer image)
+void
+CreateImage2(ImageType::Pointer image)
 {
   ImageType::IndexType start;
   start.Fill(0);
@@ -104,21 +108,19 @@ void CreateImage2(ImageType::Pointer image)
   image->SetRegions(region);
   image->Allocate();
 
-  itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-  while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 30)
     {
-    if(imageIterator.GetIndex()[0] > 30)
-      {
       imageIterator.Set(255);
-      }
+    }
     else
-      {
+    {
       imageIterator.Set(0);
-      }
-
-    ++imageIterator;
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/BinaryXORTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryXORTwoImages/Code.cxx
@@ -22,95 +22,97 @@
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage1(ImageType::Pointer image);
-static void CreateImage2(ImageType::Pointer image);
+static void
+CreateImage1(ImageType::Pointer image);
+static void
+CreateImage2(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1);
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2);
 
-    using XorImageFilterType = itk::XorImageFilter <ImageType>;
-    XorImageFilterType::Pointer xorFilter = XorImageFilterType::New();
-    xorFilter->SetInput1(image1);
-    xorFilter->SetInput2(image2);
-    xorFilter->Update();
+  using XorImageFilterType = itk::XorImageFilter<ImageType>;
+  XorImageFilterType::Pointer xorFilter = XorImageFilterType::New();
+  xorFilter->SetInput1(image1);
+  xorFilter->SetInput2(image2);
+  xorFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(xorFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(xorFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType::Pointer image)
+void
+CreateImage1(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 70)
     {
-        if(imageIterator.GetIndex()[0] < 70)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
 
-void CreateImage2(ImageType::Pointer image)
+void
+CreateImage2(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 30)
     {
-        if(imageIterator.GetIndex()[0] > 30)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/Code.cxx
+++ b/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/Code.cxx
@@ -22,28 +22,30 @@
 using FloatImageType = itk::Image<float, 2>;
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(FloatImageType* const image);
+static void
+CreateImage(FloatImageType * const image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
   FloatImageType::Pointer image;
 
   // No input image argument provided
-  if(argc < 2)
-    {
+  if (argc < 2)
+  {
     image = FloatImageType::New();
     CreateImage(image);
-    }
+  }
   else // Input image argument provided
-    {
+  {
     using ReaderType = itk::ImageFileReader<FloatImageType>;
     ReaderType::Pointer reader = ReaderType::New();
     reader->SetFileName(argv[1]);
     reader->Update();
     image = reader->GetOutput();
-    }
+  }
 
-  using ClampFilterType = itk::ClampImageFilter< FloatImageType, UnsignedCharImageType >;
+  using ClampFilterType = itk::ClampImageFilter<FloatImageType, UnsignedCharImageType>;
   ClampFilterType::Pointer clampFilter = ClampFilterType::New();
   clampFilter->SetInput(image);
   clampFilter->Update();
@@ -51,14 +53,15 @@ int main(int argc, char *argv[])
   return EXIT_SUCCESS;
 }
 
-void CreateImage(FloatImageType* const image)
+void
+CreateImage(FloatImageType * const image)
 {
   // Create an image with 2 connected components
-  FloatImageType::IndexType corner = {{0,0}};
+  FloatImageType::IndexType corner = { { 0, 0 } };
 
   FloatImageType::SizeType size;
-  unsigned int NumRows = 200;
-  unsigned int NumCols = 300;
+  unsigned int             NumRows = 200;
+  unsigned int             NumCols = 300;
   size[0] = NumRows;
   size[1] = NumCols;
 
@@ -68,15 +71,15 @@ void CreateImage(FloatImageType* const image)
   image->Allocate();
 
   // Make a square
-  for(unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-    for(unsigned int c = 40; c < 100; c++)
-      {
       FloatImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
       pixelIndex[1] = c;
 
       image->SetPixel(pixelIndex, 15);
-      }
     }
+  }
 }

--- a/src/Filtering/ImageIntensity/ComputeEdgePotential/Code.cxx
+++ b/src/Filtering/ImageIntensity/ComputeEdgePotential/Code.cxx
@@ -23,79 +23,77 @@
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
+using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int  /*argc*/, char *  /*argv*/[])
+int
+main(int /*argc*/, char * /*argv*/[])
 {
-    // Setup types
-    using FloatImageType = itk::Image< float,  2 >;
-    using VectorImageType = itk::Image< itk::CovariantVector<float, 2>, 2 >;
+  // Setup types
+  using FloatImageType = itk::Image<float, 2>;
+  using VectorImageType = itk::Image<itk::CovariantVector<float, 2>, 2>;
 
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    CreateImage(image);
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  CreateImage(image);
 
-    // Create and setup a gradient filter
-    using GradientFilterType = itk::GradientImageFilter<
-            UnsignedCharImageType, float>;
-    GradientFilterType::Pointer gradientFilter = GradientFilterType::New();
-    gradientFilter->SetInput(image);
-    gradientFilter->Update();
+  // Create and setup a gradient filter
+  using GradientFilterType = itk::GradientImageFilter<UnsignedCharImageType, float>;
+  GradientFilterType::Pointer gradientFilter = GradientFilterType::New();
+  gradientFilter->SetInput(image);
+  gradientFilter->Update();
 
-    // Create and setup an edge potential filter
-    using EdgePotentialImageFilterType = itk::EdgePotentialImageFilter<
-            VectorImageType, FloatImageType>;
-    EdgePotentialImageFilterType::Pointer edgePotentialImageFilter = EdgePotentialImageFilterType::New();
-    edgePotentialImageFilter->SetInput( gradientFilter->GetOutput() );
-    edgePotentialImageFilter->Update();
+  // Create and setup an edge potential filter
+  using EdgePotentialImageFilterType = itk::EdgePotentialImageFilter<VectorImageType, FloatImageType>;
+  EdgePotentialImageFilterType::Pointer edgePotentialImageFilter = EdgePotentialImageFilterType::New();
+  edgePotentialImageFilter->SetInput(gradientFilter->GetOutput());
+  edgePotentialImageFilter->Update();
 
-    // Scale so we can write to a PNG
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< FloatImageType, UnsignedCharImageType >;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(edgePotentialImageFilter->GetOutput());
-    rescaleFilter->SetOutputMinimum(0);
-    rescaleFilter->SetOutputMaximum(255);
-    rescaleFilter->Update();
+  // Scale so we can write to a PNG
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(edgePotentialImageFilter->GetOutput());
+  rescaleFilter->SetOutputMinimum(0);
+  rescaleFilter->SetOutputMaximum(255);
+  rescaleFilter->Update();
 
-    using FileWriterType = itk::ImageFileWriter<UnsignedCharImageType>;
-    FileWriterType::Pointer writer = FileWriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(rescaleFilter->GetOutput());
-    writer->Update();
+  using FileWriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  FileWriterType::Pointer writer = FileWriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(rescaleFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    // Create a black image with 2 white regions
+  // Create a black image with 2 white regions
 
-    UnsignedCharImageType::IndexType start;
-    start.Fill(0);
+  UnsignedCharImageType::IndexType start;
+  start.Fill(0);
 
-    UnsignedCharImageType::SizeType size;
-    size.Fill(200);
+  UnsignedCharImageType::SizeType size;
+  size.Fill(200);
 
-    UnsignedCharImageType::RegionType region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  UnsignedCharImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            UnsignedCharImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      UnsignedCharImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-
-        }
+      image->SetPixel(pixelIndex, 255);
     }
-
+  }
 }
-

--- a/src/Filtering/ImageIntensity/ComputeSigmoid/Code.cxx
+++ b/src/Filtering/ImageIntensity/ComputeSigmoid/Code.cxx
@@ -20,17 +20,18 @@
 #include "itkImageFileWriter.h"
 #include "itkSigmoidImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 7 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 7)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << " <OutputMin> <OutputMax> <Alpha> <Beta>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -38,40 +39,40 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
   using ScalarType = float;
 
-  const auto outputMinimum = static_cast<PixelType>(atoi( argv[3] ) );
-  const auto outputMaximum = static_cast<PixelType>(atoi( argv[4] ) );
-  const ScalarType alpha = std::stod( argv[5] );
-  const ScalarType beta  = std::stod( argv[6] );
+  const auto       outputMinimum = static_cast<PixelType>(atoi(argv[3]));
+  const auto       outputMaximum = static_cast<PixelType>(atoi(argv[4]));
+  const ScalarType alpha = std::stod(argv[5]);
+  const ScalarType beta = std::stod(argv[6]);
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::SigmoidImageFilter< ImageType, ImageType >;
+  using FilterType = itk::SigmoidImageFilter<ImageType, ImageType>;
   FilterType::Pointer sigmoidFilter = FilterType::New();
-  sigmoidFilter->SetInput( reader->GetOutput() );
-  sigmoidFilter->SetOutputMinimum( outputMinimum );
-  sigmoidFilter->SetOutputMaximum( outputMaximum );
-  sigmoidFilter->SetAlpha( alpha );
-  sigmoidFilter->SetBeta( beta );
+  sigmoidFilter->SetInput(reader->GetOutput());
+  sigmoidFilter->SetOutputMinimum(outputMinimum);
+  sigmoidFilter->SetOutputMaximum(outputMaximum);
+  sigmoidFilter->SetAlpha(alpha);
+  sigmoidFilter->SetBeta(beta);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( sigmoidFilter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(sigmoidFilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/ComputerMagInVectorImageToMakeMagImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/ComputerMagInVectorImageToMakeMagImage/Code.cxx
@@ -22,55 +22,50 @@
 #include "itkVectorImage.h"
 #include "itkVectorMagnitudeImageFilter.h"
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 3 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " inputImageFile outputImageFile" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 3)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " inputImageFile outputImageFile" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Parse command line arguments
-    std::string inputFilename = argv[1];
-    std::string outputFilename = argv[2];
+  // Parse command line arguments
+  std::string inputFilename = argv[1];
+  std::string outputFilename = argv[2];
 
-    // Setup types
-    using VectorImageType = itk::VectorImage< float,  2 >;
-    using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
+  // Setup types
+  using VectorImageType = itk::VectorImage<float, 2>;
+  using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-    // Create and setup a reader
-    using ReaderType = itk::ImageFileReader< VectorImageType >;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( inputFilename );
+  // Create and setup a reader
+  using ReaderType = itk::ImageFileReader<VectorImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename);
 
-    using WriterType = itk::ImageFileWriter< UnsignedCharImageType >;
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
 
-    using VectorMagnitudeFilterType = itk::VectorMagnitudeImageFilter<
-            VectorImageType, UnsignedCharImageType >;
-    VectorMagnitudeFilterType::Pointer magnitudeFilter =
-            VectorMagnitudeFilterType::New();
-    magnitudeFilter->SetInput( reader->GetOutput() );
+  using VectorMagnitudeFilterType = itk::VectorMagnitudeImageFilter<VectorImageType, UnsignedCharImageType>;
+  VectorMagnitudeFilterType::Pointer magnitudeFilter = VectorMagnitudeFilterType::New();
+  magnitudeFilter->SetInput(reader->GetOutput());
 
-    // To write the magnitude image file, we should rescale the gradient values
-    // to a reasonable range
-    using rescaleFilterType = itk::RescaleIntensityImageFilter<
-            UnsignedCharImageType, UnsignedCharImageType >;
+  // To write the magnitude image file, we should rescale the gradient values
+  // to a reasonable range
+  using rescaleFilterType = itk::RescaleIntensityImageFilter<UnsignedCharImageType, UnsignedCharImageType>;
 
-    rescaleFilterType::Pointer rescaler =
-            rescaleFilterType::New();
-    rescaler->SetOutputMinimum(0);
-    rescaler->SetOutputMaximum(255);
-    rescaler->SetInput( magnitudeFilter->GetOutput() );
+  rescaleFilterType::Pointer rescaler = rescaleFilterType::New();
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(255);
+  rescaler->SetInput(magnitudeFilter->GetOutput());
 
-    WriterType::Pointer writer =
-            WriterType::New();
+  WriterType::Pointer writer = WriterType::New();
 
-    writer->SetFileName( outputFilename );
-    writer->SetInput( rescaler->GetOutput() );
-    writer->Update();
+  writer->SetFileName(outputFilename);
+  writer->SetInput(rescaler->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/Code.cxx
@@ -21,48 +21,49 @@
 #include "itkImageFileWriter.h"
 #include "itkRGBToLuminanceImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using ComponentType = unsigned char;
-  using InputPixelType = itk::RGBPixel< ComponentType >;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputPixelType = itk::RGBPixel<ComponentType>;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using FilterType = itk::RGBToLuminanceImageFilter< InputImageType, OutputImageType >;
+  using FilterType = itk::RGBToLuminanceImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/Code.cxx
@@ -23,48 +23,49 @@
 using VectorImageType = itk::VectorImage<float, 2>;
 using ScalarImageType = itk::Image<float, 2>;
 
-static void CreateImage(VectorImageType::Pointer image);
+static void
+CreateImage(VectorImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    VectorImageType::Pointer image = VectorImageType::New();
-    CreateImage(image);
+  VectorImageType::Pointer image = VectorImageType::New();
+  CreateImage(image);
 
-    using IndexSelectionType = itk::VectorIndexSelectionCastImageFilter<VectorImageType, ScalarImageType>;
-    IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
-    indexSelectionFilter->SetIndex(0);
-    indexSelectionFilter->SetInput(image);
+  using IndexSelectionType = itk::VectorIndexSelectionCastImageFilter<VectorImageType, ScalarImageType>;
+  IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
+  indexSelectionFilter->SetIndex(0);
+  indexSelectionFilter->SetInput(image);
 
-    using ImageCalculatorFilterType = itk::MinimumMaximumImageCalculator <ScalarImageType>;
-    ImageCalculatorFilterType::Pointer imageCalculatorFilter = ImageCalculatorFilterType::New();
-    imageCalculatorFilter->SetImage(indexSelectionFilter->GetOutput());
-    imageCalculatorFilter->Compute();
+  using ImageCalculatorFilterType = itk::MinimumMaximumImageCalculator<ScalarImageType>;
+  ImageCalculatorFilterType::Pointer imageCalculatorFilter = ImageCalculatorFilterType::New();
+  imageCalculatorFilter->SetImage(indexSelectionFilter->GetOutput());
+  imageCalculatorFilter->Compute();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(VectorImageType::Pointer image)
+void
+CreateImage(VectorImageType::Pointer image)
 {
-    VectorImageType::IndexType start;
-    start.Fill(0);
+  VectorImageType::IndexType start;
+  start.Fill(0);
 
-    VectorImageType::SizeType size;
-    size.Fill(2);
+  VectorImageType::SizeType size;
+  size.Fill(2);
 
-    VectorImageType::RegionType region(start, size);
+  VectorImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->SetNumberOfComponentsPerPixel(3);
-    image->Allocate();
+  image->SetRegions(region);
+  image->SetNumberOfComponentsPerPixel(3);
+  image->Allocate();
 
-    using VariableVectorType = itk::VariableLengthVector<double>;
-    VariableVectorType variableLengthVector;
-    variableLengthVector.SetSize(3);
-    variableLengthVector[0] = 1.1;
-    variableLengthVector[1] = 2.2;
-    variableLengthVector[2] = 3.3;
+  using VariableVectorType = itk::VariableLengthVector<double>;
+  VariableVectorType variableLengthVector;
+  variableLengthVector.SetSize(3);
+  variableLengthVector[0] = 1.1;
+  variableLengthVector[1] = 2.2;
+  variableLengthVector[2] = 3.3;
 
-    image->FillBuffer(variableLengthVector);
-
+  image->FillBuffer(variableLengthVector);
 }
-

--- a/src/Filtering/ImageIntensity/IntensityWindowing/Code.cxx
+++ b/src/Filtering/ImageIntensity/IntensityWindowing/Code.cxx
@@ -22,57 +22,58 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using IntensityWindowingImageFilterType = itk::IntensityWindowingImageFilter <ImageType, ImageType>;
+  using IntensityWindowingImageFilterType = itk::IntensityWindowingImageFilter<ImageType, ImageType>;
 
-    IntensityWindowingImageFilterType::Pointer filter = IntensityWindowingImageFilterType::New();
-    filter->SetInput(image);
-    filter->SetWindowMinimum(0);
-    filter->SetWindowMaximum(100);
-    filter->SetOutputMinimum(0);
-    filter->SetOutputMaximum(255);
-    filter->Update();
+  IntensityWindowingImageFilterType::Pointer filter = IntensityWindowingImageFilterType::New();
+  filter->SetInput(image);
+  filter->SetWindowMinimum(0);
+  filter->SetWindowMaximum(100);
+  filter->SetOutputMinimum(0);
+  filter->SetOutputMaximum(255);
+  filter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(image);
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(image);
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(10);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(10);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 30)
     {
-        if(imageIterator.GetIndex()[0] > 30)
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/InverseOfMaskToImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/InverseOfMaskToImage/Code.cxx
@@ -21,72 +21,77 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateHalfMask(ImageType::Pointer image, ImageType::Pointer mask);
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateHalfMask(ImageType::Pointer image, ImageType::Pointer mask);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    ImageType::Pointer mask = ImageType::New();
-    CreateHalfMask(image, mask);
+  ImageType::Pointer mask = ImageType::New();
+  CreateHalfMask(image, mask);
 
-    using MaskNegatedImageFilterType = itk::MaskNegatedImageFilter< ImageType, ImageType >;
-    MaskNegatedImageFilterType::Pointer maskNegatedImageFilter = MaskNegatedImageFilterType::New();
-    maskNegatedImageFilter->SetInput(image);
-    maskNegatedImageFilter->SetMaskImage(mask);
-    maskNegatedImageFilter->Update();;
+  using MaskNegatedImageFilterType = itk::MaskNegatedImageFilter<ImageType, ImageType>;
+  MaskNegatedImageFilterType::Pointer maskNegatedImageFilter = MaskNegatedImageFilterType::New();
+  maskNegatedImageFilter->SetInput(image);
+  maskNegatedImageFilter->SetMaskImage(mask);
+  maskNegatedImageFilter->Update();
+  ;
 
-    using FileWriterType = itk::ImageFileWriter<ImageType>;
-    FileWriterType::Pointer writer = FileWriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(maskNegatedImageFilter->GetOutput());
-    writer->Update();
+  using FileWriterType = itk::ImageFileWriter<ImageType>;
+  FileWriterType::Pointer writer = FileWriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(maskNegatedImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateHalfMask(ImageType::Pointer image, ImageType::Pointer mask)
+void
+CreateHalfMask(ImageType::Pointer image, ImageType::Pointer mask)
 {
-    ImageType::RegionType region = image->GetLargestPossibleRegion();
+  ImageType::RegionType region = image->GetLargestPossibleRegion();
 
-    mask->SetRegions(region);
-    mask->Allocate();
+  mask->SetRegions(region);
+  mask->Allocate();
 
-    ImageType::SizeType regionSize = region.GetSize();
+  ImageType::SizeType regionSize = region.GetSize();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(mask,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(mask, region);
 
-    // Make the left half of the mask white and the right half black
-    while(!imageIterator.IsAtEnd())
+  // Make the left half of the mask white and the right half black
+  while (!imageIterator.IsAtEnd())
+  {
+    if (static_cast<unsigned int>(imageIterator.GetIndex()[0]) > regionSize[0] / 2)
     {
-        if(static_cast<unsigned int>(imageIterator.GetIndex()[0]) > regionSize[0] / 2)
-        {
-            imageIterator.Set(0);
-        }
-        else
-        {
-            imageIterator.Set(1);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(0);
+    }
+    else
+    {
+      imageIterator.Set(1);
     }
 
+    ++imageIterator;
+  }
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(122);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(122);
 }

--- a/src/Filtering/ImageIntensity/InvertImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/InvertImage/Code.cxx
@@ -20,98 +20,93 @@
 #include "itkImageFileReader.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image = ImageType::New();
-    std::stringstream desc;
+  ImageType::Pointer image = ImageType::New();
+  std::stringstream  desc;
 
+  CreateImage(image);
+
+  unsigned int maximum = 255;
+  if (argc > 1)
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+    image = reader->GetOutput();
+    desc << itksys::SystemTools::GetFilenameName(argv[1]);
+    if (argc > 2)
+    {
+      maximum = std::stoi(argv[2]);
+    }
+  }
+  else
+  {
     CreateImage(image);
+    desc << "Synthetic image";
+    maximum = 50;
+  }
 
-    unsigned int maximum = 255;
-    if (argc > 1)
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName( argv[1] );
-        reader->Update();
-        image = reader->GetOutput();
-        desc << itksys::SystemTools::GetFilenameName(argv[1]);
-        if (argc > 2)
-        {
-            maximum = std::stoi(argv[2]);
-        }
-    }
-    else
-    {
-        CreateImage(image);
-        desc << "Synthetic image";
-        maximum = 50;
-    }
+  using InvertIntensityImageFilterType = itk::InvertIntensityImageFilter<ImageType>;
 
-    using InvertIntensityImageFilterType = itk::InvertIntensityImageFilter <ImageType>;
-
-    InvertIntensityImageFilterType::Pointer invertIntensityFilter
-            = InvertIntensityImageFilterType::New();
-    invertIntensityFilter->SetInput(image);
-    invertIntensityFilter->SetMaximum(maximum);
+  InvertIntensityImageFilterType::Pointer invertIntensityFilter = InvertIntensityImageFilterType::New();
+  invertIntensityFilter->SetInput(image);
+  invertIntensityFilter->SetMaximum(maximum);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),
-            true,
-            desc.str());
+  QuickView viewer;
+  viewer.AddImage(image.GetPointer(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "InvertIntensity, maximum = " << maximum;
-    viewer.AddImage(
-            invertIntensityFilter->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "InvertIntensity, maximum = " << maximum;
+  viewer.AddImage(invertIntensityFilter->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make a square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 50);
-        }
+      image->SetPixel(pixelIndex, 50);
     }
+  }
 }
-

--- a/src/Filtering/ImageIntensity/MaskImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/MaskImage/Code.cxx
@@ -17,98 +17,92 @@
  *=========================================================================*/
 #include "itkConfigure.h"
 
-#if ( ITK_VERSION_MAJOR < 4  ) //These are all defaults in ITKv4
+#if (ITK_VERSION_MAJOR < 4) // These are all defaults in ITKv4
 //  Not supported in ITKv3.
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
   return 0;
 }
 #else
-#include "itkImage.h"
-#include "itkImageFileReader.h"
-#include "itkMaskImageFilter.h"
-#include "itkImageRegionIterator.h"
-#ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
-#endif
+#  include "itkImage.h"
+#  include "itkImageFileReader.h"
+#  include "itkMaskImageFilter.h"
+#  include "itkImageRegionIterator.h"
+#  ifdef ENABLE_QUICKVIEW
+#    include "QuickView.h"
+#  endif
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-void CreateHalfMask(ImageType::Pointer image, ImageType::Pointer &mask);
+void
+CreateHalfMask(ImageType::Pointer image, ImageType::Pointer & mask);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Usage: " << argv[0] << " filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-    ImageType::Pointer mask = ImageType::New();
-    CreateHalfMask(reader->GetOutput(), mask);
+  ImageType::Pointer mask = ImageType::New();
+  CreateHalfMask(reader->GetOutput(), mask);
 
-    using MaskFilterType = itk::MaskImageFilter< ImageType, ImageType >;
-    MaskFilterType::Pointer maskFilter = MaskFilterType::New();
-    maskFilter->SetInput(reader->GetOutput());
-    maskFilter->SetMaskImage(mask);
-    mask->Print(std::cout);
-#ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  using MaskFilterType = itk::MaskImageFilter<ImageType, ImageType>;
+  MaskFilterType::Pointer maskFilter = MaskFilterType::New();
+  maskFilter->SetInput(reader->GetOutput());
+  maskFilter->SetMaskImage(mask);
+  mask->Print(std::cout);
+#  ifdef ENABLE_QUICKVIEW
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    std::stringstream desc;
-    desc << "Mask";
-    viewer.AddImage(
-            mask.GetPointer(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Mask";
+  viewer.AddImage(mask.GetPointer(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "MaskFilter";
-    viewer.AddImage(
-            maskFilter->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  desc2 << "MaskFilter";
+  viewer.AddImage(maskFilter->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
-#endif
-    return EXIT_SUCCESS;
+  viewer.Visualize();
+#  endif
+  return EXIT_SUCCESS;
 }
 
 
-void CreateHalfMask(ImageType::Pointer image, ImageType::Pointer &mask)
+void
+CreateHalfMask(ImageType::Pointer image, ImageType::Pointer & mask)
 {
-    ImageType::RegionType region = image->GetLargestPossibleRegion();
+  ImageType::RegionType region = image->GetLargestPossibleRegion();
 
-    mask->SetRegions(region);
-    mask->Allocate();
+  mask->SetRegions(region);
+  mask->Allocate();
 
-    ImageType::SizeType regionSize = region.GetSize();
+  ImageType::SizeType regionSize = region.GetSize();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(mask,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(mask, region);
 
-    // Make the left half of the mask white and the right half black
-    while(!imageIterator.IsAtEnd())
+  // Make the left half of the mask white and the right half black
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > static_cast<ImageType::IndexValueType>(regionSize[0]) / 2)
     {
-        if(imageIterator.GetIndex()[0] > static_cast<ImageType::IndexValueType>(regionSize[0]) / 2)
-        {
-            imageIterator.Set(0);
-        }
-        else
-        {
-            imageIterator.Set(255);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(0);
+    }
+    else
+    {
+      imageIterator.Set(255);
     }
 
+    ++imageIterator;
+  }
 }
 #endif
-

--- a/src/Filtering/ImageIntensity/MultiplyImageByScalar/Code.cxx
+++ b/src/Filtering/ImageIntensity/MultiplyImageByScalar/Code.cxx
@@ -20,51 +20,52 @@
 #include "itkImageFileWriter.h"
 #include "itkMultiplyImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <Factor> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const char * inputFileName = argv[1];
-  const double factor = std::stod( argv[2] );
-  const char * outputFileName = argv[3];
+  const char *           inputFileName = argv[1];
+  const double           factor = std::stod(argv[2]);
+  const char *           outputFileName = argv[3];
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   using OutputPixelType = double;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using FilterType = itk::MultiplyImageFilter< InputImageType, InputImageType, OutputImageType >;
+  using FilterType = itk::MultiplyImageFilter<InputImageType, InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetConstant( factor );
+  filter->SetInput(reader->GetOutput());
+  filter->SetConstant(factor);
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/MultiplyTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/MultiplyTwoImages/Code.cxx
@@ -20,16 +20,17 @@
 #include "itkImageFileWriter.h"
 #include "itkMultiplyImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName 1> <InputFileName 2> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName1 = argv[1];
   const char * inputFileName2 = argv[2];
@@ -38,36 +39,36 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader1 = ReaderType::New();
-  reader1->SetFileName( inputFileName1 );
+  reader1->SetFileName(inputFileName1);
 
   ReaderType::Pointer reader2 = ReaderType::New();
-  reader2->SetFileName( inputFileName2 );
+  reader2->SetFileName(inputFileName2);
 
   using OutputPixelType = unsigned int;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using FilterType = itk::MultiplyImageFilter< InputImageType, InputImageType, OutputImageType >;
+  using FilterType = itk::MultiplyImageFilter<InputImageType, InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput1( reader1->GetOutput() );
-  filter->SetInput2( reader2->GetOutput() );
+  filter->SetInput1(reader1->GetOutput());
+  filter->SetInput2(reader2->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/NormalizeImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/NormalizeImage/Code.cxx
@@ -21,62 +21,54 @@
 #include "itkStatisticsImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 #include <iomanip>
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << "Usage: " << argv[0] << " filename" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << argv[0] << " filename" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using FloatImageType = itk::Image<double, 2>;
+  using FloatImageType = itk::Image<double, 2>;
 
-    using ReaderType = itk::ImageFileReader<FloatImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
+  using ReaderType = itk::ImageFileReader<FloatImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
-    using NormalizeFilterType = itk::NormalizeImageFilter< FloatImageType, FloatImageType >;
-    NormalizeFilterType::Pointer normalizeFilter = NormalizeFilterType::New();
-    normalizeFilter->SetInput(reader->GetOutput());
+  using NormalizeFilterType = itk::NormalizeImageFilter<FloatImageType, FloatImageType>;
+  NormalizeFilterType::Pointer normalizeFilter = NormalizeFilterType::New();
+  normalizeFilter->SetInput(reader->GetOutput());
 
-    using StatisticsFilterType = itk::StatisticsImageFilter< FloatImageType >;
-    StatisticsFilterType::Pointer statistics1 = StatisticsFilterType::New();
-    statistics1->SetInput(reader->GetOutput());
+  using StatisticsFilterType = itk::StatisticsImageFilter<FloatImageType>;
+  StatisticsFilterType::Pointer statistics1 = StatisticsFilterType::New();
+  statistics1->SetInput(reader->GetOutput());
 
-    StatisticsFilterType::Pointer statistics2 = StatisticsFilterType::New();
-    statistics2->SetInput(normalizeFilter->GetOutput());
+  StatisticsFilterType::Pointer statistics2 = StatisticsFilterType::New();
+  statistics2->SetInput(normalizeFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
+  QuickView viewer;
 
-    std::stringstream desc1;
-    statistics1->Update();
-    desc1 << itksys::SystemTools::GetFilenameName(argv[1])
-          << "\nMean: " << statistics1->GetMean()
-          << " Variance: " << statistics1->GetVariance();
-    viewer.AddImage(
-            reader->GetOutput(),
-            true,
-            desc1.str());
+  std::stringstream desc1;
+  statistics1->Update();
+  desc1 << itksys::SystemTools::GetFilenameName(argv[1]) << "\nMean: " << statistics1->GetMean()
+        << " Variance: " << statistics1->GetVariance();
+  viewer.AddImage(reader->GetOutput(), true, desc1.str());
 
-    std::stringstream desc2;
-    statistics2->Update();
-    desc2 << "Normalize"
-          << "\nMean: "
-          << std::fixed << std::setprecision (2) << statistics2->GetMean()
-          << " Variance: " << statistics2->GetVariance();
-    viewer.AddImage(
-            normalizeFilter->GetOutput(),
-            true,
-            desc2.str());
+  std::stringstream desc2;
+  statistics2->Update();
+  desc2 << "Normalize"
+        << "\nMean: " << std::fixed << std::setprecision(2) << statistics2->GetMean()
+        << " Variance: " << statistics2->GetVariance();
+  viewer.AddImage(normalizeFilter->GetOutput(), true, desc2.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/Code.cxx
@@ -21,98 +21,103 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-void CreateImage1(ImageType::Pointer image);
-void CreateImage2(ImageType::Pointer image);
+void
+CreateImage1(ImageType::Pointer image);
+void
+CreateImage2(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1);
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2);
 
-    using DivideImageFilterType = itk::DivideImageFilter <ImageType, ImageType, ImageType >;
+  using DivideImageFilterType = itk::DivideImageFilter<ImageType, ImageType, ImageType>;
 
-    DivideImageFilterType::Pointer divideImageFilter = DivideImageFilterType::New ();
-    divideImageFilter->SetInput1(image1);
-    divideImageFilter->SetInput2(image2);
-    divideImageFilter->Update();
+  DivideImageFilterType::Pointer divideImageFilter = DivideImageFilterType::New();
+  divideImageFilter->SetInput1(image1);
+  divideImageFilter->SetInput2(image2);
+  divideImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("test.png");
-    writer->SetInput(divideImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("test.png");
+  writer->SetInput(divideImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType::Pointer image)
+void
+CreateImage1(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 20; c < 80; c++)
     {
-        for(unsigned int c = 20; c < 80; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }
 
 
-void CreateImage2(ImageType::Pointer image)
+void
+CreateImage2(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make another square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make another square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }

--- a/src/Filtering/ImageIntensity/RescaleAnImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/RescaleAnImage/Code.cxx
@@ -21,46 +21,47 @@
 #include "itkImageFileWriter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
+  if (argc != 5)
   {
-  std::cerr << "Usage: "<< std::endl;
-  std::cerr << argv[0];
-  std::cerr << "<InputFileName> <OutputFileName> <OutputMin> <OutputMax>";
-  std::cerr << std::endl;
-  return EXIT_FAILURE;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0];
+    std::cerr << "<InputFileName> <OutputFileName> <OutputMin> <OutputMax>";
+    std::cerr << std::endl;
+    return EXIT_FAILURE;
   }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using FilterType = itk::RescaleIntensityImageFilter< ImageType, ImageType >;
+  using FilterType = itk::RescaleIntensityImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetOutputMinimum( std::stoi( argv[3] ) );
-  filter->SetOutputMaximum( std::stoi( argv[4] ) );
+  filter->SetInput(reader->GetOutput());
+  filter->SetOutputMinimum(std::stoi(argv[3]));
+  filter->SetOutputMaximum(std::stoi(argv[4]));
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageIntensity/ScalePixelSumToConstant/Code.cxx
+++ b/src/Filtering/ImageIntensity/ScalePixelSumToConstant/Code.cxx
@@ -21,47 +21,51 @@
 
 using ImageType = itk::Image<float, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    // Create an image
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  // Create an image
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using NormalizeToConstantImageFilterType = itk::NormalizeToConstantImageFilter <ImageType, ImageType>;
-    NormalizeToConstantImageFilterType::Pointer normalizeToConstantImageFilter = NormalizeToConstantImageFilterType::New();
-    normalizeToConstantImageFilter->SetInput(image);
-    normalizeToConstantImageFilter->SetConstant(1);
-    normalizeToConstantImageFilter->Update();
+  using NormalizeToConstantImageFilterType = itk::NormalizeToConstantImageFilter<ImageType, ImageType>;
+  NormalizeToConstantImageFilterType::Pointer normalizeToConstantImageFilter =
+    NormalizeToConstantImageFilterType::New();
+  normalizeToConstantImageFilter->SetInput(image);
+  normalizeToConstantImageFilter->SetConstant(1);
+  normalizeToConstantImageFilter->Update();
 
-    itk::ImageRegionConstIterator<ImageType> imageIterator(normalizeToConstantImageFilter->GetOutput(),
-                                                           normalizeToConstantImageFilter->GetOutput()->GetLargestPossibleRegion());
+  itk::ImageRegionConstIterator<ImageType> imageIterator(
+    normalizeToConstantImageFilter->GetOutput(),
+    normalizeToConstantImageFilter->GetOutput()->GetLargestPossibleRegion());
 
-    // The output pixels should all be 1/9 (=0.11111)
-    while(!imageIterator.IsAtEnd())
-    {
-        std::cout << imageIterator.Get() << std::endl;
-        ++imageIterator;
-    }
+  // The output pixels should all be 1/9 (=0.11111)
+  while (!imageIterator.IsAtEnd())
+  {
+    std::cout << imageIterator.Get() << std::endl;
+    ++imageIterator;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-static void CreateImage(ImageType::Pointer image)
+static void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image full of 1's
+  // Create an image full of 1's
 
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(3);
+  ImageType::SizeType size;
+  size.Fill(3);
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(1);
-
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(1);
 }

--- a/src/Filtering/ImageIntensity/SetOutputPixelToMax/Code.cxx
+++ b/src/Filtering/ImageIntensity/SetOutputPixelToMax/Code.cxx
@@ -23,90 +23,92 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage1(ImageType* image);
-static void CreateImage2(ImageType* image);
+static void
+CreateImage1(ImageType * image);
+static void
+CreateImage2(ImageType * image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1);
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2);
 
-    using MaximumImageFilterType = itk::MaximumImageFilter <ImageType>;
+  using MaximumImageFilterType = itk::MaximumImageFilter<ImageType>;
 
-    MaximumImageFilterType::Pointer maximumImageFilter
-            = MaximumImageFilterType::New ();
-    maximumImageFilter->SetInput(0, image1);
-    maximumImageFilter->SetInput(1, image2);
-    maximumImageFilter->Update();
+  MaximumImageFilterType::Pointer maximumImageFilter = MaximumImageFilterType::New();
+  maximumImageFilter->SetInput(0, image1);
+  maximumImageFilter->SetInput(1, image2);
+  maximumImageFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType* image)
+void
+CreateImage1(ImageType * image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 30)
     {
-        if(imageIterator.GetIndex()[0] < 30)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
 
-void CreateImage2(ImageType* image)
+void
+CreateImage2(ImageType * image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 70)
     {
-        if(imageIterator.GetIndex()[0] > 70)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }

--- a/src/Filtering/ImageIntensity/SetOutputPixelToMin/Code.cxx
+++ b/src/Filtering/ImageIntensity/SetOutputPixelToMin/Code.cxx
@@ -23,91 +23,92 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage1(ImageType* image);
-static void CreateImage2(ImageType* image);
+static void
+CreateImage1(ImageType * image);
+static void
+CreateImage2(ImageType * image);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1);
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2);
 
-    using MinimumImageFilterType = itk::MinimumImageFilter <ImageType>;
+  using MinimumImageFilterType = itk::MinimumImageFilter<ImageType>;
 
-    MinimumImageFilterType::Pointer minimumImageFilter
-            = MinimumImageFilterType::New ();
-    minimumImageFilter->SetInput(0, image1);
-    minimumImageFilter->SetInput(1, image2);
-    minimumImageFilter->Update();
+  MinimumImageFilterType::Pointer minimumImageFilter = MinimumImageFilterType::New();
+  minimumImageFilter->SetInput(0, image1);
+  minimumImageFilter->SetInput(1, image2);
+  minimumImageFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType* image)
+void
+CreateImage1(ImageType * image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 30)
     {
-        if(imageIterator.GetIndex()[0] < 30)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
 
-void CreateImage2(ImageType* image)
+void
+CreateImage2(ImageType * image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 70)
     {
-        if(imageIterator.GetIndex()[0] > 70)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/SquareEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/SquareEveryPixel/Code.cxx
@@ -20,57 +20,58 @@
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using SquareImageFilterType = itk::SquareImageFilter <ImageType, ImageType>;
-    SquareImageFilterType::Pointer squareImageFilter = SquareImageFilterType::New();
-    squareImageFilter->SetInput(image);
-    squareImageFilter->Update();
+  using SquareImageFilterType = itk::SquareImageFilter<ImageType, ImageType>;
+  SquareImageFilterType::Pointer squareImageFilter = SquareImageFilterType::New();
+  squareImageFilter->SetInput(image);
+  squareImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(squareImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(squareImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 70)
     {
-        if(imageIterator.GetIndex()[0] < 70)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/Code.cxx
@@ -20,58 +20,59 @@
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using SubtractImageFilterType = itk::SubtractImageFilter <ImageType, ImageType, ImageType>;
-    SubtractImageFilterType::Pointer subtractConstantFromImageFilter = SubtractImageFilterType::New();
-    subtractConstantFromImageFilter->SetInput(image);
-    subtractConstantFromImageFilter->SetConstant2(2);
-    subtractConstantFromImageFilter->Update();
+  using SubtractImageFilterType = itk::SubtractImageFilter<ImageType, ImageType, ImageType>;
+  SubtractImageFilterType::Pointer subtractConstantFromImageFilter = SubtractImageFilterType::New();
+  subtractConstantFromImageFilter->SetInput(image);
+  subtractConstantFromImageFilter->SetConstant2(2);
+  subtractConstantFromImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput(subtractConstantFromImageFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(subtractConstantFromImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] < 70)
     {
-        if(imageIterator.GetIndex()[0] < 70)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/ImageIntensity/SubtractTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/SubtractTwoImages/Code.cxx
@@ -33,186 +33,180 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage1(ImageType::Pointer image);
-static void CreateImage2(ImageType::Pointer image);
+static void
+CreateImage1(ImageType::Pointer image);
+static void
+CreateImage2(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image1 = ImageType::New();
-    CreateImage1(image1);
+  ImageType::Pointer image1 = ImageType::New();
+  CreateImage1(image1);
 
-    ImageType::Pointer image2 = ImageType::New();
-    CreateImage2(image2);
+  ImageType::Pointer image2 = ImageType::New();
+  CreateImage2(image2);
 
-    using SubtractImageFilterType = itk::SubtractImageFilter <ImageType, ImageType >;
+  using SubtractImageFilterType = itk::SubtractImageFilter<ImageType, ImageType>;
 
-    SubtractImageFilterType::Pointer subtractFilter
-            = SubtractImageFilterType::New ();
-    subtractFilter->SetInput1(image1);
-    subtractFilter->SetInput2(image2);
-    subtractFilter->Update();
+  SubtractImageFilterType::Pointer subtractFilter = SubtractImageFilterType::New();
+  subtractFilter->SetInput1(image1);
+  subtractFilter->SetInput2(image2);
+  subtractFilter->Update();
 
-    // Visualize first image
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector1 = ConnectorType::New();
-    connector1->SetInput(image1);
+  // Visualize first image
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector1 = ConnectorType::New();
+  connector1->SetInput(image1);
 
-    vtkSmartPointer<vtkImageActor> actor1 =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor1 = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor1->SetInput(connector1->GetOutput());
+  actor1->SetInput(connector1->GetOutput());
 #else
-    connector1->Update();
+  connector1->Update();
   actor1->GetMapper()->SetInputData(connector1->GetOutput());
 #endif
 
-    // Visualize second image
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector2 = ConnectorType::New();
-    connector2->SetInput(image2);
+  // Visualize second image
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector2 = ConnectorType::New();
+  connector2->SetInput(image2);
 
-    vtkSmartPointer<vtkImageActor> actor2 =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor2 = vtkSmartPointer<vtkImageActor>::New();
 
 #if VTK_MAJOR_VERSION <= 5
-    actor2->SetInput(connector2->GetOutput());
+  actor2->SetInput(connector2->GetOutput());
 #else
-    connector2->Update();
+  connector2->Update();
   actor2->GetMapper()->SetInputData(connector2->GetOutput());
 #endif
 
-    // Visualize subtracted image
-    ConnectorType::Pointer subtractConnector = ConnectorType::New();
-    subtractConnector->SetInput(subtractFilter->GetOutput());
+  // Visualize subtracted image
+  ConnectorType::Pointer subtractConnector = ConnectorType::New();
+  subtractConnector->SetInput(subtractFilter->GetOutput());
 
-    vtkSmartPointer<vtkImageActor> subtractActor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> subtractActor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    subtractActor->SetInput(subtractConnector->GetOutput());
+  subtractActor->SetInput(subtractConnector->GetOutput());
 #else
-    subtractConnector->Update();
+  subtractConnector->Update();
   subtractActor->GetMapper()->SetInputData(subtractConnector->GetOutput());
 #endif
-    // There will be one render window
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
-    renderWindow->SetSize(900, 300);
+  // There will be one render window
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+  renderWindow->SetSize(900, 300);
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    // Define viewport ranges
-    // (xmin, ymin, xmax, ymax)
-    double leftViewport[4] = {0.0, 0.0, 0.33, 1.0};
-    double centerViewport[4] = {0.33, 0.0, 0.66, 1.0};
-    double rightViewport[4] = {0.66, 0.0, 1.0, 1.0};
+  // Define viewport ranges
+  // (xmin, ymin, xmax, ymax)
+  double leftViewport[4] = { 0.0, 0.0, 0.33, 1.0 };
+  double centerViewport[4] = { 0.33, 0.0, 0.66, 1.0 };
+  double rightViewport[4] = { 0.66, 0.0, 1.0, 1.0 };
 
-    // Setup both renderers
-    vtkSmartPointer<vtkRenderer> leftRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(leftRenderer);
-    leftRenderer->SetViewport(leftViewport);
-    leftRenderer->SetBackground(.6, .5, .4);
+  // Setup both renderers
+  vtkSmartPointer<vtkRenderer> leftRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(leftRenderer);
+  leftRenderer->SetViewport(leftViewport);
+  leftRenderer->SetBackground(.6, .5, .4);
 
-    vtkSmartPointer<vtkRenderer> centerRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(centerRenderer);
-    centerRenderer->SetViewport(centerViewport);
-    centerRenderer->SetBackground(.4, .5, .6);
+  vtkSmartPointer<vtkRenderer> centerRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(centerRenderer);
+  centerRenderer->SetViewport(centerViewport);
+  centerRenderer->SetBackground(.4, .5, .6);
 
-    vtkSmartPointer<vtkRenderer> rightRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(rightRenderer);
-    rightRenderer->SetViewport(rightViewport);
-    rightRenderer->SetBackground(.4, .5, .6);
+  vtkSmartPointer<vtkRenderer> rightRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(rightRenderer);
+  rightRenderer->SetViewport(rightViewport);
+  rightRenderer->SetBackground(.4, .5, .6);
 
-    // Add the sphere to the left and the cube to the right
-    leftRenderer->AddActor(actor1);
-    centerRenderer->AddActor(actor2);
-    rightRenderer->AddActor(subtractActor);
+  // Add the sphere to the left and the cube to the right
+  leftRenderer->AddActor(actor1);
+  centerRenderer->AddActor(actor2);
+  rightRenderer->AddActor(subtractActor);
 
-    leftRenderer->ResetCamera();
-    centerRenderer->ResetCamera();
-    rightRenderer->ResetCamera();
+  leftRenderer->ResetCamera();
+  centerRenderer->ResetCamera();
+  rightRenderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
-    interactor->SetInteractorStyle(style);
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage1(ImageType::Pointer image)
+void
+CreateImage1(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 20; c < 80; c++)
     {
-        for(unsigned int c = 20; c < 80; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }
 
 
-void CreateImage2(ImageType::Pointer image)
+void
+CreateImage2(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make another square
-    for(unsigned int r = 40; r < 100; r++)
+  // Make another square
+  for (unsigned int r = 40; r < 100; r++)
+  {
+    for (unsigned int c = 40; c < 100; c++)
     {
-        for(unsigned int c = 40; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 15);
-        }
+      image->SetPixel(pixelIndex, 15);
     }
+  }
 }
-

--- a/src/Filtering/ImageIntensity/TransformVectorValuedImagePixels/Code.cxx
+++ b/src/Filtering/ImageIntensity/TransformVectorValuedImagePixels/Code.cxx
@@ -21,36 +21,37 @@
 #include "itkVectorRescaleIntensityImageFilter.h"
 #include "itkCastImageFilter.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 3)
-    {
-        std::cerr << "Required: input output" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 3)
+  {
+    std::cerr << "Required: input output" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    std::string inputFilename = argv[1];
-    std::string outputFilename = argv[2];
+  std::string inputFilename = argv[1];
+  std::string outputFilename = argv[2];
 
-    using FloatImageType = itk::Image<itk::CovariantVector<float, 3>, 2>;
-    using UnsignedCharImageType = itk::Image<itk::CovariantVector<unsigned char, 3>, 2>;
+  using FloatImageType = itk::Image<itk::CovariantVector<float, 3>, 2>;
+  using UnsignedCharImageType = itk::Image<itk::CovariantVector<unsigned char, 3>, 2>;
 
-    using ReaderType = itk::ImageFileReader<FloatImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(inputFilename);
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<FloatImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFilename);
+  reader->Update();
 
-    using VectorRescaleFilterType = itk::VectorRescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
-    VectorRescaleFilterType::Pointer rescaleFilter = VectorRescaleFilterType::New();
-    rescaleFilter->SetInput(reader->GetOutput());
-    rescaleFilter->SetOutputMaximumMagnitude(255);
-    rescaleFilter->Update();
+  using VectorRescaleFilterType = itk::VectorRescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
+  VectorRescaleFilterType::Pointer rescaleFilter = VectorRescaleFilterType::New();
+  rescaleFilter->SetInput(reader->GetOutput());
+  rescaleFilter->SetOutputMaximumMagnitude(255);
+  rescaleFilter->Update();
 
-    using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName(outputFilename);
-    writer->SetInput(rescaleFilter->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(outputFilename);
+  writer->SetInput(rescaleFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfBlobsInBinaryImage/Code.cxx
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfBlobsInBinaryImage/Code.cxx
@@ -22,78 +22,78 @@
 #include "itkRescaleIntensityImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using binaryContourImageFilterType = itk::BinaryContourImageFilter <ImageType, ImageType >;
+  using binaryContourImageFilterType = itk::BinaryContourImageFilter<ImageType, ImageType>;
 
-    // Outer boundary
-    binaryContourImageFilterType::Pointer binaryContourFilter
-            = binaryContourImageFilterType::New ();
-    binaryContourFilter->SetInput(image);
-    binaryContourFilter->SetForegroundValue(0);
-    binaryContourFilter->SetBackgroundValue(255);
-    binaryContourFilter->Update();
+  // Outer boundary
+  binaryContourImageFilterType::Pointer binaryContourFilter = binaryContourImageFilterType::New();
+  binaryContourFilter->SetInput(image);
+  binaryContourFilter->SetForegroundValue(0);
+  binaryContourFilter->SetBackgroundValue(255);
+  binaryContourFilter->Update();
 
-    // Invert the result
-    using InvertIntensityImageFilterType = itk::InvertIntensityImageFilter <ImageType>;
+  // Invert the result
+  using InvertIntensityImageFilterType = itk::InvertIntensityImageFilter<ImageType>;
 
-    InvertIntensityImageFilterType::Pointer invertIntensityFilter
-            = InvertIntensityImageFilterType::New();
-    invertIntensityFilter->SetInput(binaryContourFilter->GetOutput());
-    invertIntensityFilter->Update();
+  InvertIntensityImageFilterType::Pointer invertIntensityFilter = InvertIntensityImageFilterType::New();
+  invertIntensityFilter->SetInput(binaryContourFilter->GetOutput());
+  invertIntensityFilter->Update();
 
-    ImageType::Pointer outerBoundary = ImageType::New();
-    outerBoundary->Graft(invertIntensityFilter->GetOutput());
+  ImageType::Pointer outerBoundary = ImageType::New();
+  outerBoundary->Graft(invertIntensityFilter->GetOutput());
 
-    // Inner boundary
-    binaryContourFilter->SetForegroundValue(255);
-    binaryContourFilter->SetBackgroundValue(0);
-    binaryContourFilter->Update();
+  // Inner boundary
+  binaryContourFilter->SetForegroundValue(255);
+  binaryContourFilter->SetBackgroundValue(0);
+  binaryContourFilter->Update();
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(image.GetPointer());
-    viewer.AddImage(outerBoundary.GetPointer());
-    viewer.AddImage(binaryContourFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage(image.GetPointer());
+  viewer.AddImage(outerBoundary.GetPointer());
+  viewer.AddImage(binaryContourFilter->GetOutput());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region(start, size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a square
-    for(unsigned int r = 5; r < 10; r++)
+  // Make a square
+  for (unsigned int r = 5; r < 10; r++)
+  {
+    for (unsigned int c = 5; c < 10; c++)
     {
-        for(unsigned int c = 5; c < 10; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
-
+  }
 }

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/Code.cxx
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/Code.cxx
@@ -20,77 +20,78 @@
 #include "itkBinaryContourImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using binaryContourImageFilterType = itk::BinaryContourImageFilter <ImageType, ImageType >;
+  using binaryContourImageFilterType = itk::BinaryContourImageFilter<ImageType, ImageType>;
 
-    binaryContourImageFilterType::Pointer binaryContourFilter
-            = binaryContourImageFilterType::New ();
-    binaryContourFilter->SetInput(image);
+  binaryContourImageFilterType::Pointer binaryContourFilter = binaryContourImageFilterType::New();
+  binaryContourFilter->SetInput(image);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage<ImageType>(image);
-    viewer.AddImage<ImageType>(binaryContourFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage<ImageType>(image);
+  viewer.AddImage<ImageType>(binaryContourFilter->GetOutput());
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    // Make another square
-    for(unsigned int r = 100; r < 130; r++)
+  // Make another square
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-        for(unsigned int c = 115; c < 160; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }
-

--- a/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/Code.cxx
+++ b/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/Code.cxx
@@ -25,118 +25,113 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 namespace
 {
-    using PixelType = unsigned char;
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
-    using ImageType = itk::Image<PixelType, 2>;
-    using RGBImageType = itk::Image<RGBPixelType, 2>;
-}
+using PixelType = unsigned char;
+using RGBPixelType = itk::RGBPixel<unsigned char>;
+using ImageType = itk::Image<PixelType, 2>;
+using RGBImageType = itk::Image<RGBPixelType, 2>;
+} // namespace
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    // Create or read an image
-    ImageType::Pointer image;
-    if( argc < 2 )
-    {
-        image = ImageType::New();
-        CreateImage(image.GetPointer());
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader =
-                ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
+  // Create or read an image
+  ImageType::Pointer image;
+  if (argc < 2)
+  {
+    image = ImageType::New();
+    CreateImage(image.GetPointer());
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
 
-        image = reader->GetOutput();
-    }
+    image = reader->GetOutput();
+  }
 
-    // Generate connected components
-    using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter <ImageType, ImageType >;
-    ConnectedComponentImageFilterType::Pointer connectedComponentImageFilter
-            = ConnectedComponentImageFilterType::New ();
-    connectedComponentImageFilter->SetInput(image);
+  // Generate connected components
+  using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter<ImageType, ImageType>;
+  ConnectedComponentImageFilterType::Pointer connectedComponentImageFilter = ConnectedComponentImageFilterType::New();
+  connectedComponentImageFilter->SetInput(image);
 
-    // Generate contours for each component
-    using LabelContourImageFilterType = itk::LabelContourImageFilter<ImageType, ImageType>;
-    LabelContourImageFilterType::Pointer labelContourImageFilter =
-            LabelContourImageFilterType::New();
-    labelContourImageFilter->SetInput(connectedComponentImageFilter->GetOutput());
+  // Generate contours for each component
+  using LabelContourImageFilterType = itk::LabelContourImageFilter<ImageType, ImageType>;
+  LabelContourImageFilterType::Pointer labelContourImageFilter = LabelContourImageFilterType::New();
+  labelContourImageFilter->SetInput(connectedComponentImageFilter->GetOutput());
 
-    using RGBFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
-    RGBFilterType::Pointer rgbFilter = RGBFilterType::New();
-    rgbFilter->SetInput( labelContourImageFilter->GetOutput() );
-    rgbFilter->SetColormap( itk::RGBColormapFilterEnumType::Jet );
+  using RGBFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
+  RGBFilterType::Pointer rgbFilter = RGBFilterType::New();
+  rgbFilter->SetInput(labelContourImageFilter->GetOutput());
+  rgbFilter->SetColormap(itk::RGBColormapFilterEnumType::Jet);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),true,
-            argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
+  QuickView viewer;
+  viewer.AddImage(
+    image.GetPointer(), true, argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
 
-    std::stringstream desc;
-    desc << "LabelContourImageFilter";
-    viewer.AddRGBImage(
-            rgbFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "LabelContourImageFilter";
+  viewer.AddRGBImage(rgbFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    // Make another square
-    for(unsigned int r = 100; r < 130; r++)
+  // Make another square
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-        for(unsigned int c = 115; c < 160; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }
-

--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Code.cxx
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Code.cxx
@@ -20,47 +20,48 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 6 )
-    {
+  if (argc < 6)
+  {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
-      << " inputImageFile outputImageFile alpha beta radius" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " inputImageFile outputImageFile alpha beta radius" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using FileReaderType = itk::ImageFileReader< ImageType >;
+  using FileReaderType = itk::ImageFileReader<ImageType>;
   FileReaderType::Pointer reader = FileReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using AdaptiveHistogramEqualizationImageFilterType = itk::AdaptiveHistogramEqualizationImageFilter< ImageType >;
-  AdaptiveHistogramEqualizationImageFilterType::Pointer adaptiveHistogramEqualizationImageFilter = AdaptiveHistogramEqualizationImageFilterType::New();
+  using AdaptiveHistogramEqualizationImageFilterType = itk::AdaptiveHistogramEqualizationImageFilter<ImageType>;
+  AdaptiveHistogramEqualizationImageFilterType::Pointer adaptiveHistogramEqualizationImageFilter =
+    AdaptiveHistogramEqualizationImageFilterType::New();
 
-  float alpha = std::stod( argv[3] );
-  adaptiveHistogramEqualizationImageFilter->SetAlpha( alpha );
+  float alpha = std::stod(argv[3]);
+  adaptiveHistogramEqualizationImageFilter->SetAlpha(alpha);
 
-  float beta = std::stod( argv[4] );
-  adaptiveHistogramEqualizationImageFilter->SetBeta( beta );
+  float beta = std::stod(argv[4]);
+  adaptiveHistogramEqualizationImageFilter->SetBeta(beta);
 
-  int radiusSize = std::stoi( argv[5] );
+  int                                                         radiusSize = std::stoi(argv[5]);
   AdaptiveHistogramEqualizationImageFilterType::ImageSizeType radius;
-  radius.Fill( radiusSize );
-  adaptiveHistogramEqualizationImageFilter->SetRadius( radius );
+  radius.Fill(radiusSize);
+  adaptiveHistogramEqualizationImageFilter->SetRadius(radius);
 
-  adaptiveHistogramEqualizationImageFilter->SetInput( reader->GetOutput() );
+  adaptiveHistogramEqualizationImageFilter->SetInput(reader->GetOutput());
 
   adaptiveHistogramEqualizationImageFilter->Update();
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( adaptiveHistogramEqualizationImageFilter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(adaptiveHistogramEqualizationImageFilter->GetOutput());
 
   writer->Update();
 

--- a/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/Code.cxx
+++ b/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/Code.cxx
@@ -20,52 +20,53 @@
 #include "itkImageFileWriter.h"
 #include "itkAccumulateImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <Dimension>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  auto accumulateDimension = static_cast< unsigned int >( std::stoi( argv[3] ) );
+  auto         accumulateDimension = static_cast<unsigned int>(std::stoi(argv[3]));
 
   constexpr unsigned int Dimension = 3;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   using OutputPixelType = double;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using FilterType = itk::AccumulateImageFilter< InputImageType, OutputImageType >;
+  using FilterType = itk::AccumulateImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetAccumulateDimension( accumulateDimension );
+  filter->SetInput(reader->GetOutput());
+  filter->SetAccumulateDimension(accumulateDimension);
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/Code.cxx
+++ b/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/Code.cxx
@@ -22,72 +22,73 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using StatisticsImageFilterType = itk::StatisticsImageFilter<ImageType>;
-    StatisticsImageFilterType::Pointer statisticsImageFilter
-            = StatisticsImageFilterType::New ();
-    statisticsImageFilter->SetInput(image);
-    statisticsImageFilter->Update();
+  using StatisticsImageFilterType = itk::StatisticsImageFilter<ImageType>;
+  StatisticsImageFilterType::Pointer statisticsImageFilter = StatisticsImageFilterType::New();
+  statisticsImageFilter->SetInput(image);
+  statisticsImageFilter->Update();
 
-    std::cout << "Mean: " << statisticsImageFilter->GetMean() << std::endl;
-    std::cout << "Std.: " << statisticsImageFilter->GetSigma() << std::endl;
-    std::cout << "Min: " << statisticsImageFilter->GetMinimum() << std::endl;
-    std::cout << "Max: " << statisticsImageFilter->GetMaximum() << std::endl;
+  std::cout << "Mean: " << statisticsImageFilter->GetMean() << std::endl;
+  std::cout << "Std.: " << statisticsImageFilter->GetSigma() << std::endl;
+  std::cout << "Min: " << statisticsImageFilter->GetMinimum() << std::endl;
+  std::cout << "Max: " << statisticsImageFilter->GetMaximum() << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    // Make another square
-    for(unsigned int r = 100; r < 130; r++)
+  // Make another square
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-        for(unsigned int c = 115; c < 160; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }
-

--- a/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/Code.cxx
+++ b/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/Code.cxx
@@ -45,92 +45,89 @@ Author: Juan Cardelino <juan dot cardelino at gmail dot com>
 // VNL
 #include "vnl/vnl_sample.h"
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-    if( argc < 5 )
-    {
-        std::cerr << "Missing Parameters " << std::endl;
-        std::cerr << "Usage: " << argv[0];
-        std::cerr << " nbTrain  trainFilePattern";
-        std::cerr << " nbModes  modeFilePattern";
-        std::cerr << std::endl;
-        return 1;
-    }
+  if (argc < 5)
+  {
+    std::cerr << "Missing Parameters " << std::endl;
+    std::cerr << "Usage: " << argv[0];
+    std::cerr << " nbTrain  trainFilePattern";
+    std::cerr << " nbModes  modeFilePattern";
+    std::cerr << std::endl;
+    return 1;
+  }
 
-    for(int i=0; i<argc;i++)
-    {
-        std::cout << "id: " << i << " arg: " << argv[i] << std::endl;
-    }
-    constexpr unsigned int Dimension = 2;
-    using my_PixelType = float;
-    using ImageType = itk::Image< my_PixelType, Dimension >;
+  for (int i = 0; i < argc; i++)
+  {
+    std::cout << "id: " << i << " arg: " << argv[i] << std::endl;
+  }
+  constexpr unsigned int Dimension = 2;
+  using my_PixelType = float;
+  using ImageType = itk::Image<my_PixelType, Dimension>;
 
-    using ReaderType = itk::ImageFileReader< ImageType >;
-    using WriterType = itk::ImageFileWriter<  ImageType  >;
-    using ScaleType = itk::MultiplyImageFilter < ImageType , ImageType ,ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  using ScaleType = itk::MultiplyImageFilter<ImageType, ImageType, ImageType>;
 
-    unsigned int nb_train=atoi(argv[1]);
+  unsigned int nb_train = atoi(argv[1]);
 
-    itk::NumericSeriesFileNames::Pointer fileNamesCreator =
-            itk::NumericSeriesFileNames::New();
-    std::vector<ImageType::Pointer> trainingImages( nb_train );
+  itk::NumericSeriesFileNames::Pointer fileNamesCreator = itk::NumericSeriesFileNames::New();
+  std::vector<ImageType::Pointer>      trainingImages(nb_train);
 
-    fileNamesCreator->SetStartIndex( 0 );
-    fileNamesCreator->SetEndIndex( nb_train - 1 );
-    fileNamesCreator->SetSeriesFormat( argv[2] );
-    const std::vector<std::string> & shapeModeFileNames =
-            fileNamesCreator->GetFileNames();
+  fileNamesCreator->SetStartIndex(0);
+  fileNamesCreator->SetEndIndex(nb_train - 1);
+  fileNamesCreator->SetSeriesFormat(argv[2]);
+  const std::vector<std::string> & shapeModeFileNames = fileNamesCreator->GetFileNames();
 
-    for ( unsigned int k = 0; k < nb_train; k++ )
-    {
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName( shapeModeFileNames[k].c_str() );
-        reader->Update();
-        trainingImages[k] = reader->GetOutput();
-    }
+  for (unsigned int k = 0; k < nb_train; k++)
+  {
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(shapeModeFileNames[k].c_str());
+    reader->Update();
+    trainingImages[k] = reader->GetOutput();
+  }
 
-    using my_Estimatortype = itk::ImagePCAShapeModelEstimator<ImageType,   ImageType >;
-    my_Estimatortype::Pointer filter = my_Estimatortype::New();
-    filter->SetNumberOfTrainingImages(nb_train);
-    filter->SetNumberOfPrincipalComponentsRequired(2);
+  using my_Estimatortype = itk::ImagePCAShapeModelEstimator<ImageType, ImageType>;
+  my_Estimatortype::Pointer filter = my_Estimatortype::New();
+  filter->SetNumberOfTrainingImages(nb_train);
+  filter->SetNumberOfPrincipalComponentsRequired(2);
 
-    for ( unsigned int k = 0; k < nb_train; k++ )
-    {
-        filter->SetInput(k, trainingImages[k] );
-    }
+  for (unsigned int k = 0; k < nb_train; k++)
+  {
+    filter->SetInput(k, trainingImages[k]);
+  }
 
-    unsigned int nb_modes=atoi(argv[3]);
+  unsigned int nb_modes = atoi(argv[3]);
 
-    itk::NumericSeriesFileNames::Pointer fileNamesOutCreator =
-            itk::NumericSeriesFileNames::New();
+  itk::NumericSeriesFileNames::Pointer fileNamesOutCreator = itk::NumericSeriesFileNames::New();
 
-    fileNamesOutCreator->SetStartIndex( 0 );
-    fileNamesOutCreator->SetEndIndex( nb_modes-1  );
-    fileNamesOutCreator->SetSeriesFormat( argv[4] );
-    const std::vector<std::string> & outFileNames = fileNamesOutCreator->GetFileNames();
+  fileNamesOutCreator->SetStartIndex(0);
+  fileNamesOutCreator->SetEndIndex(nb_modes - 1);
+  fileNamesOutCreator->SetSeriesFormat(argv[4]);
+  const std::vector<std::string> & outFileNames = fileNamesOutCreator->GetFileNames();
 
-    ScaleType::Pointer scaler = ScaleType::New();
+  ScaleType::Pointer scaler = ScaleType::New();
 
-    filter->Update();
-    my_Estimatortype::VectorOfDoubleType v=filter->GetEigenValues();
-    double sv_mean=sqrt(v[0]);
+  filter->Update();
+  my_Estimatortype::VectorOfDoubleType v = filter->GetEigenValues();
+  double                               sv_mean = sqrt(v[0]);
 
-    for ( unsigned int k = 0; k < nb_modes; k++ )
-    {
-        double sv=sqrt(v[k]);
-        double sv_n=sv/sv_mean;
-        //double sv_n=sv;
-        std::cout << "writing: " << outFileNames[k] << std::endl;
+  for (unsigned int k = 0; k < nb_modes; k++)
+  {
+    double sv = sqrt(v[k]);
+    double sv_n = sv / sv_mean;
+    // double sv_n=sv;
+    std::cout << "writing: " << outFileNames[k] << std::endl;
 
-        std::cout << "svd[" << k << "]: " << sv << " norm: " << sv_n << std::endl;
-        WriterType::Pointer writer = WriterType::New();
-        writer->SetFileName( outFileNames[k].c_str() );
-        scaler->SetInput(filter->GetOutput(k));
-        scaler->SetConstant(sv_n);
-        writer->SetInput( scaler->GetOutput() );
-        writer->Update();
-    }
+    std::cout << "svd[" << k << "]: " << sv << " norm: " << sv_n << std::endl;
+    WriterType::Pointer writer = WriterType::New();
+    writer->SetFileName(outFileNames[k].c_str());
+    scaler->SetInput(filter->GetOutput(k));
+    scaler->SetConstant(sv_n);
+    writer->SetInput(scaler->GetOutput());
+    writer->Update();
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/Code.cxx
+++ b/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/Code.cxx
@@ -23,95 +23,99 @@
 #include "itkLabelStatisticsImageFilter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType>;
-    LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
-    labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
-    labelMapToLabelImageFilter->Update();
+  using LabelMapToLabelImageFilterType =
+    itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType>;
+  LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
+  labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
+  labelMapToLabelImageFilter->Update();
 
-    using LabelStatisticsImageFilterType = itk::LabelStatisticsImageFilter< ImageType, ImageType >;
-    LabelStatisticsImageFilterType::Pointer labelStatisticsImageFilter = LabelStatisticsImageFilterType::New();
-    labelStatisticsImageFilter->SetLabelInput( labelMapToLabelImageFilter->GetOutput() );
-    labelStatisticsImageFilter->SetInput(image);
-    labelStatisticsImageFilter->Update();
+  using LabelStatisticsImageFilterType = itk::LabelStatisticsImageFilter<ImageType, ImageType>;
+  LabelStatisticsImageFilterType::Pointer labelStatisticsImageFilter = LabelStatisticsImageFilterType::New();
+  labelStatisticsImageFilter->SetLabelInput(labelMapToLabelImageFilter->GetOutput());
+  labelStatisticsImageFilter->SetInput(image);
+  labelStatisticsImageFilter->Update();
 
-    std::cout << "Number of labels: " << labelStatisticsImageFilter->GetNumberOfLabels() << std::endl;
-    std::cout << std::endl;
+  std::cout << "Number of labels: " << labelStatisticsImageFilter->GetNumberOfLabels() << std::endl;
+  std::cout << std::endl;
 
-    using LabelPixelType = LabelStatisticsImageFilterType::LabelPixelType;
+  using LabelPixelType = LabelStatisticsImageFilterType::LabelPixelType;
 
-    for(auto vIt=labelStatisticsImageFilter->GetValidLabelValues().begin();
-        vIt != labelStatisticsImageFilter->GetValidLabelValues().end();
-        ++vIt)
+  for (auto vIt = labelStatisticsImageFilter->GetValidLabelValues().begin();
+       vIt != labelStatisticsImageFilter->GetValidLabelValues().end();
+       ++vIt)
+  {
+    if (labelStatisticsImageFilter->HasLabel(*vIt))
     {
-        if ( labelStatisticsImageFilter->HasLabel(*vIt) )
-        {
-            LabelPixelType labelValue = *vIt;
-            std::cout << "min: " << labelStatisticsImageFilter->GetMinimum( labelValue ) << std::endl;
-            std::cout << "max: " << labelStatisticsImageFilter->GetMaximum( labelValue ) << std::endl;
-            std::cout << "median: " << labelStatisticsImageFilter->GetMedian( labelValue ) << std::endl;
-            std::cout << "mean: " << labelStatisticsImageFilter->GetMean( labelValue ) << std::endl;
-            std::cout << "sigma: " << labelStatisticsImageFilter->GetSigma( labelValue ) << std::endl;
-            std::cout << "variance: " << labelStatisticsImageFilter->GetVariance( labelValue ) << std::endl;
-            std::cout << "sum: " << labelStatisticsImageFilter->GetSum( labelValue ) << std::endl;
-            std::cout << "count: " << labelStatisticsImageFilter->GetCount( labelValue ) << std::endl;
-            //std::cout << "box: " << labelStatisticsImageFilter->GetBoundingBox( labelValue ) << std::endl; // can't output a box
-            std::cout << "region: " << labelStatisticsImageFilter->GetRegion( labelValue ) << std::endl;
-            std::cout << std::endl << std::endl;
-
-        }
+      LabelPixelType labelValue = *vIt;
+      std::cout << "min: " << labelStatisticsImageFilter->GetMinimum(labelValue) << std::endl;
+      std::cout << "max: " << labelStatisticsImageFilter->GetMaximum(labelValue) << std::endl;
+      std::cout << "median: " << labelStatisticsImageFilter->GetMedian(labelValue) << std::endl;
+      std::cout << "mean: " << labelStatisticsImageFilter->GetMean(labelValue) << std::endl;
+      std::cout << "sigma: " << labelStatisticsImageFilter->GetSigma(labelValue) << std::endl;
+      std::cout << "variance: " << labelStatisticsImageFilter->GetVariance(labelValue) << std::endl;
+      std::cout << "sum: " << labelStatisticsImageFilter->GetSum(labelValue) << std::endl;
+      std::cout << "count: " << labelStatisticsImageFilter->GetCount(labelValue) << std::endl;
+      // std::cout << "box: " << labelStatisticsImageFilter->GetBoundingBox( labelValue ) << std::endl; // can't output
+      // a box
+      std::cout << "region: " << labelStatisticsImageFilter->GetRegion(labelValue) << std::endl;
+      std::cout << std::endl << std::endl;
     }
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make a square
-    while(!imageIterator.IsAtEnd())
+  // Make a square
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10) )
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
+    ++imageIterator;
+  }
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/Code.cxx
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/Code.cxx
@@ -25,74 +25,76 @@
 #include "itkFlatStructuringElement.h"
 #include "itkBinaryMorphologicalClosingImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 4)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <radius>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const char * inputFileName = argv[1];
-  const char * outputFileName = argv[2];
-  const unsigned int radiusValue = std::stoi( argv[3] );
+  const char *       inputFileName = argv[1];
+  const char *       outputFileName = argv[2];
+  const unsigned int radiusValue = std::stoi(argv[3]);
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using LabelObjectType = itk::LabelObject< PixelType, Dimension >;
-  using LabelMapType = itk::LabelMap< LabelObjectType >;
+  using LabelObjectType = itk::LabelObject<PixelType, Dimension>;
+  using LabelMapType = itk::LabelMap<LabelObjectType>;
 
-  using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter< ImageType, LabelMapType >;
+  using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter<ImageType, LabelMapType>;
   LabelImageToLabelMapFilterType::Pointer labelMapConverter = LabelImageToLabelMapFilterType::New();
-  labelMapConverter->SetInput( reader->GetOutput() );
-  labelMapConverter->SetBackgroundValue( itk::NumericTraits< PixelType >::Zero );
+  labelMapConverter->SetInput(reader->GetOutput());
+  labelMapConverter->SetBackgroundValue(itk::NumericTraits<PixelType>::Zero);
 
-  using StructuringElementType = itk::FlatStructuringElement< Dimension >;
+  using StructuringElementType = itk::FlatStructuringElement<Dimension>;
   StructuringElementType::RadiusType radius;
-  radius.Fill( radiusValue );
+  radius.Fill(radiusValue);
 
-  StructuringElementType structuringElement = StructuringElementType::Ball( radius );
+  StructuringElementType structuringElement = StructuringElementType::Ball(radius);
 
-  using MorphologicalFilterType = itk::BinaryMorphologicalClosingImageFilter< ImageType, ImageType, StructuringElementType >;
+  using MorphologicalFilterType =
+    itk::BinaryMorphologicalClosingImageFilter<ImageType, ImageType, StructuringElementType>;
   MorphologicalFilterType::Pointer closingFilter = MorphologicalFilterType::New();
 
-  using ObjectByObjectLabelMapFilterType = itk::ObjectByObjectLabelMapFilter< LabelMapType >;
+  using ObjectByObjectLabelMapFilterType = itk::ObjectByObjectLabelMapFilter<LabelMapType>;
   ObjectByObjectLabelMapFilterType::Pointer objectByObjectLabelMapFilter = ObjectByObjectLabelMapFilterType::New();
-  objectByObjectLabelMapFilter->SetInput( labelMapConverter->GetOutput() );
-  objectByObjectLabelMapFilter->SetBinaryInternalOutput( true );
-  objectByObjectLabelMapFilter->SetFilter( closingFilter );
+  objectByObjectLabelMapFilter->SetInput(labelMapConverter->GetOutput());
+  objectByObjectLabelMapFilter->SetBinaryInternalOutput(true);
+  objectByObjectLabelMapFilter->SetFilter(closingFilter);
 
-  using UniqueLabelMapFilterType = itk::LabelUniqueLabelMapFilter< LabelMapType >;
+  using UniqueLabelMapFilterType = itk::LabelUniqueLabelMapFilter<LabelMapType>;
   UniqueLabelMapFilterType::Pointer unique = UniqueLabelMapFilterType::New();
-  unique->SetInput( objectByObjectLabelMapFilter->GetOutput() );
+  unique->SetInput(objectByObjectLabelMapFilter->GetOutput());
 
-  using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter< LabelMapType, ImageType >;
+  using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<LabelMapType, ImageType>;
   LabelMapToLabelImageFilterType::Pointer labelImageConverter = LabelMapToLabelImageFilterType::New();
-  labelImageConverter->SetInput( unique->GetOutput() );
+  labelImageConverter->SetInput(unique->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( labelImageConverter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(labelImageConverter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/LabelMap/ConvertImageToLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertImageToLabelMap/Code.cxx
@@ -22,75 +22,76 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter <ImageType, ImageType >;
-    ConnectedComponentImageFilterType::Pointer connectedComponentImageFilter
-            = ConnectedComponentImageFilterType::New ();
-    connectedComponentImageFilter->SetInput(image);
-    connectedComponentImageFilter->Update();
+  using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter<ImageType, ImageType>;
+  ConnectedComponentImageFilterType::Pointer connectedComponentImageFilter = ConnectedComponentImageFilterType::New();
+  connectedComponentImageFilter->SetInput(image);
+  connectedComponentImageFilter->Update();
 
-    using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter <ImageType>;
-    LabelImageToLabelMapFilterType::Pointer labelImageToLabelMapFilter
-            = LabelImageToLabelMapFilterType::New ();
-    labelImageToLabelMapFilter->SetInput(connectedComponentImageFilter->GetOutput());
-    labelImageToLabelMapFilter->Update();
+  using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter<ImageType>;
+  LabelImageToLabelMapFilterType::Pointer labelImageToLabelMapFilter = LabelImageToLabelMapFilterType::New();
+  labelImageToLabelMapFilter->SetInput(connectedComponentImageFilter->GetOutput());
+  labelImageToLabelMapFilter->Update();
 
-    // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
-    std::cout << "There are " << labelImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects." << std::endl;
+  // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
+  std::cout << "There are " << labelImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects."
+            << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    // Make another square
-    for(unsigned int r = 100; r < 130; r++)
+  // Make another square
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-        for(unsigned int c = 115; c < 160; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }
-

--- a/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/Code.cxx
@@ -22,74 +22,77 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter <ImageType, ImageType >;
-    ConnectedComponentImageFilterType::Pointer connectedComponentImageFilter
-            = ConnectedComponentImageFilterType::New ();
-    connectedComponentImageFilter->SetInput(image);
-    connectedComponentImageFilter->Update();
+  using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter<ImageType, ImageType>;
+  ConnectedComponentImageFilterType::Pointer connectedComponentImageFilter = ConnectedComponentImageFilterType::New();
+  connectedComponentImageFilter->SetInput(image);
+  connectedComponentImageFilter->Update();
 
-    using LabelImageToShapeLabelMapFilterType = itk::LabelImageToShapeLabelMapFilter <ImageType>;
-    LabelImageToShapeLabelMapFilterType::Pointer labelImageToShapeLabelMapFilter
-            = LabelImageToShapeLabelMapFilterType::New ();
-    labelImageToShapeLabelMapFilter->SetInput(connectedComponentImageFilter->GetOutput());
-    labelImageToShapeLabelMapFilter->Update();
+  using LabelImageToShapeLabelMapFilterType = itk::LabelImageToShapeLabelMapFilter<ImageType>;
+  LabelImageToShapeLabelMapFilterType::Pointer labelImageToShapeLabelMapFilter =
+    LabelImageToShapeLabelMapFilterType::New();
+  labelImageToShapeLabelMapFilter->SetInput(connectedComponentImageFilter->GetOutput());
+  labelImageToShapeLabelMapFilter->Update();
 
-    // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
-    std::cout << "There are " << labelImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects." << std::endl;
+  // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
+  std::cout << "There are " << labelImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects."
+            << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    // Make another square
-    for(unsigned int r = 100; r < 130; r++)
+  // Make another square
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-        for(unsigned int c = 115; c < 160; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }

--- a/src/Filtering/LabelMap/ConvertLabelMapToImage/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertLabelMapToImage/Code.cxx
@@ -22,62 +22,66 @@
 #include "itkLabelMapToLabelImageFilter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType>;
-    LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
-    labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
-    labelMapToLabelImageFilter->Update();
+  using LabelMapToLabelImageFilterType =
+    itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, ImageType>;
+  LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
+  labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
+  labelMapToLabelImageFilter->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make a square
-    while(!imageIterator.IsAtEnd())
+  // Make a square
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10) )
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
+    ++imageIterator;
+  }
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/LabelMap/ExtractGivenLabelObject/Code.cxx
+++ b/src/Filtering/LabelMap/ExtractGivenLabelObject/Code.cxx
@@ -24,65 +24,66 @@
 #include "itkLabelMapToLabelImageFilter.h"
 #include "itkLabelSelectionLabelMapFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName1> <OutputFileName2> <Label>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   const char * inputFileName = argv[1];
   const char * outputFileName[2];
   outputFileName[0] = argv[2];
   outputFileName[1] = argv[3];
-  const auto label = static_cast< PixelType >( std::stoi( argv[4] ) );
+  const auto label = static_cast<PixelType>(std::stoi(argv[4]));
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using LabelObjectType = itk::LabelObject< PixelType, Dimension >;
-  using LabelMapType = itk::LabelMap< LabelObjectType >;
+  using LabelObjectType = itk::LabelObject<PixelType, Dimension>;
+  using LabelMapType = itk::LabelMap<LabelObjectType>;
 
-  using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter< ImageType, LabelMapType >;
+  using LabelImageToLabelMapFilterType = itk::LabelImageToLabelMapFilter<ImageType, LabelMapType>;
   LabelImageToLabelMapFilterType::Pointer labelMapConverter = LabelImageToLabelMapFilterType::New();
-  labelMapConverter->SetInput( reader->GetOutput() );
-  labelMapConverter->SetBackgroundValue( itk::NumericTraits< PixelType >::Zero );
+  labelMapConverter->SetInput(reader->GetOutput());
+  labelMapConverter->SetBackgroundValue(itk::NumericTraits<PixelType>::Zero);
 
-  using SelectorType = itk::LabelSelectionLabelMapFilter< LabelMapType >;
+  using SelectorType = itk::LabelSelectionLabelMapFilter<LabelMapType>;
   SelectorType::Pointer selector = SelectorType::New();
-  selector->SetInput( labelMapConverter->GetOutput() );
-  selector->SetLabel( label );
+  selector->SetInput(labelMapConverter->GetOutput());
+  selector->SetLabel(label);
 
-  for( int i = 0; i < 2; i++ )
-    {
-    using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter< LabelMapType, ImageType >;
+  for (int i = 0; i < 2; i++)
+  {
+    using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<LabelMapType, ImageType>;
     LabelMapToLabelImageFilterType::Pointer labelImageConverter = LabelMapToLabelImageFilterType::New();
-    labelImageConverter->SetInput( selector->GetOutput( i ) );
+    labelImageConverter->SetInput(selector->GetOutput(i));
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
+    using WriterType = itk::ImageFileWriter<ImageType>;
     WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName( outputFileName[i] );
-    writer->SetInput( labelImageConverter->GetOutput() );
+    writer->SetFileName(outputFileName[i]);
+    writer->SetInput(labelImageConverter->GetOutput());
     try
-      {
+    {
       writer->Update();
-      }
-    catch( itk::ExceptionObject & error )
-      {
+    }
+    catch (itk::ExceptionObject & error)
+    {
       std::cerr << "Error: " << error << std::endl;
       return EXIT_FAILURE;
-      }
     }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/LabelMap/InvertImageUsingBinaryNot/Code.cxx
+++ b/src/Filtering/LabelMap/InvertImageUsingBinaryNot/Code.cxx
@@ -17,70 +17,70 @@
  *=========================================================================*/
 #include "itkImage.h"
 #if ITK_VERSION_MAJOR >= 4
-#include "itkBinaryNotImageFilter.h"
+#  include "itkBinaryNotImageFilter.h"
 #endif
 #include "itkImageRegionIterator.h"
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
 #if ITK_VERSION_MAJOR >= 4
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.png");
-    writer->SetInput(image);
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 
-    using BinaryNotImageFilterType = itk::BinaryNotImageFilter <ImageType>;
+  using BinaryNotImageFilterType = itk::BinaryNotImageFilter<ImageType>;
 
-    BinaryNotImageFilterType::Pointer binaryNotFilter
-            = BinaryNotImageFilterType::New();
-    binaryNotFilter->SetInput(image);
-    binaryNotFilter->Update();
+  BinaryNotImageFilterType::Pointer binaryNotFilter = BinaryNotImageFilterType::New();
+  binaryNotFilter->SetInput(image);
+  binaryNotFilter->Update();
 
-    writer->SetFileName("output.png");
-    writer->SetInput(binaryNotFilter->GetOutput());
-    writer->Update();
+  writer->SetFileName("output.png");
+  writer->SetInput(binaryNotFilter->GetOutput());
+  writer->Update();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 50)
     {
-        if(imageIterator.GetIndex()[0] > 50)
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
+    ++imageIterator;
+  }
 }
-

--- a/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/Code.cxx
+++ b/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/Code.cxx
@@ -19,85 +19,88 @@
 #include "itkImageFileWriter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-void CreateImage(ImageType::Pointer image1, ImageType::Pointer image2);
+void
+CreateImage(ImageType::Pointer image1, ImageType::Pointer image2);
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer binaryImage = ImageType::New();
-    ImageType::Pointer featureImage = ImageType::New();
+  ImageType::Pointer binaryImage = ImageType::New();
+  ImageType::Pointer featureImage = ImageType::New();
 
-    CreateImage(binaryImage, featureImage);
+  CreateImage(binaryImage, featureImage);
 
-    using BinaryOpeningType = itk::BinaryStatisticsOpeningImageFilter<ImageType, ImageType>;
-    BinaryOpeningType::Pointer opening = BinaryOpeningType::New();
-    opening->SetInput(binaryImage);
-    opening->SetFeatureImage(featureImage);
-    opening->SetBackgroundValue(0);
-    opening->SetForegroundValue(255);
-    opening->SetLambda(150);
-    opening->SetAttribute( BinaryOpeningType::LabelObjectType::MEAN);
-    opening->Update();
+  using BinaryOpeningType = itk::BinaryStatisticsOpeningImageFilter<ImageType, ImageType>;
+  BinaryOpeningType::Pointer opening = BinaryOpeningType::New();
+  opening->SetInput(binaryImage);
+  opening->SetFeatureImage(featureImage);
+  opening->SetBackgroundValue(0);
+  opening->SetForegroundValue(255);
+  opening->SetLambda(150);
+  opening->SetAttribute(BinaryOpeningType::LabelObjectType::MEAN);
+  opening->Update();
 
-    using WriterType = itk::ImageFileWriter<ImageType>;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.mhd");
-    writer->SetInput(featureImage);
-    writer->Update();
-    writer->SetFileName("output.mhd");
-    writer->SetInput(opening->GetOutput());
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.mhd");
+  writer->SetInput(featureImage);
+  writer->Update();
+  writer->SetFileName("output.mhd");
+  writer->SetInput(opening->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image1, ImageType::Pointer image2)
+void
+CreateImage(ImageType::Pointer image1, ImageType::Pointer image2)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    size[0] = 200;
-    size[1] = 200;
+  ImageType::SizeType size;
+  size[0] = 200;
+  size[1] = 200;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image1->SetRegions(region);
-    image1->Allocate();
-    image1->FillBuffer(0);
+  image1->SetRegions(region);
+  image1->Allocate();
+  image1->FillBuffer(0);
 
-    image2->SetRegions(region);
-    image2->Allocate();
-    image2->FillBuffer(0);
+  image2->SetRegions(region);
+  image2->Allocate();
+  image2->FillBuffer(0);
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image1->SetPixel(pixelIndex, 255);
-            image2->SetPixel(pixelIndex, 100);
-        }
+      image1->SetPixel(pixelIndex, 255);
+      image2->SetPixel(pixelIndex, 100);
     }
+  }
 
-    // Make another square
-    for(unsigned int r = 100; r < 130; r++)
+  // Make another square
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-        for(unsigned int c = 115; c < 160; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image1->SetPixel(pixelIndex, 255);
-            image2->SetPixel(pixelIndex, 200);
-        }
+      image1->SetPixel(pixelIndex, 255);
+      image2->SetPixel(pixelIndex, 200);
     }
+  }
 }

--- a/src/Filtering/LabelMap/KeepRegionsAboveLevel/Code.cxx
+++ b/src/Filtering/LabelMap/KeepRegionsAboveLevel/Code.cxx
@@ -25,93 +25,97 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 using LabelImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, LabelImageType>;
-    LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
-    labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
-    labelMapToLabelImageFilter->Update();
+  using LabelMapToLabelImageFilterType =
+    itk::LabelMapToLabelImageFilter<BinaryImageToLabelMapFilterType::OutputImageType, LabelImageType>;
+  LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
+  labelMapToLabelImageFilter->SetInput(binaryImageToLabelMapFilter->GetOutput());
+  labelMapToLabelImageFilter->Update();
 
-    using LabelShapeKeepNObjectsImageFilterType = itk::LabelShapeKeepNObjectsImageFilter< LabelImageType >;
-    LabelShapeKeepNObjectsImageFilterType::Pointer labelShapeKeepNObjectsImageFilter = LabelShapeKeepNObjectsImageFilterType::New();
-    labelShapeKeepNObjectsImageFilter->SetInput( labelMapToLabelImageFilter->GetOutput() );
-    labelShapeKeepNObjectsImageFilter->SetBackgroundValue( 0 );
-    labelShapeKeepNObjectsImageFilter->SetNumberOfObjects( 2 );
-    //KeepNObjects->ReverseOrderingOn();
-    //labelShapeKeepNObjectsImageFilter->SetAttribute( LabelObjectType::PERIMETER );
-    labelShapeKeepNObjectsImageFilter->SetAttribute( LabelShapeKeepNObjectsImageFilterType::LabelObjectType::PERIMETER);
-    labelShapeKeepNObjectsImageFilter->Update();
+  using LabelShapeKeepNObjectsImageFilterType = itk::LabelShapeKeepNObjectsImageFilter<LabelImageType>;
+  LabelShapeKeepNObjectsImageFilterType::Pointer labelShapeKeepNObjectsImageFilter =
+    LabelShapeKeepNObjectsImageFilterType::New();
+  labelShapeKeepNObjectsImageFilter->SetInput(labelMapToLabelImageFilter->GetOutput());
+  labelShapeKeepNObjectsImageFilter->SetBackgroundValue(0);
+  labelShapeKeepNObjectsImageFilter->SetNumberOfObjects(2);
+  // KeepNObjects->ReverseOrderingOn();
+  // labelShapeKeepNObjectsImageFilter->SetAttribute( LabelObjectType::PERIMETER );
+  labelShapeKeepNObjectsImageFilter->SetAttribute(LabelShapeKeepNObjectsImageFilterType::LabelObjectType::PERIMETER);
+  labelShapeKeepNObjectsImageFilter->Update();
 
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
-    using RGBImageType = itk::Image<RGBPixelType, 2>;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType, 2>;
 
-    // Color each label/object a different color
-    using RGBFilterType = itk::ScalarToRGBColormapImageFilter<LabelImageType, RGBImageType>;
-    RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
-    colormapImageFilter->SetInput(labelShapeKeepNObjectsImageFilter->GetOutput());
-    colormapImageFilter->SetColormap( itk::RGBColormapFilterEnumType::Jet );
-    colormapImageFilter->Update();
+  // Color each label/object a different color
+  using RGBFilterType = itk::ScalarToRGBColormapImageFilter<LabelImageType, RGBImageType>;
+  RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
+  colormapImageFilter->SetInput(labelShapeKeepNObjectsImageFilter->GetOutput());
+  colormapImageFilter->SetColormap(itk::RGBColormapFilterEnumType::Jet);
+  colormapImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< RGBImageType >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput( colormapImageFilter->GetOutput() );
-    writer->SetFileName("output.png");
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(colormapImageFilter->GetOutput());
+  writer->SetFileName("output.png");
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with three white squares
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with three white squares
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(200);
+  ImageType::SizeType size;
+  size.Fill(200);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make a square
-    while(!imageIterator.IsAtEnd())
+  // Make a square
+  while (!imageIterator.IsAtEnd())
+  {
+    if (((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
+         (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20)) ||
+        ((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 60) &&
+         (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 60)) ||
+        ((imageIterator.GetIndex()[0] > 100 && imageIterator.GetIndex()[0] < 130) &&
+         (imageIterator.GetIndex()[1] > 100 && imageIterator.GetIndex()[1] < 130)))
     {
-        if(((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 20) &&
-            (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 20)) ||
-           ((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 60) &&
-            (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 60)) ||
-           ((imageIterator.GetIndex()[0] > 100 && imageIterator.GetIndex()[0] < 130) &&
-            (imageIterator.GetIndex()[1] > 100 && imageIterator.GetIndex()[1] < 130))  )
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.png");
-    writer->SetInput(image);
-    writer->Update();
+    ++imageIterator;
+  }
 
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/Code.cxx
+++ b/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/Code.cxx
@@ -25,95 +25,100 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 using LabelImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    // Create a ShapeLabelMap from the image
-    using BinaryImageToShapeLabelMapFilterType = itk::BinaryImageToShapeLabelMapFilter<ImageType>;
-    BinaryImageToShapeLabelMapFilterType::Pointer binaryImageToShapeLabelMapFilter = BinaryImageToShapeLabelMapFilterType::New();
-    binaryImageToShapeLabelMapFilter->SetInput(image);
-    binaryImageToShapeLabelMapFilter->Update();
+  // Create a ShapeLabelMap from the image
+  using BinaryImageToShapeLabelMapFilterType = itk::BinaryImageToShapeLabelMapFilter<ImageType>;
+  BinaryImageToShapeLabelMapFilterType::Pointer binaryImageToShapeLabelMapFilter =
+    BinaryImageToShapeLabelMapFilterType::New();
+  binaryImageToShapeLabelMapFilter->SetInput(image);
+  binaryImageToShapeLabelMapFilter->Update();
 
-    // Remove label objects that have PERIMETER greater than 50
-    using ShapeOpeningLabelMapFilterType = itk::ShapeOpeningLabelMapFilter< BinaryImageToShapeLabelMapFilterType::OutputImageType >;
-    ShapeOpeningLabelMapFilterType::Pointer shapeOpeningLabelMapFilter = ShapeOpeningLabelMapFilterType::New();
-    shapeOpeningLabelMapFilter->SetInput( binaryImageToShapeLabelMapFilter->GetOutput() );
-    shapeOpeningLabelMapFilter->SetLambda( 50 );
-    shapeOpeningLabelMapFilter->ReverseOrderingOn();
-    shapeOpeningLabelMapFilter->SetAttribute( ShapeOpeningLabelMapFilterType::LabelObjectType::PERIMETER);
-    shapeOpeningLabelMapFilter->Update();
+  // Remove label objects that have PERIMETER greater than 50
+  using ShapeOpeningLabelMapFilterType =
+    itk::ShapeOpeningLabelMapFilter<BinaryImageToShapeLabelMapFilterType::OutputImageType>;
+  ShapeOpeningLabelMapFilterType::Pointer shapeOpeningLabelMapFilter = ShapeOpeningLabelMapFilterType::New();
+  shapeOpeningLabelMapFilter->SetInput(binaryImageToShapeLabelMapFilter->GetOutput());
+  shapeOpeningLabelMapFilter->SetLambda(50);
+  shapeOpeningLabelMapFilter->ReverseOrderingOn();
+  shapeOpeningLabelMapFilter->SetAttribute(ShapeOpeningLabelMapFilterType::LabelObjectType::PERIMETER);
+  shapeOpeningLabelMapFilter->Update();
 
-    // Create a label image
-    using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<BinaryImageToShapeLabelMapFilterType::OutputImageType, LabelImageType>;
-    LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
-    labelMapToLabelImageFilter->SetInput(shapeOpeningLabelMapFilter->GetOutput());
-    labelMapToLabelImageFilter->Update();
+  // Create a label image
+  using LabelMapToLabelImageFilterType =
+    itk::LabelMapToLabelImageFilter<BinaryImageToShapeLabelMapFilterType::OutputImageType, LabelImageType>;
+  LabelMapToLabelImageFilterType::Pointer labelMapToLabelImageFilter = LabelMapToLabelImageFilterType::New();
+  labelMapToLabelImageFilter->SetInput(shapeOpeningLabelMapFilter->GetOutput());
+  labelMapToLabelImageFilter->Update();
 
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
-    using RGBImageType = itk::Image<RGBPixelType, 2>;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType, 2>;
 
-    // Color each label/object a different color
-    using RGBFilterType = itk::ScalarToRGBColormapImageFilter<LabelImageType, RGBImageType>;
-    RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
-    colormapImageFilter->SetInput(labelMapToLabelImageFilter->GetOutput());
-    colormapImageFilter->SetColormap( itk::RGBColormapFilterEnumType::Jet );
-    colormapImageFilter->Update();
+  // Color each label/object a different color
+  using RGBFilterType = itk::ScalarToRGBColormapImageFilter<LabelImageType, RGBImageType>;
+  RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
+  colormapImageFilter->SetInput(labelMapToLabelImageFilter->GetOutput());
+  colormapImageFilter->SetColormap(itk::RGBColormapFilterEnumType::Jet);
+  colormapImageFilter->Update();
 
-    // Write the output
-    using WriterType = itk::ImageFileWriter< RGBImageType >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput( colormapImageFilter->GetOutput() );
-    writer->SetFileName("output.png");
-    writer->Update();
+  // Write the output
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(colormapImageFilter->GetOutput());
+  writer->SetFileName("output.png");
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with three white squares
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with three white squares
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(200);
+  ImageType::SizeType size;
+  size.Fill(200);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make a square
-    while(!imageIterator.IsAtEnd())
+  // Make a square
+  while (!imageIterator.IsAtEnd())
+  {
+    if (((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
+         (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10)) ||
+        ((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 60) &&
+         (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 60)) ||
+        ((imageIterator.GetIndex()[0] > 100 && imageIterator.GetIndex()[0] < 130) &&
+         (imageIterator.GetIndex()[1] > 100 && imageIterator.GetIndex()[1] < 130)))
     {
-        if(((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
-            (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10)) ||
-           ((imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 60) &&
-            (imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 60)) ||
-           ((imageIterator.GetIndex()[0] > 100 && imageIterator.GetIndex()[0] < 130) &&
-            (imageIterator.GetIndex()[1] > 100 && imageIterator.GetIndex()[1] < 130))  )
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.png");
-    writer->SetInput(image);
-    writer->Update();
+    ++imageIterator;
+  }
 
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
@@ -21,72 +21,78 @@
 #include "itkBinaryImageToShapeLabelMapFilter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToShapeLabelMapFilterType = itk::BinaryImageToShapeLabelMapFilter<ImageType>;
-    BinaryImageToShapeLabelMapFilterType::Pointer binaryImageToShapeLabelMapFilter = BinaryImageToShapeLabelMapFilterType::New();
-    binaryImageToShapeLabelMapFilter->SetInput(image);
-    binaryImageToShapeLabelMapFilter->Update();
+  using BinaryImageToShapeLabelMapFilterType = itk::BinaryImageToShapeLabelMapFilter<ImageType>;
+  BinaryImageToShapeLabelMapFilterType::Pointer binaryImageToShapeLabelMapFilter =
+    BinaryImageToShapeLabelMapFilterType::New();
+  binaryImageToShapeLabelMapFilter->SetInput(image);
+  binaryImageToShapeLabelMapFilter->Update();
 
-    // The output of this filter is an itk::ShapeLabelMap, which contains itk::ShapeLabelObject's
-    std::cout << "There are " << binaryImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects." << std::endl;
+  // The output of this filter is an itk::ShapeLabelMap, which contains itk::ShapeLabelObject's
+  std::cout << "There are " << binaryImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects."
+            << std::endl;
 
-    // Loop over all of the blobs
-    for(unsigned int i = 0; i < binaryImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
-    {
-        BinaryImageToShapeLabelMapFilterType::OutputImageType::LabelObjectType* labelObject = binaryImageToShapeLabelMapFilter->GetOutput()->GetNthLabelObject(i);
-        // Output the bounding box (an example of one possible property) of the ith region
+  // Loop over all of the blobs
+  for (unsigned int i = 0; i < binaryImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  {
+    BinaryImageToShapeLabelMapFilterType::OutputImageType::LabelObjectType * labelObject =
+      binaryImageToShapeLabelMapFilter->GetOutput()->GetNthLabelObject(i);
+    // Output the bounding box (an example of one possible property) of the ith region
 #if ITK_VERSION_MAJOR >= 4
-        std::cout << "Object " << i << " has bounding box " << labelObject->GetBoundingBox() << std::endl;
+    std::cout << "Object " << i << " has bounding box " << labelObject->GetBoundingBox() << std::endl;
 #else
-        std::cout << "Object " << i << " has region " << labelObject->GetRegion() << std::endl;
+    std::cout << "Object " << i << " has region " << labelObject->GetRegion() << std::endl;
 #endif
-    }
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make a square
-    while(!imageIterator.IsAtEnd())
+  // Make a square
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10) )
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
+    ++imageIterator;
+  }
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
@@ -21,73 +21,78 @@
 #include "itkBinaryImageToLabelMapFilter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
-    std::cout << "There are " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects." << std::endl;
+  // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
+  std::cout << "There are " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects."
+            << std::endl;
 
-    // Loop over each region
-    for(unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  // Loop over each region
+  for (unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  {
+    // Get the ith region
+    BinaryImageToLabelMapFilterType::OutputImageType::LabelObjectType * labelObject =
+      binaryImageToLabelMapFilter->GetOutput()->GetNthLabelObject(i);
+
+    // Output the pixels composing the region
+    for (unsigned int pixelId = 0; pixelId < labelObject->Size(); pixelId++)
     {
-        // Get the ith region
-        BinaryImageToLabelMapFilterType::OutputImageType::LabelObjectType* labelObject = binaryImageToLabelMapFilter->GetOutput()->GetNthLabelObject(i);
-
-        // Output the pixels composing the region
-        for(unsigned int pixelId = 0; pixelId < labelObject->Size(); pixelId++)
-        {
-            std::cout << "Object " << i << " contains pixel " << labelObject->GetIndex(pixelId) << std::endl;
-        }
+      std::cout << "Object " << i << " contains pixel " << labelObject->GetIndex(pixelId) << std::endl;
     }
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make a square
-    while(!imageIterator.IsAtEnd())
+  // Make a square
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10) )
-        {
-            imageIterator.Set(255);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(255);
+    }
+    else
+    {
+      imageIterator.Set(0);
     }
 
-    using WriterType = itk::ImageFileWriter< ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
+    ++imageIterator;
+  }
+
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/Code.cxx
@@ -23,96 +23,97 @@
 #include "itkLabelImageToLabelMapFilter.h"
 #include "itkLabelMapMaskImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( ( argc != 6 ) && ( argc != 9 ) )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if ((argc != 6) && (argc != 9))
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <LabelMapFileName> <OutputFileName> <Label> <Background>";
     std::cerr << " [<negated (bool)> <crop (bool)> <border size>]";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  const char * inputFileName = argv[1];
-  const char * labelMapFileName = argv[2];
-  const char * outputFileName = argv[3];
-  const auto label = static_cast< PixelType >( std::stoi( argv[4] ) );
-  const auto background = static_cast< PixelType >( std::stoi( argv[5] ) );
-  bool negated                              = false;
-  bool crop                                 = false;
+  const char *             inputFileName = argv[1];
+  const char *             labelMapFileName = argv[2];
+  const char *             outputFileName = argv[3];
+  const auto               label = static_cast<PixelType>(std::stoi(argv[4]));
+  const auto               background = static_cast<PixelType>(std::stoi(argv[5]));
+  bool                     negated = false;
+  bool                     crop = false;
   ImageType::SizeValueType borderSize = 0;
 
-  if( argc == 9 )
+  if (argc == 9)
   {
-    negated = ( std::stoi( argv[6] ) == 1 );
-    crop    = ( std::stoi( argv[7] ) == 1 );
-    borderSize = static_cast< ImageType::SizeValueType >( std::stoi( argv[8] ) );
+    negated = (std::stoi(argv[6]) == 1);
+    crop = (std::stoi(argv[7]) == 1);
+    borderSize = static_cast<ImageType::SizeValueType>(std::stoi(argv[8]));
   }
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader1 = ReaderType::New();
-  reader1->SetFileName( inputFileName );
+  reader1->SetFileName(inputFileName);
 
   ReaderType::Pointer reader2 = ReaderType::New();
-  reader2->SetFileName( labelMapFileName );
+  reader2->SetFileName(labelMapFileName);
 
-  using LabelObjectType = itk::LabelObject< PixelType, Dimension >;
-  using LabelMapType = itk::LabelMap< LabelObjectType >;
+  using LabelObjectType = itk::LabelObject<PixelType, Dimension>;
+  using LabelMapType = itk::LabelMap<LabelObjectType>;
 
   // convert the label image into a LabelMap
-  using LabelImage2LabelMapType = itk::LabelImageToLabelMapFilter< ImageType, LabelMapType >;
+  using LabelImage2LabelMapType = itk::LabelImageToLabelMapFilter<ImageType, LabelMapType>;
   LabelImage2LabelMapType::Pointer convert = LabelImage2LabelMapType::New();
-  convert->SetInput( reader2->GetOutput() );
+  convert->SetInput(reader2->GetOutput());
 
-  using FilterType = itk::LabelMapMaskImageFilter< LabelMapType, ImageType >;
+  using FilterType = itk::LabelMapMaskImageFilter<LabelMapType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( convert->GetOutput() );
-  filter->SetFeatureImage( reader1->GetOutput() );
+  filter->SetInput(convert->GetOutput());
+  filter->SetFeatureImage(reader1->GetOutput());
 
   // The label to be used to mask the image is passed via SetLabel
-  filter->SetLabel( label );
+  filter->SetLabel(label);
 
   // The background in the output image (where the image is masked)
   // is passed via SetBackground
-  filter->SetBackgroundValue( background );
+  filter->SetBackgroundValue(background);
 
   // The user can choose to mask the image outside the label object
   // (default behavior), or inside the label object with the chosen label,
   // by calling SetNegated().
-  filter->SetNegated( negated );
+  filter->SetNegated(negated);
 
   // Finally, the image can be cropped to the masked region, by calling
   // SetCrop( true ), or to a region padded by a border, by calling both
   // SetCrop() and SetCropBorder().
   // The crop border defaults to 0, and the image is not cropped by default.
-  filter->SetCrop( crop );
+  filter->SetCrop(crop);
 
   FilterType::SizeType border;
-  border.Fill( borderSize );
+  border.Fill(borderSize);
 
-  filter->SetCropBorder( border );
+  filter->SetCropBorder(border);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/LabelMap/MergeLabelMaps/Code.cxx
+++ b/src/Filtering/LabelMap/MergeLabelMaps/Code.cxx
@@ -18,37 +18,37 @@
 #include "itkBinaryImageToShapeLabelMapFilter.h"
 #include "itkMergeLabelMapFilter.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    using ImageType = itk::Image<int, 3>;
+  using ImageType = itk::Image<int, 3>;
 
-    //Binary Image to Shape Label Map.
-    using BI2SLMType = itk::BinaryImageToShapeLabelMapFilter<ImageType>;
-    using LabelMapType = BI2SLMType::OutputImageType;
-    using LabelObjectType = BI2SLMType::LabelObjectType;
+  // Binary Image to Shape Label Map.
+  using BI2SLMType = itk::BinaryImageToShapeLabelMapFilter<ImageType>;
+  using LabelMapType = BI2SLMType::OutputImageType;
+  using LabelObjectType = BI2SLMType::LabelObjectType;
 
-    using MergerType = itk::MergeLabelMapFilter<LabelMapType>;
-    MergerType::Pointer merger = MergerType::New();
-    merger->SetMethod(itk::ChoiceMethod::PACK);
+  using MergerType = itk::MergeLabelMapFilter<LabelMapType>;
+  MergerType::Pointer merger = MergerType::New();
+  merger->SetMethod(itk::ChoiceMethod::PACK);
 
-    int noObjects = 4;
+  int noObjects = 4;
 
-    for (int i = 1; i <= noObjects; i++)
-    {
-        LabelMapType::Pointer labelMap = LabelMapType::New();
-        LabelObjectType::Pointer labelObject = LabelObjectType::New();
+  for (int i = 1; i <= noObjects; i++)
+  {
+    LabelMapType::Pointer    labelMap = LabelMapType::New();
+    LabelObjectType::Pointer labelObject = LabelObjectType::New();
 
-        labelObject->SetLabel(1);
-        labelMap->AddLabelObject(labelObject);
-        labelMap->Update();
+    labelObject->SetLabel(1);
+    labelMap->AddLabelObject(labelObject);
+    labelMap->Update();
 
-        merger->SetInput(i - 1, labelMap);
-    }
+    merger->SetInput(i - 1, labelMap);
+  }
 
-    merger->Update();
-    std::cout << "number of objects:  "
-              << merger->GetOutput()->GetNumberOfLabelObjects() << "\n";
-    std::cout << "number of expected objects:  " << noObjects << "\n";
+  merger->Update();
+  std::cout << "number of objects:  " << merger->GetOutput()->GetNumberOfLabelObjects() << "\n";
+  std::cout << "number of expected objects:  " << noObjects << "\n";
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/Code.cxx
+++ b/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/Code.cxx
@@ -20,16 +20,17 @@
 #include "itkImageFileWriter.h"
 #include "itkBinaryFillholeImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -37,30 +38,30 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::BinaryFillholeImageFilter< ImageType >;
+  using FilterType = itk::BinaryFillholeImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetForegroundValue( itk::NumericTraits< PixelType >::min() );
+  filter->SetInput(reader->GetOutput());
+  filter->SetForegroundValue(itk::NumericTraits<PixelType>::min());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
@@ -21,74 +21,80 @@
 #include "itkBinaryImageToLabelMapFilter.h"
 
 using ImageType = itk::Image<unsigned char, 2>;
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
-    BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
-    binaryImageToLabelMapFilter->SetInput(image);
-    binaryImageToLabelMapFilter->Update();
+  using BinaryImageToLabelMapFilterType = itk::BinaryImageToLabelMapFilter<ImageType>;
+  BinaryImageToLabelMapFilterType::Pointer binaryImageToLabelMapFilter = BinaryImageToLabelMapFilterType::New();
+  binaryImageToLabelMapFilter->SetInput(image);
+  binaryImageToLabelMapFilter->Update();
 
-    // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
-    std::cout << "There are " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects." << std::endl;
+  // The output of this filter is an itk::LabelMap, which contains itk::LabelObject's
+  std::cout << "There are " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects."
+            << std::endl;
 
-    std::vector<unsigned long> labelsToRemove;
+  std::vector<unsigned long> labelsToRemove;
 
-    std::cout << "There are originally " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects() << " objects." << std::endl;
+  std::cout << "There are originally " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects()
+            << " objects." << std::endl;
 
-    // Note: do NOT remove the labels inside the loop! The IDs are stored such that they will change when one is deleted.
-    // Instead, mark all of the labels to be removed first and then remove them all together.
-    for(unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  // Note: do NOT remove the labels inside the loop! The IDs are stored such that they will change when one is deleted.
+  // Instead, mark all of the labels to be removed first and then remove them all together.
+  for (unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  {
+    // Get the ith region
+    BinaryImageToLabelMapFilterType::OutputImageType::LabelObjectType * labelObject =
+      binaryImageToLabelMapFilter->GetOutput()->GetNthLabelObject(i);
+    // std::cout << "Region " << i << " has " << labelObject->Size() << " pixels." << std::endl;
+
+    // Mark every other label to be removed
+    if (i % 2 == 0)
     {
-        // Get the ith region
-        BinaryImageToLabelMapFilterType::OutputImageType::LabelObjectType* labelObject = binaryImageToLabelMapFilter->GetOutput()->GetNthLabelObject(i);
-        //std::cout << "Region " << i << " has " << labelObject->Size() << " pixels." << std::endl;
-
-        // Mark every other label to be removed
-        if(i%2 == 0)
-        {
-            labelsToRemove.push_back(labelObject->GetLabel());
-        }
+      labelsToRemove.push_back(labelObject->GetLabel());
     }
+  }
 
-    std::cout << "Removing " << labelsToRemove.size() << " objects." << std::endl;
-    // Remove all regions that were marked for removal.
-    for(unsigned long i : labelsToRemove)
-    {
-        binaryImageToLabelMapFilter->GetOutput()->RemoveLabel(i);
-    }
+  std::cout << "Removing " << labelsToRemove.size() << " objects." << std::endl;
+  // Remove all regions that were marked for removal.
+  for (unsigned long i : labelsToRemove)
+  {
+    binaryImageToLabelMapFilter->GetOutput()->RemoveLabel(i);
+  }
 
-    std::cout << "There are " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects()
-              << " objects remaining." << std::endl;
+  std::cout << "There are " << binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects()
+            << " objects remaining." << std::endl;
 
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  ImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make line of non-touching diagonal pixels
-    for(unsigned int i = 0; i < 20; i+=2)
-    {
-        itk::Index<2> pixel;
-        pixel[0] = i;
-        pixel[1] = i;
-        image->SetPixel(pixel, 255);
-    }
+  // Make line of non-touching diagonal pixels
+  for (unsigned int i = 0; i < 20; i += 2)
+  {
+    itk::Index<2> pixel;
+    pixel[0] = i;
+    pixel[1] = i;
+    image->SetPixel(pixel, 255);
+  }
 }

--- a/src/Filtering/LabelMap/ShapeAttributesForBinaryImage/Code.cxx
+++ b/src/Filtering/LabelMap/ShapeAttributesForBinaryImage/Code.cxx
@@ -21,140 +21,125 @@
 #include "itkLabelImageToShapeLabelMapFilter.h"
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    constexpr unsigned int Dimension = 2;
-    using PixelType = unsigned char;
-    using LabelType = unsigned short;
-    using InputImageType = itk::Image<PixelType, Dimension>;
-    using OutputImageType = itk::Image< LabelType, Dimension >;
-    using ShapeLabelObjectType = itk::ShapeLabelObject< LabelType, Dimension >;
-    using LabelMapType = itk::LabelMap< ShapeLabelObjectType >;
+  constexpr unsigned int Dimension = 2;
+  using PixelType = unsigned char;
+  using LabelType = unsigned short;
+  using InputImageType = itk::Image<PixelType, Dimension>;
+  using OutputImageType = itk::Image<LabelType, Dimension>;
+  using ShapeLabelObjectType = itk::ShapeLabelObject<LabelType, Dimension>;
+  using LabelMapType = itk::LabelMap<ShapeLabelObjectType>;
 
-    std::string fileName;
-    InputImageType::Pointer image;
-    if( argc < 2 )
-    {
-        image = InputImageType::New();
-        CreateImage(image.GetPointer());
-        fileName = "Generated image";
-    }
-    else
-    {
-        fileName = argv[1];
-        using ReaderType = itk::ImageFileReader<InputImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(fileName);
-        reader->Update();
+  std::string             fileName;
+  InputImageType::Pointer image;
+  if (argc < 2)
+  {
+    image = InputImageType::New();
+    CreateImage(image.GetPointer());
+    fileName = "Generated image";
+  }
+  else
+  {
+    fileName = argv[1];
+    using ReaderType = itk::ImageFileReader<InputImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(fileName);
+    reader->Update();
 
-        image = reader->GetOutput();
-    }
+    image = reader->GetOutput();
+  }
 
 
-    using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter <InputImageType, OutputImageType >;
-    using I2LType = itk::LabelImageToShapeLabelMapFilter< OutputImageType, LabelMapType>;
+  using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter<InputImageType, OutputImageType>;
+  using I2LType = itk::LabelImageToShapeLabelMapFilter<OutputImageType, LabelMapType>;
 
-    ConnectedComponentImageFilterType::Pointer connected =
-            ConnectedComponentImageFilterType::New ();
-    connected->SetInput(image);
-    connected->Update();
+  ConnectedComponentImageFilterType::Pointer connected = ConnectedComponentImageFilterType::New();
+  connected->SetInput(image);
+  connected->Update();
 
-    using I2LType = itk::LabelImageToShapeLabelMapFilter< OutputImageType, LabelMapType>;
-    I2LType::Pointer i2l = I2LType::New();
-    i2l->SetInput( connected->GetOutput() );
-    i2l->SetComputePerimeter(true);
-    i2l->Update();
+  using I2LType = itk::LabelImageToShapeLabelMapFilter<OutputImageType, LabelMapType>;
+  I2LType::Pointer i2l = I2LType::New();
+  i2l->SetInput(connected->GetOutput());
+  i2l->SetComputePerimeter(true);
+  i2l->Update();
 
-    LabelMapType *labelMap = i2l->GetOutput();
-    std::cout << "File " << "\"" << fileName << "\""
-              << " has " << labelMap->GetNumberOfLabelObjects() << " labels." << std::endl;
+  LabelMapType * labelMap = i2l->GetOutput();
+  std::cout << "File "
+            << "\"" << fileName << "\""
+            << " has " << labelMap->GetNumberOfLabelObjects() << " labels." << std::endl;
 
-    // Retrieve all attributes
-    for (unsigned int n = 0; n < labelMap->GetNumberOfLabelObjects(); ++n)
-    {
-        ShapeLabelObjectType *labelObject = labelMap->GetNthLabelObject(n);
-        std::cout << "Label: "
-                  << itk::NumericTraits<LabelMapType::LabelType>::PrintType(labelObject->GetLabel()) << std::endl;
-        std::cout << "    BoundingBox: "
-                  << labelObject->GetBoundingBox() << std::endl;
-        std::cout << "    NumberOfPixels: "
-                  << labelObject->GetNumberOfPixels() << std::endl;
-        std::cout << "    PhysicalSize: "
-                  << labelObject->GetPhysicalSize() << std::endl;
-        std::cout << "    Centroid: "
-                  << labelObject->GetCentroid() << std::endl;
-        std::cout << "    NumberOfPixelsOnBorder: "
-                  << labelObject->GetNumberOfPixelsOnBorder() << std::endl;
-        std::cout << "    PerimeterOnBorder: "
-                  << labelObject->GetPerimeterOnBorder() << std::endl;
-        std::cout << "    FeretDiameter: "
-                  << labelObject->GetFeretDiameter() << std::endl;
-        std::cout << "    PrincipalMoments: "
-                  << labelObject->GetPrincipalMoments() << std::endl;
-        std::cout << "    PrincipalAxes: "
-                  << labelObject->GetPrincipalAxes() << std::endl;
-        std::cout << "    Elongation: "
-                  << labelObject->GetElongation() << std::endl;
-        std::cout << "    Perimeter: "
-                  << labelObject->GetPerimeter() << std::endl;
-        std::cout << "    Roundness: "
-                  << labelObject->GetRoundness() << std::endl;
-        std::cout << "    EquivalentSphericalRadius: "
-                  << labelObject->GetEquivalentSphericalRadius() << std::endl;
-        std::cout << "    EquivalentSphericalPerimeter: "
-                  << labelObject->GetEquivalentSphericalPerimeter() << std::endl;
-        std::cout << "    EquivalentEllipsoidDiameter: "
-                  << labelObject->GetEquivalentEllipsoidDiameter() << std::endl;
-        std::cout << "    Flatness: "
-                  << labelObject->GetFlatness() << std::endl;
-        std::cout << "    PerimeterOnBorderRatio: "
-                  << labelObject->GetPerimeterOnBorderRatio() << std::endl;
-    }
+  // Retrieve all attributes
+  for (unsigned int n = 0; n < labelMap->GetNumberOfLabelObjects(); ++n)
+  {
+    ShapeLabelObjectType * labelObject = labelMap->GetNthLabelObject(n);
+    std::cout << "Label: " << itk::NumericTraits<LabelMapType::LabelType>::PrintType(labelObject->GetLabel())
+              << std::endl;
+    std::cout << "    BoundingBox: " << labelObject->GetBoundingBox() << std::endl;
+    std::cout << "    NumberOfPixels: " << labelObject->GetNumberOfPixels() << std::endl;
+    std::cout << "    PhysicalSize: " << labelObject->GetPhysicalSize() << std::endl;
+    std::cout << "    Centroid: " << labelObject->GetCentroid() << std::endl;
+    std::cout << "    NumberOfPixelsOnBorder: " << labelObject->GetNumberOfPixelsOnBorder() << std::endl;
+    std::cout << "    PerimeterOnBorder: " << labelObject->GetPerimeterOnBorder() << std::endl;
+    std::cout << "    FeretDiameter: " << labelObject->GetFeretDiameter() << std::endl;
+    std::cout << "    PrincipalMoments: " << labelObject->GetPrincipalMoments() << std::endl;
+    std::cout << "    PrincipalAxes: " << labelObject->GetPrincipalAxes() << std::endl;
+    std::cout << "    Elongation: " << labelObject->GetElongation() << std::endl;
+    std::cout << "    Perimeter: " << labelObject->GetPerimeter() << std::endl;
+    std::cout << "    Roundness: " << labelObject->GetRoundness() << std::endl;
+    std::cout << "    EquivalentSphericalRadius: " << labelObject->GetEquivalentSphericalRadius() << std::endl;
+    std::cout << "    EquivalentSphericalPerimeter: " << labelObject->GetEquivalentSphericalPerimeter() << std::endl;
+    std::cout << "    EquivalentEllipsoidDiameter: " << labelObject->GetEquivalentEllipsoidDiameter() << std::endl;
+    std::cout << "    Flatness: " << labelObject->GetFlatness() << std::endl;
+    std::cout << "    PerimeterOnBorderRatio: " << labelObject->GetPerimeterOnBorderRatio() << std::endl;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
-    // Create an image with 2 objects
-    typename TImage::IndexType start = {{0,0}};
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 objects
+  typename TImage::IndexType start = { { 0, 0 } };
+  start[0] = 0;
+  start[1] = 0;
 
-    typename TImage::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  typename TImage::SizeType size;
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    typename TImage::RegionType region(start, size);
+  typename TImage::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(typename TImage::IndexValueType r = 20; r < 80; ++r)
+  // Make a square
+  for (typename TImage::IndexValueType r = 20; r < 80; ++r)
+  {
+    for (typename TImage::IndexValueType c = 30; c < 100; ++c)
     {
-        for(typename TImage::IndexValueType c = 30; c < 100; ++c)
-        {
-            typename TImage::IndexType pixelIndex = {{r,c}};
+      typename TImage::IndexType pixelIndex = { { r, c } };
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    // Make another square
-    for(typename TImage::IndexValueType r = 100; r < 130; ++r)
+  // Make another square
+  for (typename TImage::IndexValueType r = 100; r < 130; ++r)
+  {
+    for (typename TImage::IndexValueType c = 115; c < 160; ++c)
     {
-        for(typename TImage::IndexValueType c = 115; c < 160; ++c)
-        {
-            typename TImage::IndexType pixelIndex = {{r,c}};
+      typename TImage::IndexType pixelIndex = { { r, c } };
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }
-

--- a/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/Code.cxx
@@ -18,12 +18,13 @@
 
 #include "itkBinaryBallStructuringElement.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   constexpr unsigned int Dimension = 3;
   using PixelType = float;
 
-  using StructuringElementType = itk::BinaryBallStructuringElement< PixelType, Dimension >;
+  using StructuringElementType = itk::BinaryBallStructuringElement<PixelType, Dimension>;
   StructuringElementType structuringElement;
   structuringElement.SetRadius(5);
   structuringElement.CreateStructuringElement();

--- a/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/Code.cxx
@@ -22,55 +22,53 @@
 #include "itkFlatStructuringElement.h"
 #include "itkGrayscaleDilateImageFilter.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc < 4 )
-    {
+  if (argc < 4)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " <inputImage> <outputImage> <radius>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
-  const char * inputImage = argv[1];
-  const char * outputImage = argv[2];
-  const unsigned int radiusValue = std::stoi( argv[3] );
+  }
+  const char *       inputImage = argv[1];
+  const char *       outputImage = argv[2];
+  const unsigned int radiusValue = std::stoi(argv[3]);
 
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using StructuringElementType = itk::FlatStructuringElement< Dimension >;
+  using StructuringElementType = itk::FlatStructuringElement<Dimension>;
   StructuringElementType::RadiusType radius;
-  radius.Fill( radiusValue );
-  StructuringElementType structuringElement =
-    StructuringElementType::Ball( radius );
+  radius.Fill(radiusValue);
+  StructuringElementType structuringElement = StructuringElementType::Ball(radius);
 
-  using GrayscaleDilateImageFilterType = itk::GrayscaleDilateImageFilter< ImageType, ImageType,
-    StructuringElementType >;
+  using GrayscaleDilateImageFilterType = itk::GrayscaleDilateImageFilter<ImageType, ImageType, StructuringElementType>;
 
-  GrayscaleDilateImageFilterType::Pointer dilateFilter =
-    GrayscaleDilateImageFilterType::New();
-  dilateFilter->SetInput( reader->GetOutput() );
-  dilateFilter->SetKernel( structuringElement );
+  GrayscaleDilateImageFilterType::Pointer dilateFilter = GrayscaleDilateImageFilterType::New();
+  dilateFilter->SetInput(reader->GetOutput());
+  dilateFilter->SetKernel(structuringElement);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( dilateFilter->GetOutput() );
-  writer->SetFileName( outputImage );
+  writer->SetInput(dilateFilter->GetOutput());
+  writer->SetFileName(outputImage);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/Code.cxx
@@ -22,55 +22,53 @@
 #include "itkGrayscaleErodeImageFilter.h"
 #include "itkFlatStructuringElement.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 4 )
-    {
+  if (argc < 4)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " <inputImage> <outputImage> <radius>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
-  const char * inputImage = argv[1];
-  const char * outputImage = argv[2];
-  const unsigned int radiusValue = std::stoi( argv[3] );
+  }
+  const char *       inputImage = argv[1];
+  const char *       outputImage = argv[2];
+  const unsigned int radiusValue = std::stoi(argv[3]);
 
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImage );
+  reader->SetFileName(inputImage);
 
-  using StructuringElementType = itk::FlatStructuringElement< Dimension >;
+  using StructuringElementType = itk::FlatStructuringElement<Dimension>;
   StructuringElementType::RadiusType radius;
-  radius.Fill( radiusValue );
-  StructuringElementType structuringElement =
-    StructuringElementType::Ball( radius );
+  radius.Fill(radiusValue);
+  StructuringElementType structuringElement = StructuringElementType::Ball(radius);
 
-  using GrayscaleErodeImageFilterType = itk::GrayscaleErodeImageFilter< ImageType, ImageType,
-    StructuringElementType >;
+  using GrayscaleErodeImageFilterType = itk::GrayscaleErodeImageFilter<ImageType, ImageType, StructuringElementType>;
 
-  GrayscaleErodeImageFilterType::Pointer erodeFilter =
-    GrayscaleErodeImageFilterType::New();
-  erodeFilter->SetInput( reader->GetOutput() );
-  erodeFilter->SetKernel( structuringElement );
+  GrayscaleErodeImageFilterType::Pointer erodeFilter = GrayscaleErodeImageFilterType::New();
+  erodeFilter->SetInput(reader->GetOutput());
+  erodeFilter->SetKernel(structuringElement);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( erodeFilter->GetOutput() );
-  writer->SetFileName( outputImage );
+  writer->SetInput(erodeFilter->GetOutput());
+  writer->SetFileName(outputImage);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/Code.cxx
@@ -20,48 +20,48 @@
 #include "itkBinaryErodeImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 2)
-    {
-        std::cerr << argv[0] << " InputImageFile [radius]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << argv[0] << " InputImageFile [radius]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    unsigned int radius = 2;
-    if (argc > 2)
-    {
-        radius = std::stoi(argv[2]);
-    }
+  unsigned int radius = 2;
+  if (argc > 2)
+  {
+    radius = std::stoi(argv[2]);
+  }
 
-    using ImageType = itk::Image<unsigned char, 2>;
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(argv[1]);
+  using ImageType = itk::Image<unsigned char, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
-    using StructuringElementType = itk::FlatStructuringElement<2>;
-    StructuringElementType::RadiusType elementRadius;
-    elementRadius.Fill(radius);
+  using StructuringElementType = itk::FlatStructuringElement<2>;
+  StructuringElementType::RadiusType elementRadius;
+  elementRadius.Fill(radius);
 
-    StructuringElementType structuringElement = StructuringElementType::Box(elementRadius);
+  StructuringElementType structuringElement = StructuringElementType::Box(elementRadius);
 
-    using BinaryErodeImageFilterType = itk::BinaryErodeImageFilter <ImageType, ImageType, StructuringElementType>;
+  using BinaryErodeImageFilterType = itk::BinaryErodeImageFilter<ImageType, ImageType, StructuringElementType>;
 
-    BinaryErodeImageFilterType::Pointer erodeFilter
-            = BinaryErodeImageFilterType::New();
-    erodeFilter->SetInput(reader->GetOutput());
-    erodeFilter->SetKernel(structuringElement);
-    erodeFilter->SetErodeValue(255);
+  BinaryErodeImageFilterType::Pointer erodeFilter = BinaryErodeImageFilterType::New();
+  erodeFilter->SetInput(reader->GetOutput());
+  erodeFilter->SetKernel(structuringElement);
+  erodeFilter->SetErodeValue(255);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(reader->GetOutput());
-    viewer.AddImage(erodeFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput());
+  viewer.AddImage(erodeFilter->GetOutput());
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
@@ -18,177 +18,167 @@
 #include "itkFlatStructuringElement.h"
 
 // Helper function
-template< class SEType>
-bool ComputeAreaError(SEType k, unsigned int thickness = 0);
+template <class SEType>
+bool
+ComputeAreaError(SEType k, unsigned int thickness = 0);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    int scalarRadius = 5;
-    int scalarThickness = 2;
-    bool radiusIsParametric = true;
+  int  scalarRadius = 5;
+  int  scalarThickness = 2;
+  bool radiusIsParametric = true;
 
-    using SE2Type = itk::FlatStructuringElement< 2 >;
-    SE2Type::RadiusType r2;
-    r2.Fill( scalarRadius );
-    SE2Type k2;
+  using SE2Type = itk::FlatStructuringElement<2>;
+  SE2Type::RadiusType r2;
+  r2.Fill(scalarRadius);
+  SE2Type k2;
 
-    std::cout << "2D ball of radius " << scalarRadius
-              << " with radiusIsParametric mode off:" << std::endl;
-    k2 = SE2Type::Ball( r2 );
-    ComputeAreaError(k2);
+  std::cout << "2D ball of radius " << scalarRadius << " with radiusIsParametric mode off:" << std::endl;
+  k2 = SE2Type::Ball(r2);
+  ComputeAreaError(k2);
 
-    // Test the radiusIsParametric mode.
-    std::cout << "2D ball of radius " << scalarRadius
-              << " with radiusIsParametric mode on:" << std::endl;
-    k2 = SE2Type::Ball(r2, radiusIsParametric);
-    ComputeAreaError(k2);
+  // Test the radiusIsParametric mode.
+  std::cout << "2D ball of radius " << scalarRadius << " with radiusIsParametric mode on:" << std::endl;
+  k2 = SE2Type::Ball(r2, radiusIsParametric);
+  ComputeAreaError(k2);
 
-    std::cout << "2D annulus of radius " << scalarRadius
-              << " and thickness " <<  scalarThickness
-              << " with radiusIsParametric mode off:" << std::endl;
-    k2 = SE2Type::Annulus(r2,scalarThickness,false);
-    ComputeAreaError(k2,scalarThickness);
+  std::cout << "2D annulus of radius " << scalarRadius << " and thickness " << scalarThickness
+            << " with radiusIsParametric mode off:" << std::endl;
+  k2 = SE2Type::Annulus(r2, scalarThickness, false);
+  ComputeAreaError(k2, scalarThickness);
 
-    // Test the radiusIsParametric mode.
-    std::cout << "2D annulus of radius " << scalarRadius
-              << " and thickness " <<  scalarThickness
-              << " with radiusIsParametric mode on:" << std::endl;
-    k2 = SE2Type::Annulus(r2,scalarThickness,false,radiusIsParametric);
-    ComputeAreaError(k2,scalarThickness);
+  // Test the radiusIsParametric mode.
+  std::cout << "2D annulus of radius " << scalarRadius << " and thickness " << scalarThickness
+            << " with radiusIsParametric mode on:" << std::endl;
+  k2 = SE2Type::Annulus(r2, scalarThickness, false, radiusIsParametric);
+  ComputeAreaError(k2, scalarThickness);
 
-    using SE3Type = itk::FlatStructuringElement< 3 >;
-    SE3Type::RadiusType r3;
-    r3.Fill( scalarRadius );
-    SE3Type k3;
+  using SE3Type = itk::FlatStructuringElement<3>;
+  SE3Type::RadiusType r3;
+  r3.Fill(scalarRadius);
+  SE3Type k3;
 
-    std::cout << "3D ball of radius " << scalarRadius
-              << " with radiusIsParametric mode off:" << std::endl;
-    k3 = SE3Type::Ball( r3 );
-    ComputeAreaError(k3);
+  std::cout << "3D ball of radius " << scalarRadius << " with radiusIsParametric mode off:" << std::endl;
+  k3 = SE3Type::Ball(r3);
+  ComputeAreaError(k3);
 
-    // Test the radiusIsParametric mode.
-    std::cout << "3D ball of radius " << scalarRadius
-              << " with radiusIsParametric mode on:" << std::endl;
-    k3 = SE3Type::Ball(r3, radiusIsParametric);
-    ComputeAreaError(k3);
+  // Test the radiusIsParametric mode.
+  std::cout << "3D ball of radius " << scalarRadius << " with radiusIsParametric mode on:" << std::endl;
+  k3 = SE3Type::Ball(r3, radiusIsParametric);
+  ComputeAreaError(k3);
 
-    std::cout << "3D annulus of radius " << scalarRadius
-              << " and thickness " <<  scalarThickness
-              << " with radiusIsParametric mode off:" << std::endl;
-    k3 = SE3Type::Annulus(r3,scalarThickness,false);
-    ComputeAreaError(k3,scalarThickness);
+  std::cout << "3D annulus of radius " << scalarRadius << " and thickness " << scalarThickness
+            << " with radiusIsParametric mode off:" << std::endl;
+  k3 = SE3Type::Annulus(r3, scalarThickness, false);
+  ComputeAreaError(k3, scalarThickness);
 
-    // Test the radiusIsParametric mode.
-    std::cout << "3D annulus of radius " << scalarRadius
-              << " and thickness " <<  scalarThickness
-              << " with radiusIsParametric mode on:" << std::endl;
-    k3 = SE3Type::Annulus(r3,scalarThickness,false,radiusIsParametric);
-    ComputeAreaError(k3,scalarThickness);
+  // Test the radiusIsParametric mode.
+  std::cout << "3D annulus of radius " << scalarRadius << " and thickness " << scalarThickness
+            << " with radiusIsParametric mode on:" << std::endl;
+  k3 = SE3Type::Annulus(r3, scalarThickness, false, radiusIsParametric);
+  ComputeAreaError(k3, scalarThickness);
 
-    using SE4Type = itk::FlatStructuringElement< 4 >;
-    SE4Type::RadiusType r4;
-    r4.Fill( scalarRadius );
-    SE4Type k4;
+  using SE4Type = itk::FlatStructuringElement<4>;
+  SE4Type::RadiusType r4;
+  r4.Fill(scalarRadius);
+  SE4Type k4;
 
-    std::cout << "4D ball of radius " << scalarRadius
-              << " with radiusIsParametric mode off:" << std::endl;
-    k4 = SE4Type::Ball( r4 );
-    ComputeAreaError(k4);
+  std::cout << "4D ball of radius " << scalarRadius << " with radiusIsParametric mode off:" << std::endl;
+  k4 = SE4Type::Ball(r4);
+  ComputeAreaError(k4);
 
-    // Test the radiusIsParametric mode.
-    std::cout << "4D ball of radius " << scalarRadius
-              << " with radiusIsParametric mode on:" << std::endl;
-    k4 = SE4Type::Ball(r4, radiusIsParametric);
-    ComputeAreaError(k4);
+  // Test the radiusIsParametric mode.
+  std::cout << "4D ball of radius " << scalarRadius << " with radiusIsParametric mode on:" << std::endl;
+  k4 = SE4Type::Ball(r4, radiusIsParametric);
+  ComputeAreaError(k4);
 
-    std::cout << "4D annulus of radius " << scalarRadius
-              << " and thickness " <<  scalarThickness
-              << " with radiusIsParametric mode off:" << std::endl;
-    k4 = SE4Type::Annulus(r4,scalarThickness,false);
-    ComputeAreaError(k4,scalarThickness);
+  std::cout << "4D annulus of radius " << scalarRadius << " and thickness " << scalarThickness
+            << " with radiusIsParametric mode off:" << std::endl;
+  k4 = SE4Type::Annulus(r4, scalarThickness, false);
+  ComputeAreaError(k4, scalarThickness);
 
-    // Test the radiusIsParametric mode.
-    std::cout << "4D annulus of radius " << scalarRadius
-              << " and thickness " <<  scalarThickness
-              << " with radiusIsParametric mode on:" << std::endl;
-    k4 = SE4Type::Annulus(r4,scalarThickness,false,radiusIsParametric);
-    ComputeAreaError(k4,scalarThickness);
+  // Test the radiusIsParametric mode.
+  std::cout << "4D annulus of radius " << scalarRadius << " and thickness " << scalarThickness
+            << " with radiusIsParametric mode on:" << std::endl;
+  k4 = SE4Type::Annulus(r4, scalarThickness, false, radiusIsParametric);
+  ComputeAreaError(k4, scalarThickness);
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-template< class SEType >
-bool ComputeAreaError(SEType k, unsigned int thickness)
+template <class SEType>
+bool
+ComputeAreaError(SEType k, unsigned int thickness)
 {
-    float expectedOuterForegroundArea = 1;
-    float expectedInnerForegroundArea;
-    if( thickness == 0 )
-    {
-        // Circle/Ellipse has no inner area to subract.
-        expectedInnerForegroundArea = 0;
-    }
-    else
-    {
-        // Annulus does have inner area to subract.
-        expectedInnerForegroundArea = 1;
-    }
-    if( SEType::NeighborhoodDimension == 2)
-    {
-        expectedOuterForegroundArea *= itk::Math::pi;
-        expectedInnerForegroundArea *= itk::Math::pi;
-    }
-    else if( SEType::NeighborhoodDimension == 3 )
-    {
-        expectedOuterForegroundArea *= 4.0/3.0 * itk::Math::pi;
-        expectedInnerForegroundArea *= 4.0/3.0 * itk::Math::pi;
-    }
-    else if ( SEType::NeighborhoodDimension == 4 )
-    {
-        expectedOuterForegroundArea *= 0.5 * itk::Math::pi * itk::Math::pi;
-        expectedInnerForegroundArea *= 0.5 * itk::Math::pi * itk::Math::pi;
-    }
-    else
-    {
-        return EXIT_FAILURE;
-    }
-    for( unsigned int i = 0; i < SEType::NeighborhoodDimension; i++ )
-    {
-        expectedOuterForegroundArea *= k.GetRadius()[i];
-        expectedInnerForegroundArea *= (k.GetRadius()[i] - thickness);
-    }
-
-    float expectedForegroundArea = expectedOuterForegroundArea - expectedInnerForegroundArea;
-
-    // Show the neighborhood if it is 2D.
-    typename SEType::Iterator SEIt;
-    if( SEType::NeighborhoodDimension == 2 )
-    {
-        for( SEIt = k.Begin(); SEIt != k.End(); ++SEIt )
-        {
-            std::cout << *SEIt << "\t";
-            if( (SEIt - k.Begin()+1) % k.GetSize()[0] == 0 )
-            {
-                std::cout << std::endl;
-            }
-        }
-    }
-
-    // Compute the area/volume.
-    float computedForegroundArea = 0;
-    for( SEIt = k.Begin(); SEIt != k.End(); ++SEIt )
-    {
-        if( *SEIt )
-        {
-            computedForegroundArea++;
-        }
-    }
-
-    std::cout << "Expected foreground area: " << expectedForegroundArea << std::endl;
-    std::cout << "Computed foreground area: " << computedForegroundArea << std::endl;
-    std::cout << "Foreground area error: "
-              << 100 * std::abs(expectedForegroundArea-computedForegroundArea)/expectedForegroundArea
-              << "%" << "\n\n";
-
+  float expectedOuterForegroundArea = 1;
+  float expectedInnerForegroundArea;
+  if (thickness == 0)
+  {
+    // Circle/Ellipse has no inner area to subract.
+    expectedInnerForegroundArea = 0;
+  }
+  else
+  {
+    // Annulus does have inner area to subract.
+    expectedInnerForegroundArea = 1;
+  }
+  if (SEType::NeighborhoodDimension == 2)
+  {
+    expectedOuterForegroundArea *= itk::Math::pi;
+    expectedInnerForegroundArea *= itk::Math::pi;
+  }
+  else if (SEType::NeighborhoodDimension == 3)
+  {
+    expectedOuterForegroundArea *= 4.0 / 3.0 * itk::Math::pi;
+    expectedInnerForegroundArea *= 4.0 / 3.0 * itk::Math::pi;
+  }
+  else if (SEType::NeighborhoodDimension == 4)
+  {
+    expectedOuterForegroundArea *= 0.5 * itk::Math::pi * itk::Math::pi;
+    expectedInnerForegroundArea *= 0.5 * itk::Math::pi * itk::Math::pi;
+  }
+  else
+  {
     return EXIT_FAILURE;
-}
+  }
+  for (unsigned int i = 0; i < SEType::NeighborhoodDimension; i++)
+  {
+    expectedOuterForegroundArea *= k.GetRadius()[i];
+    expectedInnerForegroundArea *= (k.GetRadius()[i] - thickness);
+  }
 
+  float expectedForegroundArea = expectedOuterForegroundArea - expectedInnerForegroundArea;
+
+  // Show the neighborhood if it is 2D.
+  typename SEType::Iterator SEIt;
+  if (SEType::NeighborhoodDimension == 2)
+  {
+    for (SEIt = k.Begin(); SEIt != k.End(); ++SEIt)
+    {
+      std::cout << *SEIt << "\t";
+      if ((SEIt - k.Begin() + 1) % k.GetSize()[0] == 0)
+      {
+        std::cout << std::endl;
+      }
+    }
+  }
+
+  // Compute the area/volume.
+  float computedForegroundArea = 0;
+  for (SEIt = k.Begin(); SEIt != k.End(); ++SEIt)
+  {
+    if (*SEIt)
+    {
+      computedForegroundArea++;
+    }
+  }
+
+  std::cout << "Expected foreground area: " << expectedForegroundArea << std::endl;
+  std::cout << "Computed foreground area: " << computedForegroundArea << std::endl;
+  std::cout << "Foreground area error: "
+            << 100 * std::abs(expectedForegroundArea - computedForegroundArea) / expectedForegroundArea << "%"
+            << "\n\n";
+
+  return EXIT_FAILURE;
+}

--- a/src/Filtering/MathematicalMorphology/RegionalMaximal/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/RegionalMaximal/Code.cxx
@@ -22,81 +22,85 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using RegionalMaximaImageFilter = itk::RegionalMaximaImageFilter <ImageType, ImageType >;
+  using RegionalMaximaImageFilter = itk::RegionalMaximaImageFilter<ImageType, ImageType>;
 
-    RegionalMaximaImageFilter::Pointer filter
-            = RegionalMaximaImageFilter::New ();
-    filter->SetInput(image);
+  RegionalMaximaImageFilter::Pointer filter = RegionalMaximaImageFilter::New();
+  filter->SetInput(image);
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
 
-    writer->SetFileName("intensityblobs.png");
-    writer->SetInput( image );
-    writer->Update();
+  writer->SetFileName("intensityblobs.png");
+  writer->SetInput(image);
+  writer->Update();
 
-    writer->SetFileName("maximal.png");
-    writer->SetInput( filter->GetOutput() );
-    writer->Update();
+  writer->SetFileName("maximal.png");
+  writer->SetInput(filter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumCols;
-    size[1] = NumRows;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumCols;
+  size[1] = NumRows;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make two intensity blobs
-    for(unsigned int r = 0; r < NumRows; r++)
+  // Make two intensity blobs
+  for (unsigned int r = 0; r < NumRows; r++)
+  {
+    for (unsigned int c = 0; c < NumCols; c++)
     {
-        for(unsigned int c = 0; c < NumCols; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = c;
-            pixelIndex[1] = r;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = c;
+      pixelIndex[1] = r;
 
-            double c1 = c - 100.0;
-            double c2 = c - 200.0;
+      double c1 = c - 100.0;
+      double c2 = c - 200.0;
 
-            double rr = r - 100.0;
+      double rr = r - 100.0;
 
-            // purposely use 270,257 since it is > 255
-            double v1 = 270.0 - std::sqrt( rr*rr + c1*c1 );
-            double v2 = 257.0 - std::sqrt( rr*rr + c2*c2 );
+      // purposely use 270,257 since it is > 255
+      double v1 = 270.0 - std::sqrt(rr * rr + c1 * c1);
+      double v2 = 257.0 - std::sqrt(rr * rr + c2 * c2);
 
-            double maxv = v1;
-            if( maxv < v2 )  maxv = v2;
+      double maxv = v1;
+      if (maxv < v2)
+        maxv = v2;
 
-            double val = maxv;
+      double val = maxv;
 
-            if( val <   0.0 ) val = 0.0;
-            if( val > 255.0 ) val = 255.0;
+      if (val < 0.0)
+        val = 0.0;
+      if (val > 255.0)
+        val = 255.0;
 
-            image->SetPixel(pixelIndex, val);
-        }
+      image->SetPixel(pixelIndex, val);
     }
+  }
 }
-

--- a/src/Filtering/MathematicalMorphology/RegionalMinimal/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/RegionalMinimal/Code.cxx
@@ -21,75 +21,79 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using RegionalMinimaImageFilterType = itk::RegionalMinimaImageFilter <ImageType, ImageType >;
-    RegionalMinimaImageFilterType::Pointer regionalMinimaImageFilter
-            = RegionalMinimaImageFilterType::New ();
-    regionalMinimaImageFilter->SetInput(image);
-    regionalMinimaImageFilter->Update();
+  using RegionalMinimaImageFilterType = itk::RegionalMinimaImageFilter<ImageType, ImageType>;
+  RegionalMinimaImageFilterType::Pointer regionalMinimaImageFilter = RegionalMinimaImageFilterType::New();
+  regionalMinimaImageFilter->SetInput(image);
+  regionalMinimaImageFilter->Update();
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("input.png");
-    writer->SetInput( image );
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 
-    writer->SetFileName("output.png");
-    writer->SetInput( regionalMinimaImageFilter->GetOutput() );
-    writer->Update();
+  writer->SetFileName("output.png");
+  writer->SetInput(regionalMinimaImageFilter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    ImageType::IndexType start;
-    start.Fill(0);
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size[0] = 200;
-    size[1] = 300;
+  ImageType::SizeType size;
+  size[0] = 200;
+  size[1] = 300;
 
-    ImageType::RegionType region(start,size);
+  ImageType::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make two intensity blobs
-    for(unsigned int r = 0; r < size[1]; r++)
+  // Make two intensity blobs
+  for (unsigned int r = 0; r < size[1]; r++)
+  {
+    for (unsigned int c = 0; c < size[0]; c++)
     {
-        for(unsigned int c = 0; c < size[0]; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = c;
-            pixelIndex[1] = r;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = c;
+      pixelIndex[1] = r;
 
-            double c1 = c - 100.0;
-            double c2 = c - 200.0;
+      double c1 = c - 100.0;
+      double c2 = c - 200.0;
 
-            double rr = r - 100.0;
+      double rr = r - 100.0;
 
-            // purposely use 270,257 since it is > 255
-            double v1 = 270.0 - std::sqrt( rr*rr + c1*c1 );
-            double v2 = 257.0 - std::sqrt( rr*rr + c2*c2 );
+      // purposely use 270,257 since it is > 255
+      double v1 = 270.0 - std::sqrt(rr * rr + c1 * c1);
+      double v2 = 257.0 - std::sqrt(rr * rr + c2 * c2);
 
-            double maxv = v1;
-            if( maxv < v2 )  maxv = v2;
+      double maxv = v1;
+      if (maxv < v2)
+        maxv = v2;
 
-            double val = maxv;
+      double val = maxv;
 
-            // Clip
-            if( val <   0.0 ) val = 0.0;
-            if( val > 255.0 ) val = 255.0;
+      // Clip
+      if (val < 0.0)
+        val = 0.0;
+      if (val > 255.0)
+        val = 255.0;
 
-            image->SetPixel(pixelIndex, static_cast<unsigned char>(val) );
-        }
+      image->SetPixel(pixelIndex, static_cast<unsigned char>(val));
     }
+  }
 }
-

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/Code.cxx
@@ -22,84 +22,92 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using ValuedRegionalMaximaImageFilter = itk::ValuedRegionalMaximaImageFilter <ImageType, ImageType >;
+  using ValuedRegionalMaximaImageFilter = itk::ValuedRegionalMaximaImageFilter<ImageType, ImageType>;
 
-    ValuedRegionalMaximaImageFilter::Pointer filter
-            = ValuedRegionalMaximaImageFilter::New ();
-    filter->SetInput(image);
+  ValuedRegionalMaximaImageFilter::Pointer filter = ValuedRegionalMaximaImageFilter::New();
+  filter->SetInput(image);
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
 
-    writer->SetFileName("intensityblobs.png");
-    writer->SetInput( image );
-    writer->Update();
+  writer->SetFileName("intensityblobs.png");
+  writer->SetInput(image);
+  writer->Update();
 
-    writer->SetFileName("maximal.png");
-    writer->SetInput( filter->GetOutput() );
-    writer->Update();
+  writer->SetFileName("maximal.png");
+  writer->SetInput(filter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumCols;
-    size[1] = NumRows;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumCols;
+  size[1] = NumRows;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make two intensity blobs
-    for(unsigned int r = 0; r < NumRows; r++)
+  // Make two intensity blobs
+  for (unsigned int r = 0; r < NumRows; r++)
+  {
+    for (unsigned int c = 0; c < NumCols; c++)
     {
-        for(unsigned int c = 0; c < NumCols; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = c;
-            pixelIndex[1] = r;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = c;
+      pixelIndex[1] = r;
 
-            double c1 = c - 100.0;
-            double c2 = c - 200.0;
+      double c1 = c - 100.0;
+      double c2 = c - 200.0;
 
-            double rr = r - 100.0;
+      double rr = r - 100.0;
 
-            double v1 = 200.0 - std::sqrt( rr*rr + c1*c1 );
-            double v2 = 150.0 - std::sqrt( rr*rr + c2*c2 );
+      double v1 = 200.0 - std::sqrt(rr * rr + c1 * c1);
+      double v2 = 150.0 - std::sqrt(rr * rr + c2 * c2);
 
-            if( v1 > 190.0 ) v1 = 190.0;
-            if( v2 > 140.0 ) v2 = 140.0;
+      if (v1 > 190.0)
+        v1 = 190.0;
+      if (v2 > 140.0)
+        v2 = 140.0;
 
-            double maxv = v1;
-            if( maxv < v2 )  maxv = v2;
+      double maxv = v1;
+      if (maxv < v2)
+        maxv = v2;
 
-            double val = maxv;
+      double val = maxv;
 
-            if( val <   0.0 ) val = 0.0;
-            if( val > 255.0 ) val = 255.0;
+      if (val < 0.0)
+        val = 0.0;
+      if (val > 255.0)
+        val = 255.0;
 
-            if( c < 5 ) val = 255.0;
+      if (c < 5)
+        val = 255.0;
 
-            image->SetPixel(pixelIndex, val);
-        }
+      image->SetPixel(pixelIndex, val);
     }
+  }
 }

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/Code.cxx
@@ -21,85 +21,92 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using ValuedRegionalMinimaImageFilter = itk::ValuedRegionalMinimaImageFilter <ImageType, ImageType >;
+  using ValuedRegionalMinimaImageFilter = itk::ValuedRegionalMinimaImageFilter<ImageType, ImageType>;
 
-    ValuedRegionalMinimaImageFilter::Pointer filter
-            = ValuedRegionalMinimaImageFilter::New ();
-    filter->SetInput(image);
+  ValuedRegionalMinimaImageFilter::Pointer filter = ValuedRegionalMinimaImageFilter::New();
+  filter->SetInput(image);
 
-    using WriterType = itk::ImageFileWriter< ImageType >;
-    WriterType::Pointer writer = WriterType::New();
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
 
-    writer->SetFileName("input.png");
-    writer->SetInput( image );
-    writer->Update();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 
-    writer->SetFileName("output.png");
-    writer->SetInput( filter->GetOutput() );
-    writer->Update();
+  writer->SetFileName("output.png");
+  writer->SetInput(filter->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumCols;
-    size[1] = NumRows;
+  ImageType::SizeType size;
+  unsigned int        NumRows = 200;
+  unsigned int        NumCols = 300;
+  size[0] = NumCols;
+  size[1] = NumRows;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make two intensity blobs
-    for(unsigned int r = 0; r < NumRows; r++)
+  // Make two intensity blobs
+  for (unsigned int r = 0; r < NumRows; r++)
+  {
+    for (unsigned int c = 0; c < NumCols; c++)
     {
-        for(unsigned int c = 0; c < NumCols; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = c;
-            pixelIndex[1] = r;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = c;
+      pixelIndex[1] = r;
 
-            double c1 = c - 100.0;
-            double c2 = c - 200.0;
+      double c1 = c - 100.0;
+      double c2 = c - 200.0;
 
-            double rr = r - 100.0;
+      double rr = r - 100.0;
 
-            double v1 = 200.0 - std::sqrt( rr*rr + c1*c1 );
-            double v2 = 150.0 - std::sqrt( rr*rr + c2*c2 );
+      double v1 = 200.0 - std::sqrt(rr * rr + c1 * c1);
+      double v2 = 150.0 - std::sqrt(rr * rr + c2 * c2);
 
-            if( v1 > 190.0 ) v1 = 190.0;
-            if( v2 > 140.0 ) v2 = 140.0;
+      if (v1 > 190.0)
+        v1 = 190.0;
+      if (v2 > 140.0)
+        v2 = 140.0;
 
-            double maxv = v1;
-            if( maxv < v2 )  maxv = v2;
+      double maxv = v1;
+      if (maxv < v2)
+        maxv = v2;
 
-            double val = maxv;
+      double val = maxv;
 
-            if( val <   0.0 ) val = 0.0;
-            if( val > 255.0 ) val = 255.0;
+      if (val < 0.0)
+        val = 0.0;
+      if (val > 255.0)
+        val = 255.0;
 
-            if( c < 5 ) val = 255.0;
+      if (c < 5)
+        val = 255.0;
 
-            image->SetPixel(pixelIndex, static_cast<unsigned char>(val) );
-        }
+      image->SetPixel(pixelIndex, static_cast<unsigned char>(val));
     }
+  }
 }
-

--- a/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/Code.cxx
+++ b/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/Code.cxx
@@ -17,31 +17,31 @@
  *=========================================================================*/
 #include "itkPolyLineParametricPath.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using PathType = itk::PolyLineParametricPath< 2 >;
+  using PathType = itk::PolyLineParametricPath<2>;
 
-    PathType::Pointer path = PathType::New();
-    path->Initialize();
+  PathType::Pointer path = PathType::New();
+  path->Initialize();
 
-    using ContinuousIndexType = PathType::ContinuousIndexType;
+  using ContinuousIndexType = PathType::ContinuousIndexType;
 
-    // Create a line
-    for(unsigned int i = 0; i < 20; ++i)
-    {
-        ContinuousIndexType cindex;
-        cindex[0] = 0;
-        cindex[1] = i;
-        path->AddVertex( cindex );
-    }
+  // Create a line
+  for (unsigned int i = 0; i < 20; ++i)
+  {
+    ContinuousIndexType cindex;
+    cindex[0] = 0;
+    cindex[1] = i;
+    path->AddVertex(cindex);
+  }
 
-    const PathType::VertexListType * vertexList = path->GetVertexList ();
+  const PathType::VertexListType * vertexList = path->GetVertexList();
 
-    for(unsigned int i = 0; i < vertexList->Size(); ++i)
-    {
-        std::cout << vertexList->GetElement(i) << std::endl;
-    }
+  for (unsigned int i = 0; i < vertexList->Size(); ++i)
+  {
+    std::cout << vertexList->GetElement(i) << std::endl;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
+++ b/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
@@ -23,80 +23,84 @@
 using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 using FloatImageType = itk::Image<float, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    CreateImage(image);
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  CreateImage(image);
 
-    using ApproximateSignedDistanceMapImageFilterType = itk::ApproximateSignedDistanceMapImageFilter< UnsignedCharImageType, FloatImageType  >;
-    ApproximateSignedDistanceMapImageFilterType::Pointer approximateSignedDistanceMapImageFilter = ApproximateSignedDistanceMapImageFilterType::New();
-    approximateSignedDistanceMapImageFilter->SetInput(image);
-    approximateSignedDistanceMapImageFilter->SetInsideValue(255);
-    approximateSignedDistanceMapImageFilter->SetOutsideValue(0);
-    approximateSignedDistanceMapImageFilter->Update();
+  using ApproximateSignedDistanceMapImageFilterType =
+    itk::ApproximateSignedDistanceMapImageFilter<UnsignedCharImageType, FloatImageType>;
+  ApproximateSignedDistanceMapImageFilterType::Pointer approximateSignedDistanceMapImageFilter =
+    ApproximateSignedDistanceMapImageFilterType::New();
+  approximateSignedDistanceMapImageFilter->SetInput(image);
+  approximateSignedDistanceMapImageFilter->SetInsideValue(255);
+  approximateSignedDistanceMapImageFilter->SetOutsideValue(0);
+  approximateSignedDistanceMapImageFilter->Update();
 
-    using ContourExtractor2DImageFilterType = itk::ContourExtractor2DImageFilter <FloatImageType>;
-    ContourExtractor2DImageFilterType::Pointer contourExtractor2DImageFilter
-            = ContourExtractor2DImageFilterType::New();
-    contourExtractor2DImageFilter->SetInput(approximateSignedDistanceMapImageFilter->GetOutput());
-    contourExtractor2DImageFilter->SetContourValue(0);
-    contourExtractor2DImageFilter->Update();
+  using ContourExtractor2DImageFilterType = itk::ContourExtractor2DImageFilter<FloatImageType>;
+  ContourExtractor2DImageFilterType::Pointer contourExtractor2DImageFilter = ContourExtractor2DImageFilterType::New();
+  contourExtractor2DImageFilter->SetInput(approximateSignedDistanceMapImageFilter->GetOutput());
+  contourExtractor2DImageFilter->SetContourValue(0);
+  contourExtractor2DImageFilter->Update();
 
-    std::cout << "There are " << contourExtractor2DImageFilter->GetNumberOfOutputs() << " contours" << std::endl;
+  std::cout << "There are " << contourExtractor2DImageFilter->GetNumberOfOutputs() << " contours" << std::endl;
 
 
-    for(unsigned int i = 0; i < contourExtractor2DImageFilter->GetNumberOfOutputs(); ++i)
+  for (unsigned int i = 0; i < contourExtractor2DImageFilter->GetNumberOfOutputs(); ++i)
+  {
+    std::cout << "Contour " << i << ": " << std::endl;
+    ContourExtractor2DImageFilterType::VertexListType::ConstIterator vertexIterator =
+      contourExtractor2DImageFilter->GetOutput(i)->GetVertexList()->Begin();
+    while (vertexIterator != contourExtractor2DImageFilter->GetOutput(i)->GetVertexList()->End())
     {
-        std::cout << "Contour " << i << ": " << std::endl;
-        ContourExtractor2DImageFilterType::VertexListType::ConstIterator vertexIterator =
-                contourExtractor2DImageFilter->GetOutput(i)->GetVertexList()->Begin();
-        while(vertexIterator != contourExtractor2DImageFilter->GetOutput(i)->GetVertexList()->End())
-        {
-            std::cout << vertexIterator->Value() << std::endl;
-            ++vertexIterator;
-        }
-        std::cout << std::endl;
+      std::cout << vertexIterator->Value() << std::endl;
+      ++vertexIterator;
     }
+    std::cout << std::endl;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    // Create an image
-    itk::Index<2> start;
-    start.Fill(0);
+  // Create an image
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(100);
+  itk::Size<2> size;
+  size.Fill(100);
 
-    itk::ImageRegion<2> region(start, size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  itk::ImageRegion<2> region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Create a line of white pixels
-    for(unsigned int i = 40; i < 60; ++i)
-    {
-        itk::Index<2> pixel;
-        pixel.Fill(i);
-        image->SetPixel(pixel, 255);
-    }
+  // Create a line of white pixels
+  for (unsigned int i = 40; i < 60; ++i)
+  {
+    itk::Index<2> pixel;
+    pixel.Fill(i);
+    image->SetPixel(pixel, 255);
+  }
 
-    // Create another line of pixels
-    for(unsigned int i = 10; i < 20; ++i)
-    {
-        itk::Index<2> pixel;
-        pixel[0] = 10;
-        pixel[1] = i;
-        image->SetPixel(pixel, 255);
-    }
+  // Create another line of pixels
+  for (unsigned int i = 10; i < 20; ++i)
+  {
+    itk::Index<2> pixel;
+    pixel[0] = 10;
+    pixel[1] = i;
+    image->SetPixel(pixel, 255);
+  }
 
-    using WriterType = itk::ImageFileWriter< UnsignedCharImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("image.png");
-    writer->SetInput(image);
-    writer->Update();
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("image.png");
+  writer->SetInput(image);
+  writer->Update();
 }

--- a/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/Code.cxx
+++ b/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/Code.cxx
@@ -23,51 +23,52 @@
 
 #include "itkCleanQuadEdgeMeshFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 3 )
-    {
-    std::cout <<"Requires 3 argument: " <<std::endl;
-    std::cout <<"1-Input file name " <<std::endl;
-    std::cout <<"2-Relative Tolerance " <<std::endl;
-    std::cout <<"3-Output file name " <<std::endl;
+  if (argc < 3)
+  {
+    std::cout << "Requires 3 argument: " << std::endl;
+    std::cout << "1-Input file name " << std::endl;
+    std::cout << "2-Relative Tolerance " << std::endl;
+    std::cout << "3-Output file name " << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   using Coord = double;
   constexpr unsigned int Dimension = 3;
 
-  using MeshType = itk::QuadEdgeMesh< Coord, Dimension >;
-  using ReaderType = itk::MeshFileReader< MeshType >;
-  using WriterType = itk::MeshFileWriter< MeshType >;
+  using MeshType = itk::QuadEdgeMesh<Coord, Dimension>;
+  using ReaderType = itk::MeshFileReader<MeshType>;
+  using WriterType = itk::MeshFileWriter<MeshType>;
 
-  ReaderType::Pointer reader = ReaderType::New( );
-  reader->SetFileName( argv[1] );
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
-  MeshType::Pointer mesh = reader->GetOutput( );
+  MeshType::Pointer mesh = reader->GetOutput();
 
-  Coord tol;
-  std::stringstream ssout( argv[2] );
-  ssout >>tol;
+  Coord             tol;
+  std::stringstream ssout(argv[2]);
+  ssout >> tol;
 
-  using CleanFilterType = itk::CleanQuadEdgeMeshFilter< MeshType, MeshType >;
+  using CleanFilterType = itk::CleanQuadEdgeMeshFilter<MeshType, MeshType>;
   CleanFilterType::Pointer filter = CleanFilterType::New();
-  filter->SetInput( mesh );
-  filter->SetRelativeTolerance( tol );
+  filter->SetInput(mesh);
+  filter->SetRelativeTolerance(tol);
 
-  WriterType::Pointer writer = WriterType::New( );
-  writer->SetInput( filter->GetOutput( ) );
-  writer->SetFileName( argv[3] );
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(filter->GetOutput());
+  writer->SetFileName(argv[3]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   std::cout << filter;
   return EXIT_SUCCESS;

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/Code.cxx
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/Code.cxx
@@ -22,60 +22,54 @@
 #include "itkQuadEdgeMeshExtendedTraits.h"
 #include "itkNormalQuadEdgeMeshFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 2 )
-    {
-    std::cerr << "Usage:" <<std::endl;
+  if (argc < 2)
+  {
+    std::cerr << "Usage:" << std::endl;
     std::cerr << argv[0] << "<InputFileName> <WeightType>" << std::endl;
     std::cerr << "Weight type: " << std::endl;
     std::cerr << "  * 0:  GOURAUD" << std::endl;
     std::cerr << "  * 1:  THURMER" << std::endl;
     std::cerr << "  * 2:  AREA" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
 
-  using InputMeshType = itk::QuadEdgeMesh< CoordType, Dimension >;
+  using InputMeshType = itk::QuadEdgeMesh<CoordType, Dimension>;
 
-  using VectorType = itk::Vector< CoordType, Dimension >;
+  using VectorType = itk::Vector<CoordType, Dimension>;
 
-  using Traits = itk::QuadEdgeMeshExtendedTraits <
-    VectorType,
-    Dimension,
-    2,
-    CoordType,
-    CoordType,
-    VectorType,
-    bool,
-    bool >;
+  using Traits =
+    itk::QuadEdgeMeshExtendedTraits<VectorType, Dimension, 2, CoordType, CoordType, VectorType, bool, bool>;
 
-  using ReaderType = itk::MeshFileReader< InputMeshType >;
-  ReaderType::Pointer reader = ReaderType::New( );
-  reader->SetFileName( argv[1] );
-  reader->Update( );
+  using ReaderType = itk::MeshFileReader<InputMeshType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
+  reader->Update();
 
-  using OutputMeshType = itk::QuadEdgeMesh < VectorType, Dimension, Traits >;
+  using OutputMeshType = itk::QuadEdgeMesh<VectorType, Dimension, Traits>;
 
-  using NormalFilterType = itk::NormalQuadEdgeMeshFilter< InputMeshType, OutputMeshType >;
+  using NormalFilterType = itk::NormalQuadEdgeMeshFilter<InputMeshType, OutputMeshType>;
   NormalFilterType::WeightType weight_type;
 
-  int param = std::stoi( argv[2] );
+  int param = std::stoi(argv[2]);
 
-  if( ( param < 0 ) || ( param > 2 ) )
-    {
-    std::cerr <<"Weight type must be either: " <<std::endl;
-    std::cerr <<"   * 0:  GOURAUD" <<std::endl;
-    std::cerr <<"   * 1:  THURMER" <<std::endl;
-    std::cerr <<"   * 2:  AREA" <<std::endl;
+  if ((param < 0) || (param > 2))
+  {
+    std::cerr << "Weight type must be either: " << std::endl;
+    std::cerr << "   * 0:  GOURAUD" << std::endl;
+    std::cerr << "   * 1:  THURMER" << std::endl;
+    std::cerr << "   * 2:  AREA" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   else
+  {
+    switch (param)
     {
-    switch( param )
-      {
       default:
       case 0:
         weight_type = NormalFilterType::GOURAUD;
@@ -86,33 +80,33 @@ int main( int argc, char* argv[] )
       case 2:
         weight_type = NormalFilterType::AREA;
         break;
-      }
     }
+  }
 
-  NormalFilterType::Pointer normals = NormalFilterType::New( );
-  normals->SetInput( reader->GetOutput() );
-  normals->SetWeight( weight_type );
-  normals->Update( );
+  NormalFilterType::Pointer normals = NormalFilterType::New();
+  normals->SetInput(reader->GetOutput());
+  normals->SetWeight(weight_type);
+  normals->Update();
 
-  OutputMeshType::Pointer output = normals->GetOutput( );
+  OutputMeshType::Pointer output = normals->GetOutput();
 
-  OutputMeshType::PointsContainerPointer    points = output->GetPoints();
-  OutputMeshType::PointsContainerIterator   p_it = points->Begin();
+  OutputMeshType::PointsContainerPointer  points = output->GetPoints();
+  OutputMeshType::PointsContainerIterator p_it = points->Begin();
 
-  OutputMeshType::PointDataContainerPointer container = output->GetPointData();
+  OutputMeshType::PointDataContainerPointer  container = output->GetPointData();
   OutputMeshType::PointDataContainerIterator d_it = container->Begin();
 
   std::cout << "Index * Point * Normal" << std::endl;
 
-  while( p_it != points->End() )
-    {
+  while (p_it != points->End())
+  {
     std::cout << p_it.Index() << " * ";
     std::cout << p_it.Value() << " * ";
     std::cout << d_it.Value() << std::endl;
 
     ++p_it;
     ++d_it;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/Code.cxx
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/Code.cxx
@@ -22,25 +22,26 @@
 #include "VNLIterativeSparseSolverTraits.h"
 #include "itkParameterizationQuadEdgeMeshFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cout <<"Requires 4 arguments: " << std::endl;
-    std::cout <<"1-Input file name " << std::endl;
-    std::cout <<"2-Border Type" << std::endl;
-    std::cout <<"   * 0: SQUARE" << std::endl;
-    std::cout <<"   * 1: DISK" << std::endl;
-    std::cout <<"3-CoefficientType Type" << std::endl;
-    std::cout <<"   * 0: OnesMatrixCoefficients" << std::endl;
-    std::cout <<"   * 1: InverseEuclideanDistanceMatrixCoefficients" << std::endl;
-    std::cout <<"   * 2: ConformalMatrixCoefficients" << std::endl;
-    std::cout <<"   * 3: AuthalicMatrixCoefficients" << std::endl;
-    std::cout <<"   * 4: HarmonicMatrixCoefficients" << std::endl;
-    std::cout <<"4-Output file name " << std::endl;
+  if (argc != 5)
+  {
+    std::cout << "Requires 4 arguments: " << std::endl;
+    std::cout << "1-Input file name " << std::endl;
+    std::cout << "2-Border Type" << std::endl;
+    std::cout << "   * 0: SQUARE" << std::endl;
+    std::cout << "   * 1: DISK" << std::endl;
+    std::cout << "3-CoefficientType Type" << std::endl;
+    std::cout << "   * 0: OnesMatrixCoefficients" << std::endl;
+    std::cout << "   * 1: InverseEuclideanDistanceMatrixCoefficients" << std::endl;
+    std::cout << "   * 2: ConformalMatrixCoefficients" << std::endl;
+    std::cout << "   * 3: AuthalicMatrixCoefficients" << std::endl;
+    std::cout << "   * 4: HarmonicMatrixCoefficients" << std::endl;
+    std::cout << "4-Output file name " << std::endl;
 
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[4];
@@ -48,94 +49,94 @@ int main( int argc, char* argv[] )
   using CoordType = double;
   constexpr unsigned int Dimension = 3;
 
-  using MeshType = itk::QuadEdgeMesh< CoordType, Dimension >;
-  using ReaderType = itk::MeshFileReader< MeshType >;
-  using WriterType = itk::MeshFileWriter< MeshType >;
-  using BorderTransformType = itk::BorderQuadEdgeMeshFilter< MeshType, MeshType >;
-  using SolverTraits = VNLIterativeSparseSolverTraits< CoordType >;
+  using MeshType = itk::QuadEdgeMesh<CoordType, Dimension>;
+  using ReaderType = itk::MeshFileReader<MeshType>;
+  using WriterType = itk::MeshFileWriter<MeshType>;
+  using BorderTransformType = itk::BorderQuadEdgeMeshFilter<MeshType, MeshType>;
+  using SolverTraits = VNLIterativeSparseSolverTraits<CoordType>;
 
-  using ParametrizationType = itk::ParameterizationQuadEdgeMeshFilter< MeshType, MeshType, SolverTraits >;
+  using ParametrizationType = itk::ParameterizationQuadEdgeMeshFilter<MeshType, MeshType, SolverTraits>;
 
-  ReaderType::Pointer reader = ReaderType::New( );
-  reader->SetFileName( inputFileName );
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFileName);
 
-  MeshType::Pointer mesh = reader->GetOutput( );
+  MeshType::Pointer mesh = reader->GetOutput();
 
-  BorderTransformType::Pointer border_transform = BorderTransformType::New( );
-  border_transform->SetInput( reader->GetOutput() );
+  BorderTransformType::Pointer border_transform = BorderTransformType::New();
+  border_transform->SetInput(reader->GetOutput());
 
-  int border;
-  std::stringstream ssout( argv[2] );
+  int               border;
+  std::stringstream ssout(argv[2]);
   ssout >> border;
-  switch( border )  // choose border type
-    {
+  switch (border) // choose border type
+  {
     case 0: // square shaped domain
-      border_transform->SetTransformType( BorderTransformType::SQUARE_BORDER_TRANSFORM );
+      border_transform->SetTransformType(BorderTransformType::SQUARE_BORDER_TRANSFORM);
       break;
     case 1: // disk shaped domain
-      border_transform->SetTransformType( BorderTransformType::DISK_BORDER_TRANSFORM );
+      border_transform->SetTransformType(BorderTransformType::DISK_BORDER_TRANSFORM);
       break;
     default: // handle .... user ....
       std::cerr << "2nd argument must be " << std::endl;
       std::cerr << "0 for SQUARE BORDER TRANSFORM or "
                 << "1 for DISK BORDER TRANSFORM" << std::endl;
       return EXIT_FAILURE;
-    }
+  }
 
-  std::cout << "Transform type is: " << border_transform->GetTransformType( ) << std::endl;
+  std::cout << "Transform type is: " << border_transform->GetTransformType() << std::endl;
 
   // ** CHOOSE AND SET BARYCENTRIC WEIGHTS **
-  itk::OnesMatrixCoefficients< MeshType >                     coeff0;
-  itk::InverseEuclideanDistanceMatrixCoefficients< MeshType > coeff1;
-  itk::ConformalMatrixCoefficients< MeshType >                coeff2;
-  itk::AuthalicMatrixCoefficients< MeshType >                 coeff3;
-  itk::HarmonicMatrixCoefficients< MeshType >                 coeff4;
+  itk::OnesMatrixCoefficients<MeshType>                     coeff0;
+  itk::InverseEuclideanDistanceMatrixCoefficients<MeshType> coeff1;
+  itk::ConformalMatrixCoefficients<MeshType>                coeff2;
+  itk::AuthalicMatrixCoefficients<MeshType>                 coeff3;
+  itk::HarmonicMatrixCoefficients<MeshType>                 coeff4;
 
-  ParametrizationType::Pointer param = ParametrizationType::New( );
-  param->SetInput( mesh );
-  param->SetBorderTransform( border_transform );
+  ParametrizationType::Pointer param = ParametrizationType::New();
+  param->SetInput(mesh);
+  param->SetBorderTransform(border_transform);
 
-  int param_type;
-  std::stringstream ssout3( argv[3] );
+  int               param_type;
+  std::stringstream ssout3(argv[3]);
   ssout3 >> param_type;
 
-  switch( param_type )
-    {
+  switch (param_type)
+  {
     case 0:
-      param->SetCoefficientsMethod( &coeff0 );
+      param->SetCoefficientsMethod(&coeff0);
       break;
     case 1:
-      param->SetCoefficientsMethod( &coeff1 );
+      param->SetCoefficientsMethod(&coeff1);
       break;
     case 2:
-      param->SetCoefficientsMethod( &coeff2 );
+      param->SetCoefficientsMethod(&coeff2);
       break;
     case 3:
-      param->SetCoefficientsMethod( &coeff3 );
+      param->SetCoefficientsMethod(&coeff3);
       break;
     case 4:
-      param->SetCoefficientsMethod( &coeff4 );
+      param->SetCoefficientsMethod(&coeff4);
       break;
     default:
       std::cerr << "3rd argument must be " << std::endl;
       std::cerr << "0, 1, 2, 3 or 4" << std::endl;
       std::cerr << "Here it is: " << param_type << std::endl;
       return EXIT_FAILURE;
-    }
+  }
 
-  WriterType::Pointer writer = WriterType::New( );
-  writer->SetInput( param->GetOutput( ) );
-  writer->SetFileName( outputFileName );
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(param->GetOutput());
+  writer->SetFileName(outputFileName);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/Code.cxx
+++ b/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/Code.cxx
@@ -22,51 +22,51 @@
 
 #include "itkDelaunayConformingQuadEdgeMeshFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
   // Error message and help.
-  if( argc != 3 )
-    {
-    std::cerr << "Usage:" <<std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage:" << std::endl;
     std::cerr << argv[0] << " <InputFileName> <OutputFileName>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Basic types.
   constexpr unsigned int Dimension = 3;
   using CoordType = double;
 
-  using MeshType = itk::QuadEdgeMesh< CoordType, Dimension >;
+  using MeshType = itk::QuadEdgeMesh<CoordType, Dimension>;
 
   // Read the file in.
-  using ReaderType = itk::MeshFileReader< MeshType >;
-  ReaderType::Pointer reader = ReaderType::New( );
-  reader->SetFileName( argv[1] );
+  using ReaderType = itk::MeshFileReader<MeshType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
   // Process the mesh.
-  MeshType::Pointer mesh = reader->GetOutput( );
-  using DelaunayConformFilterType = itk::DelaunayConformingQuadEdgeMeshFilter< MeshType, MeshType >;
+  MeshType::Pointer mesh = reader->GetOutput();
+  using DelaunayConformFilterType = itk::DelaunayConformingQuadEdgeMeshFilter<MeshType, MeshType>;
   DelaunayConformFilterType::Pointer filter = DelaunayConformFilterType::New();
-  filter->SetInput( mesh );
+  filter->SetInput(mesh);
 
   // Write the output.
-  using WriterType = itk::MeshFileWriter< MeshType >;
-  WriterType::Pointer writer = WriterType::New( );
-  writer->SetInput( filter->GetOutput( ) );
-  writer->SetFileName( argv[2] );
+  using WriterType = itk::MeshFileWriter<MeshType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(filter->GetOutput());
+  writer->SetFileName(argv[2]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  std::cout << "Number of Edge flipped performed: "
-            << filter->GetNumberOfEdgeFlips() <<std::endl;
+  std::cout << "Number of Edge flipped performed: " << filter->GetNumberOfEdgeFlips() << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Smoothing/ApplyMeanFilter/Code.cxx
+++ b/src/Filtering/Smoothing/ApplyMeanFilter/Code.cxx
@@ -21,52 +21,52 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
+  if (argc != 4)
+  {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <radius>"
-              << std::endl;
+    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <radius>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const int radiusValue = std::stoi( argv[3] );
+  const int    radiusValue = std::stoi(argv[3]);
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::MeanImageFilter< ImageType, ImageType >;
+  using FilterType = itk::MeanImageFilter<ImageType, ImageType>;
   FilterType::Pointer meanFilter = FilterType::New();
 
   FilterType::InputSizeType radius;
-  radius.Fill( radiusValue );
+  radius.Fill(radiusValue);
 
-  meanFilter->SetRadius( radius );
-  meanFilter->SetInput( reader->GetOutput() );
+  meanFilter->SetRadius(radius);
+  meanFilter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( meanFilter->GetOutput() );
-  writer->SetFileName( outputFileName );
+  writer->SetInput(meanFilter->GetOutput());
+  writer->SetFileName(outputFileName);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Smoothing/ApplyMedianFilter/Code.cxx
+++ b/src/Filtering/Smoothing/ApplyMedianFilter/Code.cxx
@@ -21,52 +21,52 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
+  if (argc != 4)
+  {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <radius>"
-              << std::endl;
+    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <radius>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const int radiusValue = std::stoi( argv[3] );
+  const int    radiusValue = std::stoi(argv[3]);
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::MedianImageFilter< ImageType, ImageType >;
+  using FilterType = itk::MedianImageFilter<ImageType, ImageType>;
   FilterType::Pointer medianFilter = FilterType::New();
 
   FilterType::InputSizeType radius;
-  radius.Fill( radiusValue );
+  radius.Fill(radiusValue);
 
-  medianFilter->SetRadius( radius );
-  medianFilter->SetInput( reader->GetOutput() );
+  medianFilter->SetRadius(radius);
+  medianFilter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( medianFilter->GetOutput() );
-  writer->SetFileName( outputFileName );
+  writer->SetInput(medianFilter->GetOutput());
+  writer->SetFileName(outputFileName);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/Code.cxx
+++ b/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/Code.cxx
@@ -22,49 +22,48 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkBinomialBlurImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 4 )
-    {
+  if (argc < 4)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << "  inputImageFile  outputImageFile  numberOfRepetitions" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   using InputPixelType = float;
   using OutputPixelType = float;
-  using InputImageType = itk::Image< InputPixelType,  2 >;
-  using OutputImageType = itk::Image< OutputPixelType, 2 >;
+  using InputImageType = itk::Image<InputPixelType, 2>;
+  using OutputImageType = itk::Image<OutputPixelType, 2>;
 
 
-  using FilterType = itk::BinomialBlurImageFilter<
-                 InputImageType, OutputImageType >;
+  using FilterType = itk::BinomialBlurImageFilter<InputImageType, OutputImageType>;
   FilterType::Pointer filter = FilterType::New();
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
 
-  reader->SetFileName( argv[1] );
-  const unsigned int repetitions = std::stoi( argv[3] );
-  filter->SetInput( reader->GetOutput() );
-  filter->SetRepetitions( repetitions );
+  reader->SetFileName(argv[1]);
+  const unsigned int repetitions = std::stoi(argv[3]);
+  filter->SetInput(reader->GetOutput());
+  filter->SetRepetitions(repetitions);
   filter->Update();
 
   using WritePixelType = unsigned char;
-  using WriteImageType = itk::Image< WritePixelType, 2 >;
-  using RescaleFilterType = itk::RescaleIntensityImageFilter<
-               OutputImageType, WriteImageType >;
+  using WriteImageType = itk::Image<WritePixelType, 2>;
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<OutputImageType, WriteImageType>;
 
   RescaleFilterType::Pointer rescaler = RescaleFilterType::New();
-  rescaler->SetOutputMinimum(   0 );
-  rescaler->SetOutputMaximum( 255 );
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(255);
 
-  using WriterType = itk::ImageFileWriter< WriteImageType >;
+  using WriterType = itk::ImageFileWriter<WriteImageType>;
   WriterType::Pointer writer = WriterType::New();
 
-  writer->SetFileName( argv[2] );
-  rescaler->SetInput( filter->GetOutput() );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(argv[2]);
+  rescaler->SetInput(filter->GetOutput());
+  writer->SetInput(rescaler->GetOutput());
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/src/Filtering/Smoothing/FindHigherDerivativesOfImage/Code.cxx
+++ b/src/Filtering/Smoothing/FindHigherDerivativesOfImage/Code.cxx
@@ -22,48 +22,47 @@
 #include "itkRecursiveGaussianImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << "inputImageFile" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << "inputImageFile" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Parse command line arguments
-    std::string inputFilename = argv[1];
+  // Parse command line arguments
+  std::string inputFilename = argv[1];
 
-    // Setup types
-    using FloatImageType = itk::Image< float,  2 >;
-    using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
+  // Setup types
+  using FloatImageType = itk::Image<float, 2>;
+  using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-    using readerType = itk::ImageFileReader< UnsignedCharImageType >;
+  using readerType = itk::ImageFileReader<UnsignedCharImageType>;
 
-    using filterType = itk::RecursiveGaussianImageFilter<
-            UnsignedCharImageType, FloatImageType >;
+  using filterType = itk::RecursiveGaussianImageFilter<UnsignedCharImageType, FloatImageType>;
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    reader->SetFileName( inputFilename.c_str() );
+  // Create and setup a reader
+  readerType::Pointer reader = readerType::New();
+  reader->SetFileName(inputFilename.c_str());
 
-    // Create and setup a gaussian filter
-    filterType::Pointer gaussianFilter = filterType::New();
-    gaussianFilter->SetInput( reader->GetOutput() );
-    gaussianFilter->SetDirection(0); // "x" axis
-    gaussianFilter->SetSecondOrder();
+  // Create and setup a gaussian filter
+  filterType::Pointer gaussianFilter = filterType::New();
+  gaussianFilter->SetInput(reader->GetOutput());
+  gaussianFilter->SetDirection(0); // "x" axis
+  gaussianFilter->SetSecondOrder();
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage<UnsignedCharImageType>(reader->GetOutput());
-    viewer.AddImage<FloatImageType>(gaussianFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage<UnsignedCharImageType>(reader->GetOutput());
+  viewer.AddImage<FloatImageType>(gaussianFilter->GetOutput());
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Code.cxx
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Code.cxx
@@ -31,7 +31,7 @@ namespace itk
  * This class overrides the <= and < operators to use Luminance as a sorting
  * value.
  */
-template< typename TComponent = unsigned short >
+template <typename TComponent = unsigned short>
 class myRGBPixel : public RGBPixel<TComponent>
 {
 public:
@@ -40,70 +40,72 @@ public:
 
   using RGBPixel<TComponent>::operator=;
 
-  bool operator<=(const Self & r) const
-    {
+  bool
+  operator<=(const Self & r) const
+  {
     return (this->GetLuminance() <= r.GetLuminance());
-    }
-  bool operator<(const Self & r) const
-    {
+  }
+  bool
+  operator<(const Self & r) const
+  {
     return (this->GetLuminance() < r.GetLuminance());
-    }
+  }
 };
-}
+} // namespace itk
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
   // Verify command line arguments
-  if( argc != 4 )
-    {
+  if (argc != 4)
+  {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <radius>"
-              << std::endl;
+    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <radius>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Setup types
   constexpr unsigned int Dimension = 2;
 
-  using MyPixelType = itk::myRGBPixel< unsigned char >;
-  using MyImageType = itk::Image< MyPixelType, Dimension >;
+  using MyPixelType = itk::myRGBPixel<unsigned char>;
+  using MyImageType = itk::Image<MyPixelType, Dimension>;
 
   // Create and setup a reader
-  using ReaderType = itk::ImageFileReader< MyImageType >;
+  using ReaderType = itk::ImageFileReader<MyImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   // Create and setup a median filter
-  using FilterType = itk::MedianImageFilter< MyImageType, MyImageType >;
+  using FilterType = itk::MedianImageFilter<MyImageType, MyImageType>;
   FilterType::Pointer medianFilter = FilterType::New();
 
   FilterType::InputSizeType radius;
-  radius.Fill( std::stoi( argv[3] ) );
+  radius.Fill(std::stoi(argv[3]));
 
-  medianFilter->SetRadius( radius );
-  medianFilter->SetInput( reader->GetOutput() );
+  medianFilter->SetRadius(radius);
+  medianFilter->SetInput(reader->GetOutput());
 
   // Cast the custom myRBGPixel's to RGBPixel's
-  using RGBPixelType = itk::RGBPixel< unsigned char >;
-  using RGBImageType = itk::Image< RGBPixelType, Dimension >;
-  using CastType = itk::CastImageFilter< MyImageType, RGBImageType >;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType, Dimension>;
+  using CastType = itk::CastImageFilter<MyImageType, RGBImageType>;
   CastType::Pointer cast = CastType::New();
-  cast->SetInput( medianFilter->GetOutput() );
+  cast->SetInput(medianFilter->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< RGBImageType >;
+  using WriterType = itk::ImageFileWriter<RGBImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( cast->GetOutput() );
-  writer->SetFileName( argv[2] );
+  writer->SetInput(cast->GetOutput());
+  writer->SetFileName(argv[2]);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/Code.cxx
+++ b/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/Code.cxx
@@ -20,53 +20,52 @@
 #include "itkDiscreteGaussianImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-    // Verify command line arguments
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " inputImageFile [variance]" << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify command line arguments
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " inputImageFile [variance]" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Parse command line argumentsa
-    std::string inputFilename = argv[1];
+  // Parse command line argumentsa
+  std::string inputFilename = argv[1];
 
-    double variance = 4.0;
-    if (argc > 2)
-    {
-        variance = std::stod(argv[2]);
-    }
+  double variance = 4.0;
+  if (argc > 2)
+  {
+    variance = std::stod(argv[2]);
+  }
 
-    // Setup types
-    using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
-    using FloatImageType = itk::Image< float, 2 >;
+  // Setup types
+  using UnsignedCharImageType = itk::Image<unsigned char, 2>;
+  using FloatImageType = itk::Image<float, 2>;
 
-    using readerType = itk::ImageFileReader< UnsignedCharImageType >;
+  using readerType = itk::ImageFileReader<UnsignedCharImageType>;
 
-    using filterType = itk::DiscreteGaussianImageFilter<
-            UnsignedCharImageType, FloatImageType >;
+  using filterType = itk::DiscreteGaussianImageFilter<UnsignedCharImageType, FloatImageType>;
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    reader->SetFileName( inputFilename.c_str() );
+  // Create and setup a reader
+  readerType::Pointer reader = readerType::New();
+  reader->SetFileName(inputFilename.c_str());
 
-    // Create and setup a Gaussian filter
-    filterType::Pointer gaussianFilter = filterType::New();
-    gaussianFilter->SetInput( reader->GetOutput() );
-    gaussianFilter->SetVariance(variance);
+  // Create and setup a Gaussian filter
+  filterType::Pointer gaussianFilter = filterType::New();
+  gaussianFilter->SetInput(reader->GetOutput());
+  gaussianFilter->SetVariance(variance);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage<UnsignedCharImageType>(reader->GetOutput());
-    viewer.AddImage<FloatImageType>(gaussianFilter->GetOutput());
-    viewer.Visualize();
+  QuickView viewer;
+  viewer.AddImage<UnsignedCharImageType>(reader->GetOutput());
+  viewer.AddImage<FloatImageType>(gaussianFilter->GetOutput());
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/Smoothing/SmoothWithRecursiveGaussian/Code.cxx
+++ b/src/Filtering/Smoothing/SmoothWithRecursiveGaussian/Code.cxx
@@ -21,49 +21,49 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char * argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 4 )
-    {
+  if (argc != 4)
+  {
     std::cerr << "Usage: " << std::endl;
-    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <sigma>"
-              << std::endl;
+    std::cerr << argv[0] << " <InputImageFile> <OutputImageFile> <sigma>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  const float sigmaValue = std::stod( argv[3] );
+  const float  sigmaValue = std::stod(argv[3]);
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::SmoothingRecursiveGaussianImageFilter< ImageType, ImageType >;
+  using FilterType = itk::SmoothingRecursiveGaussianImageFilter<ImageType, ImageType>;
   FilterType::Pointer smoothFilter = FilterType::New();
 
-  smoothFilter->SetSigma( sigmaValue );
-  smoothFilter->SetInput( reader->GetOutput() );
+  smoothFilter->SetSigma(sigmaValue);
+  smoothFilter->SetInput(reader->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( smoothFilter->GetOutput() );
-  writer->SetFileName( outputFileName );
+  writer->SetInput(smoothFilter->GetOutput());
+  writer->SetFileName(outputFileName);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/Code.cxx
+++ b/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/Code.cxx
@@ -35,86 +35,81 @@
 #include <sstream>
 #include <map>
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-    if( argc < 2 )
-    {
-        std::cout << "Usage: " << argv[0];
-        std::cout << " inputImageFile";
-        std::cerr << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cout << "Usage: " << argv[0];
+    std::cout << " inputImageFile";
+    std::cerr << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using InputPixelType = short;
-    using OutputPixelType = unsigned char;
+  using InputPixelType = short;
+  using OutputPixelType = unsigned char;
 
-    using InputImageType = itk::Image< InputPixelType,  2 >;
-    using OutputImageType = itk::Image< OutputPixelType, 2 >;
+  using InputImageType = itk::Image<InputPixelType, 2>;
+  using OutputImageType = itk::Image<OutputPixelType, 2>;
 
-    using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType >;
-    using HuangFilterType = itk::HuangThresholdImageFilter<InputImageType, OutputImageType >;
-    using IntermodesFilterType = itk::IntermodesThresholdImageFilter<InputImageType, OutputImageType >;
-    using IsoDataFilterType = itk::IsoDataThresholdImageFilter<InputImageType, OutputImageType >;
-    using KittlerIllingworthFilterType = itk::KittlerIllingworthThresholdImageFilter<InputImageType, OutputImageType >;
-    using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType >;
-    using MaximumEntropyFilterType = itk::MaximumEntropyThresholdImageFilter<InputImageType, OutputImageType >;
-    using MomentsFilterType = itk::MomentsThresholdImageFilter<InputImageType, OutputImageType >;
-    using OtsuFilterType = itk::OtsuThresholdImageFilter<InputImageType, OutputImageType >;
-    using RenyiEntropyFilterType = itk::RenyiEntropyThresholdImageFilter<InputImageType, OutputImageType >;
-    using ShanbhagFilterType = itk::ShanbhagThresholdImageFilter<InputImageType, OutputImageType >;
-    using TriangleFilterType = itk::TriangleThresholdImageFilter<InputImageType, OutputImageType >;
-    using YenFilterType = itk::YenThresholdImageFilter<InputImageType, OutputImageType >;
+  using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType>;
+  using HuangFilterType = itk::HuangThresholdImageFilter<InputImageType, OutputImageType>;
+  using IntermodesFilterType = itk::IntermodesThresholdImageFilter<InputImageType, OutputImageType>;
+  using IsoDataFilterType = itk::IsoDataThresholdImageFilter<InputImageType, OutputImageType>;
+  using KittlerIllingworthFilterType = itk::KittlerIllingworthThresholdImageFilter<InputImageType, OutputImageType>;
+  using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType>;
+  using MaximumEntropyFilterType = itk::MaximumEntropyThresholdImageFilter<InputImageType, OutputImageType>;
+  using MomentsFilterType = itk::MomentsThresholdImageFilter<InputImageType, OutputImageType>;
+  using OtsuFilterType = itk::OtsuThresholdImageFilter<InputImageType, OutputImageType>;
+  using RenyiEntropyFilterType = itk::RenyiEntropyThresholdImageFilter<InputImageType, OutputImageType>;
+  using ShanbhagFilterType = itk::ShanbhagThresholdImageFilter<InputImageType, OutputImageType>;
+  using TriangleFilterType = itk::TriangleThresholdImageFilter<InputImageType, OutputImageType>;
+  using YenFilterType = itk::YenThresholdImageFilter<InputImageType, OutputImageType>;
 
-    using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
 
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( argv[1] );
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    using FilterContainerType = std::map<std::string, itk::HistogramThresholdImageFilter<InputImageType, OutputImageType>::Pointer>;
-    FilterContainerType filterContainer;
+  using FilterContainerType =
+    std::map<std::string, itk::HistogramThresholdImageFilter<InputImageType, OutputImageType>::Pointer>;
+  FilterContainerType filterContainer;
 
-    filterContainer["Huang"] = HuangFilterType::New();
-    filterContainer["Intermodes"] = IntermodesFilterType::New();
-    filterContainer["IsoData"] = IsoDataFilterType::New();
-    filterContainer["KittlerIllingworth"] = KittlerIllingworthFilterType::New();
-    filterContainer["Li"] = LiFilterType::New();
-    filterContainer["MaximumEntropy"] = MaximumEntropyFilterType::New();
-    filterContainer["Moments"] = MomentsFilterType::New();
-    filterContainer["Otsu"] = OtsuFilterType::New();
-    filterContainer["RenyiEntropy"] = RenyiEntropyFilterType::New();
-    filterContainer["Shanbhag"] = ShanbhagFilterType::New();
-    filterContainer["Triangle"] = TriangleFilterType::New();
-    filterContainer["Yen"] = YenFilterType::New();
+  filterContainer["Huang"] = HuangFilterType::New();
+  filterContainer["Intermodes"] = IntermodesFilterType::New();
+  filterContainer["IsoData"] = IsoDataFilterType::New();
+  filterContainer["KittlerIllingworth"] = KittlerIllingworthFilterType::New();
+  filterContainer["Li"] = LiFilterType::New();
+  filterContainer["MaximumEntropy"] = MaximumEntropyFilterType::New();
+  filterContainer["Moments"] = MomentsFilterType::New();
+  filterContainer["Otsu"] = OtsuFilterType::New();
+  filterContainer["RenyiEntropy"] = RenyiEntropyFilterType::New();
+  filterContainer["Shanbhag"] = ShanbhagFilterType::New();
+  filterContainer["Triangle"] = TriangleFilterType::New();
+  filterContainer["Yen"] = YenFilterType::New();
 
-    auto it = filterContainer.begin();
-    for (it = filterContainer.begin(); it != filterContainer.end(); ++it)
-    {
-        (*it).second->SetInsideValue( 255 );
-        (*it).second->SetOutsideValue( 0 );
-        (*it).second->SetInput( reader->GetOutput() );
-        (*it).second->SetNumberOfHistogramBins( 100 );
-        (*it).second->Update();
-        std::stringstream desc;
-        desc << (*it).first << " threshold = "
-             << (*it).second->GetThreshold();
-        viewer.AddImage(
-                (*it).second->GetOutput(),
-                true,
-                desc.str());
-    }
+  auto it = filterContainer.begin();
+  for (it = filterContainer.begin(); it != filterContainer.end(); ++it)
+  {
+    (*it).second->SetInsideValue(255);
+    (*it).second->SetOutsideValue(0);
+    (*it).second->SetInput(reader->GetOutput());
+    (*it).second->SetNumberOfHistogramBins(100);
+    (*it).second->Update();
+    std::stringstream desc;
+    desc << (*it).first << " threshold = " << (*it).second->GetThreshold();
+    viewer.AddImage((*it).second->GetOutput(), true, desc.str());
+  }
 
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Filtering/Thresholding/SeparateGroundUsingOtsu/Code.cxx
+++ b/src/Filtering/Thresholding/SeparateGroundUsingOtsu/Code.cxx
@@ -25,87 +25,83 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 namespace
 {
-    using PixelType = unsigned char;
-    using ImageType = itk::Image<PixelType, 2>;
-}
+using PixelType = unsigned char;
+using ImageType = itk::Image<PixelType, 2>;
+} // namespace
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image;
-    if( argc < 2 )
-    {
-        image = ImageType::New();
-        CreateImage(image.GetPointer());
-    }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader =
-                ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
+  ImageType::Pointer image;
+  if (argc < 2)
+  {
+    image = ImageType::New();
+    CreateImage(image.GetPointer());
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
 
-        image = reader->GetOutput();
-    }
+    image = reader->GetOutput();
+  }
 
-    using FilterType = itk::OtsuThresholdImageFilter <ImageType, ImageType>;
-    FilterType::Pointer otsuFilter
-            = FilterType::New();
-    otsuFilter->SetInput(image);
-    otsuFilter->Update(); // To compute threshold
+  using FilterType = itk::OtsuThresholdImageFilter<ImageType, ImageType>;
+  FilterType::Pointer otsuFilter = FilterType::New();
+  otsuFilter->SetInput(image);
+  otsuFilter->Update(); // To compute threshold
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),true,
-            argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
+  QuickView viewer;
+  viewer.AddImage(
+    image.GetPointer(), true, argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
 
-    std::stringstream desc;
-    desc << "Otsu Threshold: "
-         << itk::NumericTraits<FilterType::InputPixelType>::PrintType(otsuFilter->GetThreshold());
-    viewer.AddImage(
-            otsuFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Otsu Threshold: " << itk::NumericTraits<FilterType::InputPixelType>::PrintType(otsuFilter->GetThreshold());
+  viewer.AddImage(otsuFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create an image
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make the whole image white
-    itk::ImageRegionIterator<ImageType> iterator(image,image->GetLargestPossibleRegion());
+  // Make the whole image white
+  itk::ImageRegionIterator<ImageType> iterator(image, image->GetLargestPossibleRegion());
 
-    /*
-     //Create a square
-    while(!iterator.IsAtEnd())
-      {
-      iterator.Set(255);
-      ++iterator;
-      }
-    */
+  /*
+   //Create a square
+  while(!iterator.IsAtEnd())
+    {
+    iterator.Set(255);
+    ++iterator;
+    }
+  */
 }

--- a/src/Filtering/Thresholding/ThresholdAnImage/Code.cxx
+++ b/src/Filtering/Thresholding/ThresholdAnImage/Code.cxx
@@ -20,16 +20,17 @@
 #include "itkImageFileWriter.h"
 #include "itkThresholdImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 5 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 5)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <Lower Threshold> <Upper Threshold>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
@@ -37,34 +38,34 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  unsigned char lowerThreshold = std::stoi( argv[3] );
-  unsigned char upperThreshold = std::stoi( argv[4] );
+  unsigned char lowerThreshold = std::stoi(argv[3]);
+  unsigned char upperThreshold = std::stoi(argv[4]);
 
-  using FilterType = itk::ThresholdImageFilter< ImageType >;
+  using FilterType = itk::ThresholdImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
+  filter->SetInput(reader->GetOutput());
   filter->ThresholdOutside(lowerThreshold, upperThreshold);
-  filter->SetOutsideValue( 0 );
+  filter->SetOutsideValue(0);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/Code.cxx
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/Code.cxx
@@ -21,17 +21,17 @@
 #include "itkImage.h"
 #include "itkBinaryThresholdImageFilter.h"
 
-int main( int argc, char * argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 7 )
-    {
+  if (argc < 7)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << " <InputImage> <OutputImage> <LowerThreshold>";
-    std::cerr << " <UpperThreshold> <OutsideValue> <InsideValue>"
-              << std::endl;
+    std::cerr << " <UpperThreshold> <OutsideValue> <InsideValue>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
@@ -39,39 +39,39 @@ int main( int argc, char * argv[] )
   const char * InputImage = argv[1];
   const char * OutputImage = argv[2];
 
-  const auto LowerThreshold = static_cast<PixelType>(atoi( argv[3] ) );
-  const auto UpperThreshold = static_cast<PixelType>(atoi( argv[4] ) );
-  const auto OutsideValue = static_cast<PixelType>(atoi( argv[5] ) );
-  const auto InsideValue = static_cast<PixelType>(atoi( argv[6] ) );
+  const auto LowerThreshold = static_cast<PixelType>(atoi(argv[3]));
+  const auto UpperThreshold = static_cast<PixelType>(atoi(argv[4]));
+  const auto OutsideValue = static_cast<PixelType>(atoi(argv[5]));
+  const auto InsideValue = static_cast<PixelType>(atoi(argv[6]));
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( InputImage );
+  reader->SetFileName(InputImage);
 
-  using FilterType = itk::BinaryThresholdImageFilter< ImageType, ImageType >;
+  using FilterType = itk::BinaryThresholdImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetLowerThreshold( LowerThreshold );
-  filter->SetUpperThreshold( UpperThreshold );
-  filter->SetOutsideValue( OutsideValue );
-  filter->SetInsideValue( InsideValue );
+  filter->SetInput(reader->GetOutput());
+  filter->SetLowerThreshold(LowerThreshold);
+  filter->SetUpperThreshold(UpperThreshold);
+  filter->SetOutsideValue(OutsideValue);
+  filter->SetInsideValue(InsideValue);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( OutputImage );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(OutputImage);
+  writer->SetInput(filter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/Code.cxx
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/Code.cxx
@@ -21,17 +21,17 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 6 )
-    {
+  if (argc < 6)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << " <InputImage> <OutputImage> <NumberOfBins>";
-    std::cerr << " <NumberOfThresholds> <LabelOffset>"
-              << std::endl;
+    std::cerr << " <NumberOfThresholds> <LabelOffset>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
@@ -40,54 +40,54 @@ int main( int argc, char* argv[] )
   const char * InputImage = argv[1];
   const char * OutputImage = argv[2];
 
-  const auto NumberOfHistogramBins = static_cast<SizeType>(atoi( argv[3] ) );
-  const auto NumberOfThresholds = static_cast<SizeType>(atoi( argv[4] ) );
-  const auto LabelOffset = static_cast<PixelType>(atoi( argv[5] ) );
+  const auto NumberOfHistogramBins = static_cast<SizeType>(atoi(argv[3]));
+  const auto NumberOfThresholds = static_cast<SizeType>(atoi(argv[4]));
+  const auto LabelOffset = static_cast<PixelType>(atoi(argv[5]));
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( InputImage );
+  reader->SetFileName(InputImage);
 
-  using FilterType = itk::OtsuMultipleThresholdsImageFilter< ImageType, ImageType >;
+  using FilterType = itk::OtsuMultipleThresholdsImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetNumberOfHistogramBins( NumberOfHistogramBins );
-  filter->SetNumberOfThresholds( NumberOfThresholds );
-  filter->SetLabelOffset( LabelOffset );
+  filter->SetInput(reader->GetOutput());
+  filter->SetNumberOfHistogramBins(NumberOfHistogramBins);
+  filter->SetNumberOfThresholds(NumberOfThresholds);
+  filter->SetLabelOffset(LabelOffset);
 
   FilterType::ThresholdVectorType thresholds = filter->GetThresholds();
 
   std::cout << "Thresholds:" << std::endl;
 
-  for(double threshold : thresholds)
-    {
-    std:: cout << threshold << std::endl;
-    }
+  for (double threshold : thresholds)
+  {
+    std::cout << threshold << std::endl;
+  }
 
   std::cout << std::endl;
 
-  using RescaleType = itk::RescaleIntensityImageFilter< ImageType, ImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<ImageType, ImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( filter->GetOutput() );
-  rescaler->SetOutputMinimum( 0 );
-  rescaler->SetOutputMaximum( 255 );
+  rescaler->SetInput(filter->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(255);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( OutputImage );
-  writer->SetInput( rescaler->GetOutput() );
+  writer->SetFileName(OutputImage);
+  writer->SetInput(rescaler->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/Code.cxx
+++ b/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/Code.cxx
@@ -22,23 +22,24 @@
 #include "itkImageSeriesReader.h"
 #include "itkImageFileWriter.h"
 
-int main(int argc, char* argv[])
+int
+main(int argc, char * argv[])
 {
   if (argc < 2)
-    {
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " [DicomDirectory  [outputFileName  [seriesName]]]";
     std::cerr << "\nIf DicomDirectory is not specified, current directory is used\n";
-    }
-  std::string dirName = "."; //current directory by default
+  }
+  std::string dirName = "."; // current directory by default
   if (argc > 1)
-    {
+  {
     dirName = argv[1];
-    }
+  }
 
   using PixelType = signed short;
   constexpr unsigned int Dimension = 3;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   using NamesGeneratorType = itk::GDCMSeriesFileNames;
   NamesGeneratorType::Pointer nameGenerator = NamesGeneratorType::New();
@@ -49,89 +50,88 @@ int main(int argc, char* argv[])
   nameGenerator->SetDirectory(dirName);
 
   try
-    {
-    using SeriesIdContainer = std::vector< std::string >;
+  {
+    using SeriesIdContainer = std::vector<std::string>;
     const SeriesIdContainer & seriesUID = nameGenerator->GetSeriesUIDs();
-    auto seriesItr = seriesUID.begin();
-    auto seriesEnd = seriesUID.end();
+    auto                      seriesItr = seriesUID.begin();
+    auto                      seriesEnd = seriesUID.end();
 
     if (seriesItr != seriesEnd)
-      {
+    {
       std::cout << "The directory: ";
       std::cout << dirName << std::endl;
       std::cout << "Contains the following DICOM Series: ";
       std::cout << std::endl;
-      }
+    }
     else
-      {
+    {
       std::cout << "No DICOMs in: " << dirName << std::endl;
       return EXIT_SUCCESS;
-      }
+    }
 
     while (seriesItr != seriesEnd)
-      {
+    {
       std::cout << seriesItr->c_str() << std::endl;
       ++seriesItr;
-      }
+    }
 
     seriesItr = seriesUID.begin();
     while (seriesItr != seriesUID.end())
-      {
+    {
       std::string seriesIdentifier;
       if (argc > 3) // If seriesIdentifier given convert only that
-        {
+      {
         seriesIdentifier = argv[3];
         seriesItr = seriesUID.end();
-        }
-      else //otherwise convert everything
-        {
+      }
+      else // otherwise convert everything
+      {
         seriesIdentifier = seriesItr->c_str();
         seriesItr++;
-        }
+      }
       std::cout << "\nReading: ";
       std::cout << seriesIdentifier << std::endl;
-      using FileNamesContainer = std::vector< std::string >;
-      FileNamesContainer fileNames =
-        nameGenerator->GetFileNames(seriesIdentifier);
+      using FileNamesContainer = std::vector<std::string>;
+      FileNamesContainer fileNames = nameGenerator->GetFileNames(seriesIdentifier);
 
-      using ReaderType = itk::ImageSeriesReader< ImageType >;
+      using ReaderType = itk::ImageSeriesReader<ImageType>;
       ReaderType::Pointer reader = ReaderType::New();
       using ImageIOType = itk::GDCMImageIO;
       ImageIOType::Pointer dicomIO = ImageIOType::New();
       reader->SetImageIO(dicomIO);
       reader->SetFileNames(fileNames);
-      reader->ForceOrthogonalDirectionOff(); //properly read CTs with gantry tilt
+      reader->ForceOrthogonalDirectionOff(); // properly read CTs with gantry tilt
 
-      using WriterType = itk::ImageFileWriter< ImageType >;
+      using WriterType = itk::ImageFileWriter<ImageType>;
       WriterType::Pointer writer = WriterType::New();
-      std::string outFileName;
+      std::string         outFileName;
       if (argc > 2)
-        {
+      {
         outFileName = argv[2];
-        }
+      }
       else
-        {
+      {
         outFileName = dirName + std::string("/") + seriesIdentifier + ".nrrd";
-        }
+      }
       writer->SetFileName(outFileName);
       writer->UseCompressionOn();
       writer->SetInput(reader->GetOutput());
       std::cout << "Writing: " << outFileName << std::endl;
       try
-        {
+      {
         writer->Update();
-        }
-      catch (itk::ExceptionObject &ex)
-        {
+      }
+      catch (itk::ExceptionObject & ex)
+      {
         std::cout << ex << std::endl;
         continue;
-        }
       }
     }
-  catch (itk::ExceptionObject &ex)
-    {
+  }
+  catch (itk::ExceptionObject & ex)
+  {
     std::cout << ex << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }

--- a/src/IO/GDCM/ResampleDICOMSeries/Code.cxx
+++ b/src/IO/GDCM/ResampleDICOMSeries/Code.cxx
@@ -40,8 +40,8 @@
 
 #include "itkResampleImageFilter.h"
 
-#if ( ( ITK_VERSION_MAJOR == 4 ) && ( ITK_VERSION_MINOR < 6 ) )
-#include "itkShiftScaleImageFilter.h"
+#if ((ITK_VERSION_MAJOR == 4) && (ITK_VERSION_MINOR < 6))
+#  include "itkShiftScaleImageFilter.h"
 #endif
 
 #include "itkIdentityTransform.h"
@@ -50,344 +50,325 @@
 #include <itksys/SystemTools.hxx>
 
 #if ITK_VERSION_MAJOR >= 4
-#include "gdcmUIDGenerator.h"
+#  include "gdcmUIDGenerator.h"
 #else
-#include "gdcm/src/gdcmFile.h"
-#include "gdcm/src/gdcmUtil.h"
+#  include "gdcm/src/gdcmFile.h"
+#  include "gdcm/src/gdcmUtil.h"
 #endif
 
 #include <string>
 #include <sstream>
 
-static void CopyDictionary (itk::MetaDataDictionary &fromDict,
-                            itk::MetaDataDictionary &toDict);
+static void
+CopyDictionary(itk::MetaDataDictionary & fromDict, itk::MetaDataDictionary & toDict);
 
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-    // Validate input parameters
-    if( argc < 4 )
-    {
-        std::cerr << "Usage: "
-                  << argv[0]
-                  << " InputDicomDirectory OutputDicomDirectory spacing_x spacing_y spacing_z"
-                  << std::endl;
-        return EXIT_FAILURE;
-    }
-
-    constexpr unsigned int InputDimension = 3;
-    constexpr unsigned int OutputDimension = 2;
-
-    using PixelType = signed short;
-
-    using InputImageType = itk::Image< PixelType, InputDimension >;
-    using OutputImageType = itk::Image< PixelType, OutputDimension >;
-    using ReaderType = itk::ImageSeriesReader< InputImageType >;
-    using ImageIOType = itk::GDCMImageIO;
-    using InputNamesGeneratorType = itk::GDCMSeriesFileNames;
-    using OutputNamesGeneratorType = itk::NumericSeriesFileNames;
-    using TransformType = itk::IdentityTransform< double, InputDimension >;
-    using InterpolatorType = itk::LinearInterpolateImageFunction< InputImageType, double >;
-    using ResampleFilterType = itk::ResampleImageFilter< InputImageType, InputImageType >;
-#if ( ( ITK_VERSION_MAJOR == 4 ) && ( ITK_VERSION_MINOR < 6 ) )
-    using ShiftScaleType = itk::ShiftScaleImageFilter< InputImageType, InputImageType >;
-#endif
-    using SeriesWriterType = itk::ImageSeriesWriter< InputImageType, OutputImageType >;
-
-////////////////////////////////////////////////
-// 1) Read the input series
-
-    ImageIOType::Pointer gdcmIO = ImageIOType::New();
-    InputNamesGeneratorType::Pointer inputNames = InputNamesGeneratorType::New();
-    inputNames->SetInputDirectory( argv[1] );
-
-    const ReaderType::FileNamesContainer & filenames =
-            inputNames->GetInputFileNames();
-
-    ReaderType::Pointer reader = ReaderType::New();
-
-    reader->SetImageIO( gdcmIO );
-    reader->SetFileNames( filenames );
-    try
-    {
-        reader->Update();
-    }
-    catch (itk::ExceptionObject &excp)
-    {
-        std::cerr << "Exception thrown while reading the series" << std::endl;
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-    }
-
-////////////////////////////////////////////////
-// 2) Resample the series
-    InterpolatorType::Pointer interpolator = InterpolatorType::New();
-
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
-
-    const InputImageType::SpacingType& inputSpacing =
-            reader->GetOutput()->GetSpacing();
-    const InputImageType::RegionType& inputRegion =
-            reader->GetOutput()->GetLargestPossibleRegion();
-    const InputImageType::SizeType& inputSize =
-            inputRegion.GetSize();
-
-    std::cout << "The input series in directory " << argv[1]
-              << " has " << filenames.size() << " files with spacing "
-              << inputSpacing
+  // Validate input parameters
+  if (argc < 4)
+  {
+    std::cerr << "Usage: " << argv[0] << " InputDicomDirectory OutputDicomDirectory spacing_x spacing_y spacing_z"
               << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Compute the size of the output. The user specifies a spacing on
-    // the command line. If the spacing is 0, the input spacing will be
-    // used. The size (# of pixels) in the output is recomputed using
-    // the ratio of the input and output sizes.
-    InputImageType::SpacingType outputSpacing;
-    outputSpacing[0] = std::stod(argv[3]);
-    outputSpacing[1] = std::stod(argv[4]);
-    outputSpacing[2] = std::stod(argv[5]);
+  constexpr unsigned int InputDimension = 3;
+  constexpr unsigned int OutputDimension = 2;
 
-    bool changeInSpacing = false;
-    for (unsigned int i = 0; i < 3; i++)
-    {
-        if (outputSpacing[i] == 0.0)
-        {
-            outputSpacing[i] = inputSpacing[i];
-        }
-        else
-        {
-            changeInSpacing = true;
-        }
-    }
-    InputImageType::SizeType   outputSize;
-    using SizeValueType = InputImageType::SizeType::SizeValueType;
-    outputSize[0] = static_cast<SizeValueType>(inputSize[0] * inputSpacing[0] / outputSpacing[0] + .5);
-    outputSize[1] = static_cast<SizeValueType>(inputSize[1] * inputSpacing[1] / outputSpacing[1] + .5);
-    outputSize[2] = static_cast<SizeValueType>(inputSize[2] * inputSpacing[2] / outputSpacing[2] + .5);
+  using PixelType = signed short;
 
-    ResampleFilterType::Pointer resampler = ResampleFilterType::New();
-    resampler->SetInput( reader->GetOutput() );
-    resampler->SetTransform( transform );
-    resampler->SetInterpolator( interpolator );
-    resampler->SetOutputOrigin ( reader->GetOutput()->GetOrigin());
-    resampler->SetOutputSpacing ( outputSpacing );
-    resampler->SetOutputDirection ( reader->GetOutput()->GetDirection());
-    resampler->SetSize ( outputSize );
-    resampler->Update ();
-
-
-////////////////////////////////////////////////
-// 3) Create a MetaDataDictionary for each slice.
-
-    // Copy the dictionary from the first image and override slice
-    // specific fields
-    ReaderType::DictionaryRawPointer inputDict = (*(reader->GetMetaDataDictionaryArray()))[0];
-    ReaderType::DictionaryArrayType outputArray;
-
-    // To keep the new series in the same study as the original we need
-    // to keep the same study UID. But we need new series and frame of
-    // reference UID's.
-#if ITK_VERSION_MAJOR >= 4
-    gdcm::UIDGenerator suid;
-    std::string seriesUID = suid.Generate();
-    gdcm::UIDGenerator fuid;
-    std::string frameOfReferenceUID = fuid.Generate();
-#else
-    std::string seriesUID = gdcm::Util::CreateUniqueUID( gdcmIO->GetUIDPrefix());
-  std::string frameOfReferenceUID = gdcm::Util::CreateUniqueUID( gdcmIO->GetUIDPrefix());
+  using InputImageType = itk::Image<PixelType, InputDimension>;
+  using OutputImageType = itk::Image<PixelType, OutputDimension>;
+  using ReaderType = itk::ImageSeriesReader<InputImageType>;
+  using ImageIOType = itk::GDCMImageIO;
+  using InputNamesGeneratorType = itk::GDCMSeriesFileNames;
+  using OutputNamesGeneratorType = itk::NumericSeriesFileNames;
+  using TransformType = itk::IdentityTransform<double, InputDimension>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<InputImageType, double>;
+  using ResampleFilterType = itk::ResampleImageFilter<InputImageType, InputImageType>;
+#if ((ITK_VERSION_MAJOR == 4) && (ITK_VERSION_MINOR < 6))
+  using ShiftScaleType = itk::ShiftScaleImageFilter<InputImageType, InputImageType>;
 #endif
-    std::string studyUID;
-    std::string sopClassUID;
-    itk::ExposeMetaData<std::string>(*inputDict, "0020|000d", studyUID);
-    itk::ExposeMetaData<std::string>(*inputDict, "0008|0016", sopClassUID);
-    gdcmIO->KeepOriginalUIDOn();
+  using SeriesWriterType = itk::ImageSeriesWriter<InputImageType, OutputImageType>;
 
-    for (unsigned int f = 0; f < outputSize[2]; f++)
+  ////////////////////////////////////////////////
+  // 1) Read the input series
+
+  ImageIOType::Pointer             gdcmIO = ImageIOType::New();
+  InputNamesGeneratorType::Pointer inputNames = InputNamesGeneratorType::New();
+  inputNames->SetInputDirectory(argv[1]);
+
+  const ReaderType::FileNamesContainer & filenames = inputNames->GetInputFileNames();
+
+  ReaderType::Pointer reader = ReaderType::New();
+
+  reader->SetImageIO(gdcmIO);
+  reader->SetFileNames(filenames);
+  try
+  {
+    reader->Update();
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << "Exception thrown while reading the series" << std::endl;
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  ////////////////////////////////////////////////
+  // 2) Resample the series
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
+
+  const InputImageType::SpacingType & inputSpacing = reader->GetOutput()->GetSpacing();
+  const InputImageType::RegionType &  inputRegion = reader->GetOutput()->GetLargestPossibleRegion();
+  const InputImageType::SizeType &    inputSize = inputRegion.GetSize();
+
+  std::cout << "The input series in directory " << argv[1] << " has " << filenames.size() << " files with spacing "
+            << inputSpacing << std::endl;
+
+  // Compute the size of the output. The user specifies a spacing on
+  // the command line. If the spacing is 0, the input spacing will be
+  // used. The size (# of pixels) in the output is recomputed using
+  // the ratio of the input and output sizes.
+  InputImageType::SpacingType outputSpacing;
+  outputSpacing[0] = std::stod(argv[3]);
+  outputSpacing[1] = std::stod(argv[4]);
+  outputSpacing[2] = std::stod(argv[5]);
+
+  bool changeInSpacing = false;
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    if (outputSpacing[i] == 0.0)
     {
-        // Create a new dictionary for this slice
-        auto dict = new ReaderType::DictionaryType;
+      outputSpacing[i] = inputSpacing[i];
+    }
+    else
+    {
+      changeInSpacing = true;
+    }
+  }
+  InputImageType::SizeType outputSize;
+  using SizeValueType = InputImageType::SizeType::SizeValueType;
+  outputSize[0] = static_cast<SizeValueType>(inputSize[0] * inputSpacing[0] / outputSpacing[0] + .5);
+  outputSize[1] = static_cast<SizeValueType>(inputSize[1] * inputSpacing[1] / outputSpacing[1] + .5);
+  outputSize[2] = static_cast<SizeValueType>(inputSize[2] * inputSpacing[2] / outputSpacing[2] + .5);
 
-        // Copy the dictionary from the first slice
-        CopyDictionary (*inputDict, *dict);
+  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  resampler->SetInput(reader->GetOutput());
+  resampler->SetTransform(transform);
+  resampler->SetInterpolator(interpolator);
+  resampler->SetOutputOrigin(reader->GetOutput()->GetOrigin());
+  resampler->SetOutputSpacing(outputSpacing);
+  resampler->SetOutputDirection(reader->GetOutput()->GetDirection());
+  resampler->SetSize(outputSize);
+  resampler->Update();
 
-        // Set the UID's for the study, series, SOP  and frame of reference
-        itk::EncapsulateMetaData<std::string>(*dict,"0020|000d", studyUID);
-        itk::EncapsulateMetaData<std::string>(*dict,"0020|000e", seriesUID);
-        itk::EncapsulateMetaData<std::string>(*dict,"0020|0052", frameOfReferenceUID);
+
+  ////////////////////////////////////////////////
+  // 3) Create a MetaDataDictionary for each slice.
+
+  // Copy the dictionary from the first image and override slice
+  // specific fields
+  ReaderType::DictionaryRawPointer inputDict = (*(reader->GetMetaDataDictionaryArray()))[0];
+  ReaderType::DictionaryArrayType  outputArray;
+
+  // To keep the new series in the same study as the original we need
+  // to keep the same study UID. But we need new series and frame of
+  // reference UID's.
+#if ITK_VERSION_MAJOR >= 4
+  gdcm::UIDGenerator suid;
+  std::string        seriesUID = suid.Generate();
+  gdcm::UIDGenerator fuid;
+  std::string        frameOfReferenceUID = fuid.Generate();
+#else
+  std::string seriesUID = gdcm::Util::CreateUniqueUID(gdcmIO->GetUIDPrefix());
+  std::string frameOfReferenceUID = gdcm::Util::CreateUniqueUID(gdcmIO->GetUIDPrefix());
+#endif
+  std::string studyUID;
+  std::string sopClassUID;
+  itk::ExposeMetaData<std::string>(*inputDict, "0020|000d", studyUID);
+  itk::ExposeMetaData<std::string>(*inputDict, "0008|0016", sopClassUID);
+  gdcmIO->KeepOriginalUIDOn();
+
+  for (unsigned int f = 0; f < outputSize[2]; f++)
+  {
+    // Create a new dictionary for this slice
+    auto dict = new ReaderType::DictionaryType;
+
+    // Copy the dictionary from the first slice
+    CopyDictionary(*inputDict, *dict);
+
+    // Set the UID's for the study, series, SOP  and frame of reference
+    itk::EncapsulateMetaData<std::string>(*dict, "0020|000d", studyUID);
+    itk::EncapsulateMetaData<std::string>(*dict, "0020|000e", seriesUID);
+    itk::EncapsulateMetaData<std::string>(*dict, "0020|0052", frameOfReferenceUID);
 
 #if ITK_VERSION_MAJOR >= 4
-        gdcm::UIDGenerator sopuid;
-        std::string sopInstanceUID = sopuid.Generate();
+    gdcm::UIDGenerator sopuid;
+    std::string        sopInstanceUID = sopuid.Generate();
 #else
-        std::string sopInstanceUID = gdcm::Util::CreateUniqueUID( gdcmIO->GetUIDPrefix());
+    std::string sopInstanceUID = gdcm::Util::CreateUniqueUID(gdcmIO->GetUIDPrefix());
 #endif
-        itk::EncapsulateMetaData<std::string>(*dict,"0008|0018", sopInstanceUID);
-        itk::EncapsulateMetaData<std::string>(*dict,"0002|0003", sopInstanceUID);
+    itk::EncapsulateMetaData<std::string>(*dict, "0008|0018", sopInstanceUID);
+    itk::EncapsulateMetaData<std::string>(*dict, "0002|0003", sopInstanceUID);
 
-        // Change fields that are slice specific
-        std::ostringstream value;
-        value.str("");
-        value << f + 1;
+    // Change fields that are slice specific
+    std::ostringstream value;
+    value.str("");
+    value << f + 1;
 
-        // Image Number
-        itk::EncapsulateMetaData<std::string>(*dict,"0020|0013", value.str());
+    // Image Number
+    itk::EncapsulateMetaData<std::string>(*dict, "0020|0013", value.str());
 
-        // Series Description - Append new description to current series
-        // description
-        std::string oldSeriesDesc;
-        itk::ExposeMetaData<std::string>(*inputDict, "0008|103e", oldSeriesDesc);
+    // Series Description - Append new description to current series
+    // description
+    std::string oldSeriesDesc;
+    itk::ExposeMetaData<std::string>(*inputDict, "0008|103e", oldSeriesDesc);
 
-        value.str("");
-        value << oldSeriesDesc
-              << ": Resampled with pixel spacing "
-              << outputSpacing[0] << ", "
-              << outputSpacing[1] << ", "
-              << outputSpacing[2];
-        // This is an long string and there is a 64 character limit in the
-        // standard
-        unsigned lengthDesc = value.str().length();
+    value.str("");
+    value << oldSeriesDesc << ": Resampled with pixel spacing " << outputSpacing[0] << ", " << outputSpacing[1] << ", "
+          << outputSpacing[2];
+    // This is an long string and there is a 64 character limit in the
+    // standard
+    unsigned lengthDesc = value.str().length();
 
-        std::string seriesDesc( value.str(), 0,
-                                lengthDesc > 64 ? 64
-                                                : lengthDesc);
-        itk::EncapsulateMetaData<std::string>(*dict,"0008|103e", seriesDesc);
+    std::string seriesDesc(value.str(), 0, lengthDesc > 64 ? 64 : lengthDesc);
+    itk::EncapsulateMetaData<std::string>(*dict, "0008|103e", seriesDesc);
 
-        // Series Number
-        value.str("");
-        value << 1001;
-        itk::EncapsulateMetaData<std::string>(*dict,"0020|0011", value.str());
+    // Series Number
+    value.str("");
+    value << 1001;
+    itk::EncapsulateMetaData<std::string>(*dict, "0020|0011", value.str());
 
-        // Derivation Description - How this image was derived
-        value.str("");
-        for (int i = 0; i < argc; i++)
-        {
-            value << argv[i] << " ";
-        }
-        value << ": " << ITK_SOURCE_VERSION;
+    // Derivation Description - How this image was derived
+    value.str("");
+    for (int i = 0; i < argc; i++)
+    {
+      value << argv[i] << " ";
+    }
+    value << ": " << ITK_SOURCE_VERSION;
 
-        lengthDesc = value.str().length();
-        std::string derivationDesc( value.str(), 0,
-                                    lengthDesc > 1024 ? 1024
-                                                      : lengthDesc);
-        itk::EncapsulateMetaData<std::string>(*dict,"0008|2111", derivationDesc);
+    lengthDesc = value.str().length();
+    std::string derivationDesc(value.str(), 0, lengthDesc > 1024 ? 1024 : lengthDesc);
+    itk::EncapsulateMetaData<std::string>(*dict, "0008|2111", derivationDesc);
 
-        // Image Position Patient: This is calculated by computing the
-        // physical coordinate of the first pixel in each slice.
-        InputImageType::PointType position;
-        InputImageType::IndexType index;
-        index[0] = 0;
-        index[1] = 0;
-        index[2] = f;
-        resampler->GetOutput()->TransformIndexToPhysicalPoint(index, position);
+    // Image Position Patient: This is calculated by computing the
+    // physical coordinate of the first pixel in each slice.
+    InputImageType::PointType position;
+    InputImageType::IndexType index;
+    index[0] = 0;
+    index[1] = 0;
+    index[2] = f;
+    resampler->GetOutput()->TransformIndexToPhysicalPoint(index, position);
 
-        value.str("");
-        value << position[0] << "\\" << position[1] << "\\" << position[2];
-        itk::EncapsulateMetaData<std::string>(*dict,"0020|0032", value.str());
-        // Slice Location: For now, we store the z component of the Image
-        // Position Patient.
-        value.str("");
-        value << position[2];
-        itk::EncapsulateMetaData<std::string>(*dict,"0020|1041", value.str());
+    value.str("");
+    value << position[0] << "\\" << position[1] << "\\" << position[2];
+    itk::EncapsulateMetaData<std::string>(*dict, "0020|0032", value.str());
+    // Slice Location: For now, we store the z component of the Image
+    // Position Patient.
+    value.str("");
+    value << position[2];
+    itk::EncapsulateMetaData<std::string>(*dict, "0020|1041", value.str());
 
-        if (changeInSpacing)
-        {
-            // Slice Thickness: For now, we store the z spacing
-            value.str("");
-            value << outputSpacing[2];
-            itk::EncapsulateMetaData<std::string>(*dict,"0018|0050",
-                                                  value.str());
-            // Spacing Between Slices
-            itk::EncapsulateMetaData<std::string>(*dict,"0018|0088",
-                                                  value.str());
-        }
-
-        // Save the dictionary
-        outputArray.push_back(dict);
+    if (changeInSpacing)
+    {
+      // Slice Thickness: For now, we store the z spacing
+      value.str("");
+      value << outputSpacing[2];
+      itk::EncapsulateMetaData<std::string>(*dict, "0018|0050", value.str());
+      // Spacing Between Slices
+      itk::EncapsulateMetaData<std::string>(*dict, "0018|0088", value.str());
     }
 
-#if ( ( ITK_VERSION_MAJOR == 4 ) && ( ITK_VERSION_MINOR < 6 ) )
-    ////////////////////////////////////////////////
-// 4) Shift data to undo the effect of a rescale intercept by the
-//    DICOM reader
+    // Save the dictionary
+    outputArray.push_back(dict);
+  }
+
+#if ((ITK_VERSION_MAJOR == 4) && (ITK_VERSION_MINOR < 6))
+  ////////////////////////////////////////////////
+  // 4) Shift data to undo the effect of a rescale intercept by the
+  //    DICOM reader
   std::string interceptTag("0028|1052");
-  using MetaDataStringType = itk::MetaDataObject< std::string >;
+  using MetaDataStringType = itk::MetaDataObject<std::string>;
   itk::MetaDataObjectBase::Pointer entry = (*inputDict)[interceptTag];
 
-  MetaDataStringType::ConstPointer interceptValue =
-    dynamic_cast<const MetaDataStringType *>( entry.GetPointer() );
+  MetaDataStringType::ConstPointer interceptValue = dynamic_cast<const MetaDataStringType *>(entry.GetPointer());
 
   int interceptShift = 0;
-  if( interceptValue )
-    {
+  if (interceptValue)
+  {
     std::string tagValue = interceptValue->GetMetaDataObjectValue();
-    interceptShift = -atoi ( tagValue.c_str() );
-    }
+    interceptShift = -atoi(tagValue.c_str());
+  }
 
   ShiftScaleType::Pointer shiftScale = ShiftScaleType::New();
-  shiftScale->SetInput( resampler->GetOutput());
-  shiftScale->SetShift( interceptShift );
+  shiftScale->SetInput(resampler->GetOutput());
+  shiftScale->SetShift(interceptShift);
 #endif
 
-////////////////////////////////////////////////
-// 5) Write the new DICOM series
+  ////////////////////////////////////////////////
+  // 5) Write the new DICOM series
 
-    // Make the output directory and generate the file names.
-    itksys::SystemTools::MakeDirectory( argv[2] );
+  // Make the output directory and generate the file names.
+  itksys::SystemTools::MakeDirectory(argv[2]);
 
-    // Generate the file names
-    OutputNamesGeneratorType::Pointer outputNames = OutputNamesGeneratorType::New();
-    std::string seriesFormat(argv[2]);
-    seriesFormat = seriesFormat + "/" + "IM%d.dcm";
-    outputNames->SetSeriesFormat (seriesFormat.c_str());
-    outputNames->SetStartIndex (1);
-    outputNames->SetEndIndex (outputSize[2]);
+  // Generate the file names
+  OutputNamesGeneratorType::Pointer outputNames = OutputNamesGeneratorType::New();
+  std::string                       seriesFormat(argv[2]);
+  seriesFormat = seriesFormat + "/" + "IM%d.dcm";
+  outputNames->SetSeriesFormat(seriesFormat.c_str());
+  outputNames->SetStartIndex(1);
+  outputNames->SetEndIndex(outputSize[2]);
 
-    SeriesWriterType::Pointer seriesWriter = SeriesWriterType::New();
-#if ( ( ITK_VERSION_MAJOR == 4 ) && ( ITK_VERSION_MINOR < 6 ) )
-    seriesWriter->SetInput( shiftScale->GetOutput() );
+  SeriesWriterType::Pointer seriesWriter = SeriesWriterType::New();
+#if ((ITK_VERSION_MAJOR == 4) && (ITK_VERSION_MINOR < 6))
+  seriesWriter->SetInput(shiftScale->GetOutput());
 #else
-    seriesWriter->SetInput( resampler->GetOutput() );
+  seriesWriter->SetInput(resampler->GetOutput());
 #endif
-    seriesWriter->SetImageIO( gdcmIO );
-    seriesWriter->SetFileNames( outputNames->GetFileNames() );
-    seriesWriter->SetMetaDataDictionaryArray( &outputArray );
-    try
-    {
-        seriesWriter->Update();
-    }
-    catch( itk::ExceptionObject & excp )
-    {
-        std::cerr << "Exception thrown while writing the series " << std::endl;
-        std::cerr << excp << std::endl;
-        return EXIT_FAILURE;
-    }
-    std::cout << "The output series in directory " << argv[2]
-              << " has " << outputSize[2] << " files with spacing "
-              << outputSpacing
-              << std::endl;
-    return EXIT_SUCCESS;
+  seriesWriter->SetImageIO(gdcmIO);
+  seriesWriter->SetFileNames(outputNames->GetFileNames());
+  seriesWriter->SetMetaDataDictionaryArray(&outputArray);
+  try
+  {
+    seriesWriter->Update();
+  }
+  catch (itk::ExceptionObject & excp)
+  {
+    std::cerr << "Exception thrown while writing the series " << std::endl;
+    std::cerr << excp << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::cout << "The output series in directory " << argv[2] << " has " << outputSize[2] << " files with spacing "
+            << outputSpacing << std::endl;
+  return EXIT_SUCCESS;
 }
 
-void CopyDictionary (itk::MetaDataDictionary &fromDict, itk::MetaDataDictionary &toDict)
+void
+CopyDictionary(itk::MetaDataDictionary & fromDict, itk::MetaDataDictionary & toDict)
 {
-    using DictionaryType = itk::MetaDataDictionary;
+  using DictionaryType = itk::MetaDataDictionary;
 
-    DictionaryType::ConstIterator itr = fromDict.Begin();
-    DictionaryType::ConstIterator end = fromDict.End();
-    using MetaDataStringType = itk::MetaDataObject< std::string >;
+  DictionaryType::ConstIterator itr = fromDict.Begin();
+  DictionaryType::ConstIterator end = fromDict.End();
+  using MetaDataStringType = itk::MetaDataObject<std::string>;
 
-    while( itr != end )
+  while (itr != end)
+  {
+    itk::MetaDataObjectBase::Pointer entry = itr->second;
+
+    MetaDataStringType::Pointer entryvalue = dynamic_cast<MetaDataStringType *>(entry.GetPointer());
+    if (entryvalue)
     {
-        itk::MetaDataObjectBase::Pointer  entry = itr->second;
-
-        MetaDataStringType::Pointer entryvalue =
-                dynamic_cast<MetaDataStringType *>( entry.GetPointer() );
-        if( entryvalue )
-        {
-            std::string tagkey   = itr->first;
-            std::string tagvalue = entryvalue->GetMetaDataObjectValue();
-            itk::EncapsulateMetaData<std::string>(toDict, tagkey, tagvalue);
-        }
-        ++itr;
+      std::string tagkey = itr->first;
+      std::string tagvalue = entryvalue->GetMetaDataObjectValue();
+      itk::EncapsulateMetaData<std::string>(toDict, tagkey, tagvalue);
     }
+    ++itr;
+  }
 }

--- a/src/IO/ImageBase/ConvertFileFormats/Code.cxx
+++ b/src/IO/ImageBase/ConvertFileFormats/Code.cxx
@@ -19,40 +19,41 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( reader->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(reader->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/IO/ImageBase/ConvertImageToAnotherType/Code.cxx
+++ b/src/IO/ImageBase/ConvertImageToAnotherType/Code.cxx
@@ -22,81 +22,75 @@
 #include "itkConvertPixelBuffer.h"
 #include "itkImageRandomConstIteratorWithIndex.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    constexpr int xDimension = 200;
-    constexpr int yDimension = 100;
+  constexpr int xDimension = 200;
+  constexpr int yDimension = 100;
 
-    using ComponentType = unsigned char;
-    using RGBPixelType = itk::RGBPixel<ComponentType>;
-    using RGBAPixelType = itk::RGBAPixel<ComponentType>;
-    using RGBImageType = itk::Image< RGBPixelType, 2 >;
-    using RGBAImageType = itk::Image< RGBAPixelType, 2 >;
-    using TraitsType = itk::DefaultConvertPixelTraits< RGBPixelType >;
-    using RGBAConverterType = itk::ConvertPixelBuffer< ComponentType, RGBPixelType, TraitsType >;
+  using ComponentType = unsigned char;
+  using RGBPixelType = itk::RGBPixel<ComponentType>;
+  using RGBAPixelType = itk::RGBAPixel<ComponentType>;
+  using RGBImageType = itk::Image<RGBPixelType, 2>;
+  using RGBAImageType = itk::Image<RGBAPixelType, 2>;
+  using TraitsType = itk::DefaultConvertPixelTraits<RGBPixelType>;
+  using RGBAConverterType = itk::ConvertPixelBuffer<ComponentType, RGBPixelType, TraitsType>;
 
-    RGBImageType::Pointer rgbImg   = RGBImageType::New();
-    RGBAImageType::Pointer rgbaImg = RGBAImageType::New();
+  RGBImageType::Pointer  rgbImg = RGBImageType::New();
+  RGBAImageType::Pointer rgbaImg = RGBAImageType::New();
 
-    // Create the two images
-    // RGBAImage
-    RGBAImageType::IndexType rgbaStart;
-    rgbaStart[0] = 0;
-    rgbaStart[1] = 0;
+  // Create the two images
+  // RGBAImage
+  RGBAImageType::IndexType rgbaStart;
+  rgbaStart[0] = 0;
+  rgbaStart[1] = 0;
 
-    RGBAImageType::SizeType rgbaSize;
-    rgbaSize[0] = xDimension;
-    rgbaSize[1] = yDimension;
+  RGBAImageType::SizeType rgbaSize;
+  rgbaSize[0] = xDimension;
+  rgbaSize[1] = yDimension;
 
-    itk::ImageRegion<2> rgbaRegion(rgbaStart,rgbaSize);
-    rgbaImg->SetRegions(rgbaRegion);
-    rgbaImg->Allocate();
+  itk::ImageRegion<2> rgbaRegion(rgbaStart, rgbaSize);
+  rgbaImg->SetRegions(rgbaRegion);
+  rgbaImg->Allocate();
 
-    RGBAPixelType rgbaDefault;
-    rgbaDefault[0] = 127;
-    rgbaDefault[1] = 100;
-    rgbaDefault[2] = 230;
-    rgbaDefault[3] = 255;
-    rgbaImg->FillBuffer(rgbaDefault);
+  RGBAPixelType rgbaDefault;
+  rgbaDefault[0] = 127;
+  rgbaDefault[1] = 100;
+  rgbaDefault[2] = 230;
+  rgbaDefault[3] = 255;
+  rgbaImg->FillBuffer(rgbaDefault);
 
-    // RGBImage
-    itk::ImageRegion<2>     rgbRegion = rgbaRegion;
-    rgbImg->SetRegions(rgbRegion);
-    rgbImg->Allocate();
+  // RGBImage
+  itk::ImageRegion<2> rgbRegion = rgbaRegion;
+  rgbImg->SetRegions(rgbRegion);
+  rgbImg->Allocate();
 
-    size_t numberOfPixels =
-            rgbImg->GetLargestPossibleRegion().GetNumberOfPixels();
+  size_t numberOfPixels = rgbImg->GetLargestPossibleRegion().GetNumberOfPixels();
 
-    // Convert a raw buffer to a buffer of pixel types
-    RGBAConverterType::Convert(
-            rgbaImg->GetBufferPointer()->GetDataPointer(),
-            rgbaImg->GetNumberOfComponentsPerPixel(),
-            rgbImg->GetBufferPointer(),
-            numberOfPixels);
+  // Convert a raw buffer to a buffer of pixel types
+  RGBAConverterType::Convert(rgbaImg->GetBufferPointer()->GetDataPointer(),
+                             rgbaImg->GetNumberOfComponentsPerPixel(),
+                             rgbImg->GetBufferPointer(),
+                             numberOfPixels);
 
-    // Check a few random values
-    itk::ImageRandomConstIteratorWithIndex<RGBImageType>
-            rgbIterator(rgbImg, rgbImg->GetLargestPossibleRegion());
-    rgbIterator.SetNumberOfSamples(numberOfPixels / 10);
-    rgbIterator.GoToBegin();
+  // Check a few random values
+  itk::ImageRandomConstIteratorWithIndex<RGBImageType> rgbIterator(rgbImg, rgbImg->GetLargestPossibleRegion());
+  rgbIterator.SetNumberOfSamples(numberOfPixels / 10);
+  rgbIterator.GoToBegin();
 
-    while(!rgbIterator.IsAtEnd())
+  while (!rgbIterator.IsAtEnd())
+  {
+    if (rgbImg->GetPixel(rgbIterator.GetIndex())[0] != rgbaImg->GetPixel(rgbIterator.GetIndex())[0] ||
+
+        rgbImg->GetPixel(rgbIterator.GetIndex())[1] != rgbaImg->GetPixel(rgbIterator.GetIndex())[1] ||
+
+        rgbImg->GetPixel(rgbIterator.GetIndex())[2] != rgbaImg->GetPixel(rgbIterator.GetIndex())[2])
     {
-        if (rgbImg->GetPixel(rgbIterator.GetIndex())[0] !=
-            rgbaImg->GetPixel(rgbIterator.GetIndex())[0] ||
-
-            rgbImg->GetPixel(rgbIterator.GetIndex())[1] !=
-            rgbaImg->GetPixel(rgbIterator.GetIndex())[1] ||
-
-            rgbImg->GetPixel(rgbIterator.GetIndex())[2] !=
-            rgbaImg->GetPixel(rgbIterator.GetIndex())[2])
-        {
-            std::cout << "Copy failed for index " << rgbIterator.GetIndex()
-                      << " got " << rgbImg->GetPixel(rgbIterator.GetIndex())
-                      << " but expected " << rgbaImg->GetPixel(rgbIterator.GetIndex())
-                      << std::endl;
-        }
-        ++rgbIterator;
+      std::cout << "Copy failed for index " << rgbIterator.GetIndex() << " got "
+                << rgbImg->GetPixel(rgbIterator.GetIndex()) << " but expected "
+                << rgbaImg->GetPixel(rgbIterator.GetIndex()) << std::endl;
     }
-    return EXIT_SUCCESS;
+    ++rgbIterator;
+  }
+  return EXIT_SUCCESS;
 }

--- a/src/IO/ImageBase/Creade3DFromSeriesOf2D/Code.cxx
+++ b/src/IO/ImageBase/Creade3DFromSeriesOf2D/Code.cxx
@@ -20,68 +20,64 @@
 #include "itkImageFileWriter.h"
 #include "itkNumericSeriesFileNames.h"
 
-int main( int argc, char * argv[] )
+int
+main(int argc, char * argv[])
 {
-    // Verify the number of parameters in the command line
-    if( argc < 5 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0]
-                  << " pattern firstSliceValue lastSliceValue outputImageFile"
-                  << std::endl;
-        return EXIT_FAILURE;
-    }
+  // Verify the number of parameters in the command line
+  if (argc < 5)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " pattern firstSliceValue lastSliceValue outputImageFile" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using PixelType = unsigned char;
-    constexpr unsigned int Dimension = 3;
+  using PixelType = unsigned char;
+  constexpr unsigned int Dimension = 3;
 
-    using ImageType = itk::Image< PixelType, Dimension >;
-    using ReaderType = itk::ImageSeriesReader< ImageType >;
-    using WriterType = itk::ImageFileWriter<   ImageType >;
+  using ImageType = itk::Image<PixelType, Dimension>;
+  using ReaderType = itk::ImageSeriesReader<ImageType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
-    ReaderType::Pointer reader = ReaderType::New();
-    WriterType::Pointer writer = WriterType::New();
+  ReaderType::Pointer reader = ReaderType::New();
+  WriterType::Pointer writer = WriterType::New();
 
-    const unsigned int first = std::stoi( argv[2] );
-    const unsigned int last  = std::stoi( argv[3] );
+  const unsigned int first = std::stoi(argv[2]);
+  const unsigned int last = std::stoi(argv[3]);
 
-    const char * outputFilename = argv[4];
+  const char * outputFilename = argv[4];
 
-    using NameGeneratorType = itk::NumericSeriesFileNames;
+  using NameGeneratorType = itk::NumericSeriesFileNames;
 
-    NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
+  NameGeneratorType::Pointer nameGenerator = NameGeneratorType::New();
 
-    nameGenerator->SetSeriesFormat( argv[1] );
+  nameGenerator->SetSeriesFormat(argv[1]);
 
-    nameGenerator->SetStartIndex( first );
-    nameGenerator->SetEndIndex( last );
-    nameGenerator->SetIncrementIndex( 1 );
-    std::vector<std::string> names = nameGenerator->GetFileNames();
+  nameGenerator->SetStartIndex(first);
+  nameGenerator->SetEndIndex(last);
+  nameGenerator->SetIncrementIndex(1);
+  std::vector<std::string> names = nameGenerator->GetFileNames();
 
-    // List the files
-    //
-    std::vector<std::string>::iterator nit;
-    for (nit = names.begin();
-         nit != names.end();
-         nit++)
-    {
-        std::cout << "File: " << (*nit).c_str() << std::endl;
-    }
+  // List the files
+  //
+  std::vector<std::string>::iterator nit;
+  for (nit = names.begin(); nit != names.end(); nit++)
+  {
+    std::cout << "File: " << (*nit).c_str() << std::endl;
+  }
 
-    reader->SetFileNames( names  );
+  reader->SetFileNames(names);
 
-    writer->SetFileName( outputFilename );
-    writer->SetInput( reader->GetOutput() );
-    try
-    {
-        writer->Update();
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cerr << "ExceptionObject caught !" << std::endl;
-        std::cerr << err << std::endl;
-        return EXIT_FAILURE;
-    }
-    return EXIT_SUCCESS;
+  writer->SetFileName(outputFilename);
+  writer->SetInput(reader->GetOutput());
+  try
+  {
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/IO/ImageBase/CreateAListOfFileNames/Code.cxx
+++ b/src/IO/ImageBase/CreateAListOfFileNames/Code.cxx
@@ -18,22 +18,21 @@
 
 #include "itkNumericSeriesFileNames.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-  itk::NumericSeriesFileNames::Pointer numericSeriesFileNames =
-    itk::NumericSeriesFileNames::New();
+  itk::NumericSeriesFileNames::Pointer numericSeriesFileNames = itk::NumericSeriesFileNames::New();
   numericSeriesFileNames->SetStartIndex(0);
   numericSeriesFileNames->SetEndIndex(150);
   numericSeriesFileNames->SetIncrementIndex(10);
   numericSeriesFileNames->SetSeriesFormat("output_%d.png");
 
-  std::vector< std::string > fileNames =
-    numericSeriesFileNames->GetFileNames();
+  std::vector<std::string> fileNames = numericSeriesFileNames->GetFileNames();
 
-  for(const auto & fileName : fileNames)
-    {
+  for (const auto & fileName : fileNames)
+  {
     std::cout << fileName << std::endl;
-    }
+  }
 
   std::cout << std::endl;
   std::cout << "***************" << std::endl;
@@ -43,10 +42,10 @@ int main(int, char *[])
 
   fileNames = numericSeriesFileNames->GetFileNames();
 
-  for(const auto & fileName : fileNames)
-    {
+  for (const auto & fileName : fileNames)
+  {
     std::cout << fileName << std::endl;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/IO/ImageBase/GenerateSlicesFromVolume/Code.cxx
+++ b/src/IO/ImageBase/GenerateSlicesFromVolume/Code.cxx
@@ -22,69 +22,67 @@
 #include "itkNumericSeriesFileNames.h"
 #include "itkImageSeriesWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
 
-  std::string format =  std::string( outputFileName ) +
-                        std::string( "-%d.png" );
+  std::string format = std::string(outputFileName) + std::string("-%d.png");
 
   constexpr unsigned int Dimension = 3;
 
   using PixelType = unsigned char;
-  using InputImageType = itk::Image< PixelType, Dimension >;
+  using InputImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
   using OutputPixelType = unsigned char;
-  using RescaleImageType = itk::Image< OutputPixelType, Dimension >;
+  using RescaleImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using RescaleFilterType = itk::RescaleIntensityImageFilter< InputImageType, RescaleImageType >;
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<InputImageType, RescaleImageType>;
   RescaleFilterType::Pointer rescale = RescaleFilterType::New();
-  rescale->SetInput( reader->GetOutput() );
-  rescale->SetOutputMinimum( 0 );
-  rescale->SetOutputMaximum( 255 );
+  rescale->SetInput(reader->GetOutput());
+  rescale->SetOutputMinimum(0);
+  rescale->SetOutputMaximum(255);
   rescale->UpdateLargestPossibleRegion();
 
-  InputImageType::RegionType region =
-    reader->GetOutput()->GetLargestPossibleRegion();
-  InputImageType::SizeType size = region.GetSize();
+  InputImageType::RegionType region = reader->GetOutput()->GetLargestPossibleRegion();
+  InputImageType::SizeType   size = region.GetSize();
 
-  itk::NumericSeriesFileNames::Pointer fnames =
-    itk::NumericSeriesFileNames::New();
-  fnames->SetStartIndex( 0 );
-  fnames->SetEndIndex( size[2] - 1 );
-  fnames->SetIncrementIndex( 1 );
-  fnames->SetSeriesFormat( format.c_str() );
+  itk::NumericSeriesFileNames::Pointer fnames = itk::NumericSeriesFileNames::New();
+  fnames->SetStartIndex(0);
+  fnames->SetEndIndex(size[2] - 1);
+  fnames->SetIncrementIndex(1);
+  fnames->SetSeriesFormat(format.c_str());
 
-  using OutputImageType = itk::Image< OutputPixelType, 2 >;
+  using OutputImageType = itk::Image<OutputPixelType, 2>;
 
-  using WriterType = itk::ImageSeriesWriter< RescaleImageType, OutputImageType >;
+  using WriterType = itk::ImageSeriesWriter<RescaleImageType, OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetInput( rescale->GetOutput() );
-  writer->SetFileNames( fnames->GetFileNames() );
+  writer->SetInput(rescale->GetOutput());
+  writer->SetFileNames(fnames->GetFileNames());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/IO/ImageBase/ReadAnImage/Code.cxx
+++ b/src/IO/ImageBase/ReadAnImage/Code.cxx
@@ -19,25 +19,26 @@
 #include "itkImage.h"
 #include "itkImageFileReader.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
   ImageType::Pointer image = reader->GetOutput();

--- a/src/IO/ImageBase/ReadUnknownImageType/Code.cxx
+++ b/src/IO/ImageBase/ReadUnknownImageType/Code.cxx
@@ -20,265 +20,260 @@
 #include "itkImageFileWriter.h"
 #include "itkImageIOBase.h"
 
-template< class TImage >
-int ReadImage( const char* fileName,
-               typename TImage::Pointer image )
+template <class TImage>
+int
+ReadImage(const char * fileName, typename TImage::Pointer image)
 {
   using ImageType = TImage;
-  using ImageReaderType = itk::ImageFileReader< ImageType >;
+  using ImageReaderType = itk::ImageFileReader<ImageType>;
 
   typename ImageReaderType::Pointer reader = ImageReaderType::New();
-  reader->SetFileName( fileName );
+  reader->SetFileName(fileName);
 
   try
-    {
+  {
     reader->Update();
-    }
-  catch( itk::ExceptionObject& e )
-    {
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  image->Graft( reader->GetOutput() );
+  image->Graft(reader->GetOutput());
 
   return EXIT_SUCCESS;
 }
 
-template< unsigned int VDimension >
-int ReadScalarImage( const char* inputFileName,
-                     const itk::ImageIOBase::IOComponentType componentType )
+template <unsigned int VDimension>
+int
+ReadScalarImage(const char * inputFileName, const itk::ImageIOBase::IOComponentType componentType)
 {
-  switch( componentType )
-    {
+  switch (componentType)
+  {
     default:
     case itk::ImageIOBase::UNKNOWNCOMPONENTTYPE:
       std::cerr << "Unknown and unsupported component type!" << std::endl;
       return EXIT_FAILURE;
 
     case itk::ImageIOBase::UCHAR:
-      {
+    {
       using PixelType = unsigned char;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::CHAR:
-      {
+    {
       using PixelType = char;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::USHORT:
-      {
+    {
       using PixelType = unsigned short;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::SHORT:
-      {
+    {
       using PixelType = short;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::UINT:
-      {
+    {
       using PixelType = unsigned int;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::INT:
-      {
+    {
       using PixelType = int;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
     }
 
     case itk::ImageIOBase::ULONG:
-      {
+    {
       using PixelType = unsigned long;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::LONG:
-      {
+    {
       using PixelType = long;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::FLOAT:
-      {
+    {
       using PixelType = float;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
+    }
 
     case itk::ImageIOBase::DOUBLE:
-      {
+    {
       using PixelType = double;
-      using ImageType = itk::Image< PixelType, VDimension >;
+      using ImageType = itk::Image<PixelType, VDimension>;
 
       typename ImageType::Pointer image = ImageType::New();
 
-      if( ReadImage< ImageType >( inputFileName, image ) == EXIT_FAILURE )
-        {
+      if (ReadImage<ImageType>(inputFileName, image) == EXIT_FAILURE)
+      {
         return EXIT_FAILURE;
-        }
+      }
 
       std::cout << image << std::endl;
       break;
-      }
     }
+  }
   return EXIT_SUCCESS;
 }
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 2 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 2)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
 
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(
-      inputFileName,
-      itk::ImageIOFactory::FileModeType::ReadMode );
+    itk::ImageIOFactory::CreateImageIO(inputFileName, itk::ImageIOFactory::FileModeType::ReadMode);
 
-  imageIO->SetFileName( inputFileName );
+  imageIO->SetFileName(inputFileName);
   imageIO->ReadImageInformation();
 
   using IOPixelType = itk::ImageIOBase::IOPixelType;
   const IOPixelType pixelType = imageIO->GetPixelType();
 
-  std::cout << "Pixel Type is "
-            << itk::ImageIOBase::GetPixelTypeAsString( pixelType )
-            << std::endl;
+  std::cout << "Pixel Type is " << itk::ImageIOBase::GetPixelTypeAsString(pixelType) << std::endl;
 
   using IOComponentType = itk::ImageIOBase::IOComponentType;
   const IOComponentType componentType = imageIO->GetComponentType();
 
-  std::cout << "Component Type is "
-            << imageIO->GetComponentTypeAsString( componentType )
-            << std::endl;
+  std::cout << "Component Type is " << imageIO->GetComponentTypeAsString(componentType) << std::endl;
 
   const unsigned int imageDimension = imageIO->GetNumberOfDimensions();
 
   std::cout << "Image Dimension is " << imageDimension << std::endl;
 
-  switch( pixelType )
-    {
+  switch (pixelType)
+  {
     case itk::ImageIOBase::SCALAR:
+    {
+      if (imageDimension == 2)
       {
-      if( imageDimension == 2 )
-        {
-        return ReadScalarImage< 2 >( inputFileName, componentType );
-        }
-      else if( imageDimension == 3 )
-        {
-        return ReadScalarImage< 3 >( inputFileName, componentType );
-        }
-      else if( imageDimension == 4 )
-        {
-        return ReadScalarImage< 4 >( inputFileName, componentType );
-        }
+        return ReadScalarImage<2>(inputFileName, componentType);
       }
+      else if (imageDimension == 3)
+      {
+        return ReadScalarImage<3>(inputFileName, componentType);
+      }
+      else if (imageDimension == 4)
+      {
+        return ReadScalarImage<4>(inputFileName, componentType);
+      }
+    }
 
     default:
       std::cerr << "not implemented yet!" << std::endl;
       return EXIT_FAILURE;
-    }
+  }
   return EXIT_SUCCESS;
 }

--- a/src/IO/ImageBase/RegisterIOFactories/Code.cxx
+++ b/src/IO/ImageBase/RegisterIOFactories/Code.cxx
@@ -20,16 +20,17 @@
 #include "itkMetaImageIOFactory.h"
 #include "itkPNGImageIOFactory.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-     {
-     std::cerr << "Usage: "<< std::endl;
-     std::cerr << argv[0];
-     std::cerr << " <MetaImageFileName> <PNGFileName>";
-     std::cerr << std::endl;
-     return EXIT_FAILURE;
-     }
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0];
+    std::cerr << " <MetaImageFileName> <PNGFileName>";
+    std::cerr << std::endl;
+    return EXIT_FAILURE;
+  }
 
   const char * metaImageFileName = argv[1];
   const char * pngFileName = argv[2];
@@ -37,68 +38,66 @@ int main( int argc, char* argv[] )
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
 
-  using RegisteredObjectsContainerType = std::list< itk::LightObject::Pointer >;
+  using RegisteredObjectsContainerType = std::list<itk::LightObject::Pointer>;
 
 
-  RegisteredObjectsContainerType registeredIOs =
-    itk::ObjectFactoryBase::CreateAllInstance( "itkImageIOBase" );
+  RegisteredObjectsContainerType registeredIOs = itk::ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
   std::cout << "When CMake is not used to register the IO classes, there are\n"
-            << registeredIOs.size()
-            << " IO objects available to the ImageFileReader.\n" << std::endl;
+            << registeredIOs.size() << " IO objects available to the ImageFileReader.\n"
+            << std::endl;
 
 
   std::cout << "When we try to read a MetaImage, we will ";
-  reader->SetFileName( metaImageFileName );
+  reader->SetFileName(metaImageFileName);
   try
-    {
+  {
     reader->Update();
     return EXIT_FAILURE;
-    }
-  catch( itk::ImageFileReaderException & )
-    {
+  }
+  catch (itk::ImageFileReaderException &)
+  {
     std::cout << "fail.\n" << std::endl;
-    }
+  }
 
 
   std::cout << "After registering the MetaImageIO object, ";
   itk::MetaImageIOFactory::RegisterOneFactory();
 
   std::cout << "there are\n";
-  registeredIOs = itk::ObjectFactoryBase::CreateAllInstance( "itkImageIOBase" );
-  std::cout << registeredIOs.size()
-            << " IO objects available to the ImageFileReader.\n" << std::endl;
+  registeredIOs = itk::ObjectFactoryBase::CreateAllInstance("itkImageIOBase");
+  std::cout << registeredIOs.size() << " IO objects available to the ImageFileReader.\n" << std::endl;
 
   std::cout << "Now, when we try to read a MetaImage, we will ";
   try
-    {
+  {
     reader->Update();
     std::cout << "succeed.\n" << std::endl;
-    }
-  catch( itk::ImageFileReaderException & error )
-    {
+  }
+  catch (itk::ImageFileReaderException & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
 
   std::cout << "Every format desired to be supported by the reader\n"
             << "must be registered." << std::endl;
   itk::PNGImageIOFactory::RegisterOneFactory();
-  reader->SetFileName( pngFileName );
+  reader->SetFileName(pngFileName);
   try
-    {
+  {
     reader->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
 
   return EXIT_SUCCESS;

--- a/src/IO/ImageBase/WriteAnImage/Code.cxx
+++ b/src/IO/ImageBase/WriteAnImage/Code.cxx
@@ -22,24 +22,25 @@
 #include <iostream>
 #include <string>
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
   std::string outputFilename;
-  if(argc > 1)
-    {
+  if (argc > 1)
+  {
     outputFilename = argv[1];
-    }
+  }
   else
-    {
+  {
     outputFilename = "test.png";
-    }
+  }
 
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 2;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::RegionType region;
-  ImageType::IndexType start;
+  ImageType::IndexType  start;
   start[0] = 0;
   start[1] = 0;
 
@@ -58,20 +59,20 @@ int main(int argc, char *argv[])
   ind[0] = 10;
   ind[1] = 10;
 
-  using WriterType = itk::ImageFileWriter< ImageType  >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName(outputFilename);
   writer->SetInput(image);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/IO/Mesh/ReadMesh/Code.cxx
+++ b/src/IO/Mesh/ReadMesh/Code.cxx
@@ -20,39 +20,40 @@
 #include "itkMeshFileReader.h"
 #include "itkMeshFileWriter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( ( argc != 2 ) && ( argc != 4 ) )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if ((argc != 2) && (argc != 4))
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <id 1 (optional)> <id 2 (optional)>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 3;
 
   using CoordinateType = double;
-  using MeshType = itk::Mesh< CoordinateType, Dimension >;
+  using MeshType = itk::Mesh<CoordinateType, Dimension>;
 
-  using ReaderType = itk::MeshFileReader< MeshType >;
+  using ReaderType = itk::MeshFileReader<MeshType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
   MeshType::Pointer mesh = reader->GetOutput();
 
-  if( argc == 4 )
-    {
-    MeshType::PointIdentifier id1 = std::stoi( argv[2] );
-    MeshType::PointIdentifier id2 = std::stoi( argv[3] );
+  if (argc == 4)
+  {
+    MeshType::PointIdentifier id1 = std::stoi(argv[2]);
+    MeshType::PointIdentifier id2 = std::stoi(argv[3]);
 
-    MeshType::PointType p = mesh->GetPoint( id1 );
-    MeshType::PointType q = mesh->GetPoint( id2 );
+    MeshType::PointType p = mesh->GetPoint(id1);
+    MeshType::PointType q = mesh->GetPoint(id2);
 
-    std::cout << p.EuclideanDistanceTo( q ) << std::endl;
-    }
+    std::cout << p.EuclideanDistanceTo(q) << std::endl;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/IO/TIFF/WriteATIFFImage/Code.cxx
+++ b/src/IO/TIFF/WriteATIFFImage/Code.cxx
@@ -21,25 +21,26 @@
 #include "itkImageRegionIterator.h"
 #include "itkTIFFImageIO.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
   std::string outputFilename;
-  if(argc > 1)
-    {
+  if (argc > 1)
+  {
     outputFilename = argv[1];
-    }
+  }
   else
-    {
+  {
     outputFilename = "test.tif";
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
 
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   ImageType::RegionType region;
-  ImageType::IndexType start;
+  ImageType::IndexType  start;
   start[0] = 0;
   start[1] = 0;
 
@@ -54,22 +55,22 @@ int main(int argc, char *argv[])
   image->SetRegions(region);
   image->Allocate();
 
-  itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-  while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 100)
     {
-    if(imageIterator.GetIndex()[0] > 100)
-      {
       imageIterator.Set(100);
-      }
-    else
-      {
-      imageIterator.Set(200);
-      }
-    ++imageIterator;
     }
+    else
+    {
+      imageIterator.Set(200);
+    }
+    ++imageIterator;
+  }
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   using TIFFIOType = itk::TIFFImageIO;
 
   TIFFIOType::Pointer tiffIO = TIFFIOType::New();
@@ -81,14 +82,14 @@ int main(int argc, char *argv[])
   writer->SetImageIO(tiffIO);
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/IO/TransformBase/ReadTransformFromFile/Code.cxx
+++ b/src/IO/TransformBase/ReadTransformFromFile/Code.cxx
@@ -18,33 +18,32 @@
 #include "itkTransformFileReader.h"
 #include "itkTransformFactoryBase.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    std::string fileName;
-    if(argc == 1) // No arguments were provided
-    {
-        fileName = "test.tfm";
-    }
-    else
-    {
-        fileName = argv[1];
-    }
+  std::string fileName;
+  if (argc == 1) // No arguments were provided
+  {
+    fileName = "test.tfm";
+  }
+  else
+  {
+    fileName = argv[1];
+  }
 
-    // Register default transforms
-    itk::TransformFactoryBase::RegisterDefaultTransforms();
+  // Register default transforms
+  itk::TransformFactoryBase::RegisterDefaultTransforms();
 
 #if (ITK_VERSION_MAJOR == 4 && ITK_VERSION_MINOR >= 5) || ITK_VERSION_MAJOR > 4
-    itk::TransformFileReaderTemplate<float>::Pointer reader =
-    itk::TransformFileReaderTemplate<float>::New();
+  itk::TransformFileReaderTemplate<float>::Pointer reader = itk::TransformFileReaderTemplate<float>::New();
 #else
-    itk::TransformFileReader::Pointer writer = itk::TransformFileReader::New();
+  itk::TransformFileReader::Pointer writer = itk::TransformFileReader::New();
 #endif
-    reader->SetFileName(fileName);
-    reader->Update();
+  reader->SetFileName(fileName);
+  reader->Update();
 
-    // Display the transform
-    std::cout << *(reader->GetTransformList()->begin()) << std::endl;
+  // Display the transform
+  std::cout << *(reader->GetTransformList()->begin()) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/IO/TransformBase/WriteTransformToFile/Code.cxx
+++ b/src/IO/TransformBase/WriteTransformToFile/Code.cxx
@@ -20,31 +20,31 @@
 #include "itkRigid2DTransform.h"
 #include "itkTransformFileWriter.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    std::string fileName;
-    if(argc == 1) // No arguments were provided
-    {
-        fileName = "test.tfm";
-    }
-    else
-    {
-        fileName = argv[1];
-    }
+  std::string fileName;
+  if (argc == 1) // No arguments were provided
+  {
+    fileName = "test.tfm";
+  }
+  else
+  {
+    fileName = argv[1];
+  }
 
-    using TransformType = itk::Rigid2DTransform< float >;
-    TransformType::Pointer transform = TransformType::New();
+  using TransformType = itk::Rigid2DTransform<float>;
+  TransformType::Pointer transform = TransformType::New();
 
 #if (ITK_VERSION_MAJOR == 4 && ITK_VERSION_MINOR >= 5) || ITK_VERSION_MAJOR > 4
-    itk::TransformFileWriterTemplate<float>::Pointer writer =
-            itk::TransformFileWriterTemplate<float>::New();
+  itk::TransformFileWriterTemplate<float>::Pointer writer = itk::TransformFileWriterTemplate<float>::New();
 #else
-    itk::TransformFileWriter::Pointer writer = itk::TransformFileWriter::New();
+  itk::TransformFileWriter::Pointer writer = itk::TransformFileWriter::New();
 #endif
 
-    writer->SetInput(transform);
-    writer->SetFileName(fileName);
-    writer->Update();
+  writer->SetInput(transform);
+  writer->SetFileName(fileName);
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/IO/TransformFactory/RegisterTransformWithTransformFactory/Code.cxx
+++ b/src/IO/TransformFactory/RegisterTransformWithTransformFactory/Code.cxx
@@ -20,31 +20,31 @@
 #include "itkTransformFactory.h"
 #include "itkMatrixOffsetTransformBase.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    std::string fileName;
-    if(argc == 1) // No arguments were provided
-    {
-        fileName = "test.tfm";
-    }
-    else
-    {
-        fileName = argv[1];
-    }
+  std::string fileName;
+  if (argc == 1) // No arguments were provided
+  {
+    fileName = "test.tfm";
+  }
+  else
+  {
+    fileName = argv[1];
+  }
 
-    using MatrixOffsetTransformType = itk::MatrixOffsetTransformBase< double, 3, 3 >;
-    itk::TransformFactory<MatrixOffsetTransformType>::RegisterTransform();
+  using MatrixOffsetTransformType = itk::MatrixOffsetTransformBase<double, 3, 3>;
+  itk::TransformFactory<MatrixOffsetTransformType>::RegisterTransform();
 
 #if (ITK_VERSION_MAJOR == 4 && ITK_VERSION_MINOR >= 5) || ITK_VERSION_MAJOR > 4
-    itk::TransformFileReaderTemplate<float>::Pointer reader =
-    itk::TransformFileReaderTemplate<float>::New();
+  itk::TransformFileReaderTemplate<float>::Pointer reader = itk::TransformFileReaderTemplate<float>::New();
 #else
-    itk::TransformFileReader::Pointer reader = itk::TransformFileReader::New();
+  itk::TransformFileReader::Pointer reader = itk::TransformFileReader::New();
 #endif
-    reader->SetFileName(fileName);
-    reader->Update();
+  reader->SetFileName(fileName);
+  reader->Update();
 
-    std::cout << *(reader->GetTransformList()->begin()) << std::endl;
+  std::cout << *(reader->GetTransformList()->begin()) << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/ImageCompareCommand.cxx
+++ b/src/ImageCompareCommand.cxx
@@ -30,303 +30,294 @@
 
 #define ITK_TEST_DIMENSION_MAX 6
 
-int RegressionTestImage (const char *, const char *, int, bool,double,int,int);
+int
+RegressionTestImage(const char *, const char *, int, bool, double, int, int);
 
-int main(int argc, char **argv)
+int
+main(int argc, char ** argv)
 {
   // Process some command-line arguments intended for BatchMake
   MetaCommand command;
 
   // Option for setting the tolerable difference in intensity values
   // between the two images.
-  command.SetOption("toleranceIntensity","i",false,
-      "Acceptable differences in pixels intensity");
-  command.SetOptionLongTag("toleranceIntensity","tolerance-intensity");
-  command.AddOptionField("toleranceIntensity","value",MetaCommand::FLOAT,true);
+  command.SetOption("toleranceIntensity", "i", false, "Acceptable differences in pixels intensity");
+  command.SetOptionLongTag("toleranceIntensity", "tolerance-intensity");
+  command.AddOptionField("toleranceIntensity", "value", MetaCommand::FLOAT, true);
 
   // Option for setting the radius of the neighborhood around a pixel
   // to search for similar intensity values.
-  command.SetOption("toleranceRadius","r",false,
-      "Neighbor pixels to look for similar values");
-  command.SetOptionLongTag("toleranceRadius","tolerance-radius");
-  command.AddOptionField("toleranceRadius","value",MetaCommand::INT,true);
+  command.SetOption("toleranceRadius", "r", false, "Neighbor pixels to look for similar values");
+  command.SetOptionLongTag("toleranceRadius", "tolerance-radius");
+  command.AddOptionField("toleranceRadius", "value", MetaCommand::INT, true);
 
   // Option for setting the number of pixel that can be tolerated to
   // have different intensities.
-  command.SetOption("toleranceNumberOfPixels","n",false,
-      "Number of Pixels that are acceptable to have intensity differences");
-  command.SetOptionLongTag("toleranceNumberOfPixels",
-    "tolerance-number-of-pixels");
-  command.AddOptionField("toleranceNumberOfPixels",
-    "value",MetaCommand::INT,true);
+  command.SetOption(
+    "toleranceNumberOfPixels", "n", false, "Number of Pixels that are acceptable to have intensity differences");
+  command.SetOptionLongTag("toleranceNumberOfPixels", "tolerance-number-of-pixels");
+  command.AddOptionField("toleranceNumberOfPixels", "value", MetaCommand::INT, true);
 
   // Option for setting the filename of the test image.
-  command.SetOption("testImage","t",true,
-      "Filename of the image to be tested against the baseline images");
-  command.SetOptionLongTag("testImage","test-image");
-  command.AddOptionField("testImage","filename",MetaCommand::STRING,true);
+  command.SetOption("testImage", "t", true, "Filename of the image to be tested against the baseline images");
+  command.SetOptionLongTag("testImage", "test-image");
+  command.AddOptionField("testImage", "filename", MetaCommand::STRING, true);
 
   // Option for setting the filename of multiple baseline images.
-  command.SetOption("baselineImages","s",false,
-      "List of baseline images <N> <image1> <image2>...<imageN>");
-  command.SetOptionLongTag("baselineImages","baseline-images");
-  command.AddOptionField("baselineImages","filename",MetaCommand::LIST,true);
+  command.SetOption("baselineImages", "s", false, "List of baseline images <N> <image1> <image2>...<imageN>");
+  command.SetOptionLongTag("baselineImages", "baseline-images");
+  command.AddOptionField("baselineImages", "filename", MetaCommand::LIST, true);
 
   // Option for setting the filename of a single baseline image.
-  command.SetOption("baselineImage","b",false,
-      "Baseline images filename");
-  command.SetOptionLongTag("baselineImage","baseline-image");
-  command.AddOptionField("baselineImage","filename",MetaCommand::STRING,true);
+  command.SetOption("baselineImage", "b", false, "Baseline images filename");
+  command.SetOptionLongTag("baselineImage", "baseline-image");
+  command.AddOptionField("baselineImage", "filename", MetaCommand::STRING, true);
 
-  command.SetParseFailureOnUnrecognizedOption( true );
+  command.SetParseFailureOnUnrecognizedOption(true);
 
-  if( !command.Parse( argc, argv ) )
-    {
-    std::cerr << "Error during " << argv[0]
-              << " command argument parsing." << std::endl;
+  if (!command.Parse(argc, argv))
+  {
+    std::cerr << "Error during " << argv[0] << " command argument parsing." << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  double toleranceIntensity = 0.0;
+  double        toleranceIntensity = 0.0;
   unsigned int  toleranceRadius = 0;
   unsigned long toleranceNumberOfPixels = 0;
-  std::string testImageFilename;
-  std::string baselineImageFilename;
+  std::string   testImageFilename;
+  std::string   baselineImageFilename;
 
   // If a value of intensity tolerance was given in the command line
-  if( command.GetOptionWasSet("toleranceIntensity") )
-    {
-    toleranceIntensity =
-      command.GetValueAsFloat("toleranceIntensity","value");
-    }
+  if (command.GetOptionWasSet("toleranceIntensity"))
+  {
+    toleranceIntensity = command.GetValueAsFloat("toleranceIntensity", "value");
+  }
 
   // If a value of neighborhood radius tolerance was given in the command line
-  if( command.GetOptionWasSet("toleranceRadius") )
-    {
-    toleranceRadius =
-      command.GetValueAsInt("toleranceRadius","value");
-    }
+  if (command.GetOptionWasSet("toleranceRadius"))
+  {
+    toleranceRadius = command.GetValueAsInt("toleranceRadius", "value");
+  }
 
   // If a value of number of pixels tolerance was given in the command line
-  if( command.GetOptionWasSet("toleranceNumberOfPixels") )
-    {
-    toleranceNumberOfPixels =
-      command.GetValueAsInt("toleranceNumberOfPixels","value");
-    }
+  if (command.GetOptionWasSet("toleranceNumberOfPixels"))
+  {
+    toleranceNumberOfPixels = command.GetValueAsInt("toleranceNumberOfPixels", "value");
+  }
 
   // Get the filename of the image to be tested
-  if( command.GetOptionWasSet("testImage") )
-    {
-    testImageFilename =
-      command.GetValueAsString("testImage","filename");
-    }
+  if (command.GetOptionWasSet("testImage"))
+  {
+    testImageFilename = command.GetValueAsString("testImage", "filename");
+  }
 
-  std::list< std::string > baselineImageFilenames;
+  std::list<std::string> baselineImageFilenames;
   baselineImageFilenames.clear();
 
   bool singleBaselineImage = true;
 
-  if( !command.GetOptionWasSet("baselineImage") &&
-      !command.GetOptionWasSet("baselineImages") )
-    {
+  if (!command.GetOptionWasSet("baselineImage") && !command.GetOptionWasSet("baselineImages"))
+  {
     std::cerr << "You must provide a --baseline-image"
               << " or --baseline-images option." << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Get the filename of the base line image
-  if( command.GetOptionWasSet("baselineImage") )
-    {
+  if (command.GetOptionWasSet("baselineImage"))
+  {
     singleBaselineImage = true;
-    baselineImageFilename = command.GetValueAsString("baselineImage",
-      "filename");
-    }
+    baselineImageFilename = command.GetValueAsString("baselineImage", "filename");
+  }
 
   // Get the filename of the base line image
-  if( command.GetOptionWasSet("baselineImages") )
-    {
+  if (command.GetOptionWasSet("baselineImages"))
+  {
     singleBaselineImage = false;
     baselineImageFilenames = command.GetValueAsList("baselineImages");
-    }
+  }
 
   std::string bestBaselineFilename;
-  int bestBaselineStatus = 2001;
+  int         bestBaselineStatus = 2001;
 
   try
+  {
+    if (singleBaselineImage)
     {
-    if( singleBaselineImage )
-      {
-      bestBaselineStatus =
-        RegressionTestImage(
-            testImageFilename.c_str(), baselineImageFilename.c_str(),
-            0, false, toleranceIntensity, toleranceRadius,
-            toleranceNumberOfPixels);
+      bestBaselineStatus = RegressionTestImage(testImageFilename.c_str(),
+                                               baselineImageFilename.c_str(),
+                                               0,
+                                               false,
+                                               toleranceIntensity,
+                                               toleranceRadius,
+                                               toleranceNumberOfPixels);
       bestBaselineFilename = baselineImageFilename;
-      }
+    }
     else
-      {
+    {
 
-      using nameIterator = std::list< std::string >::const_iterator;
+      using nameIterator = std::list<std::string>::const_iterator;
       nameIterator baselineImageItr = baselineImageFilenames.begin();
-      while( baselineImageItr != baselineImageFilenames.end() )
+      while (baselineImageItr != baselineImageFilenames.end())
+      {
+        const int currentStatus = RegressionTestImage(testImageFilename.c_str(),
+                                                      baselineImageItr->c_str(),
+                                                      0,
+                                                      false,
+                                                      toleranceIntensity,
+                                                      toleranceRadius,
+                                                      toleranceNumberOfPixels);
+        if (currentStatus < bestBaselineStatus)
         {
-        const int currentStatus =
-          RegressionTestImage(
-              testImageFilename.c_str(), baselineImageItr->c_str(),
-              0, false, toleranceIntensity, toleranceRadius,
-              toleranceNumberOfPixels);
-        if(currentStatus < bestBaselineStatus)
-          {
           bestBaselineStatus = currentStatus;
           bestBaselineFilename = *baselineImageItr;
-          }
-        if(bestBaselineStatus == 0)
-          {
-          break;
-          }
-        ++baselineImageItr;
         }
+        if (bestBaselineStatus == 0)
+        {
+          break;
+        }
+        ++baselineImageItr;
       }
-    // generate images of our closest match
-    if(bestBaselineStatus == 0)
-      {
-      RegressionTestImage(
-        testImageFilename.c_str(),
-        bestBaselineFilename.c_str(), 1, false,
-        toleranceIntensity,toleranceRadius,toleranceNumberOfPixels);
-      }
-    else
-      {
-      RegressionTestImage(
-        testImageFilename.c_str(),
-        bestBaselineFilename.c_str(), 1, true,
-        toleranceIntensity,toleranceRadius,toleranceNumberOfPixels);
-      }
-
     }
-  catch(itk::ExceptionObject& e)
+    // generate images of our closest match
+    if (bestBaselineStatus == 0)
     {
+      RegressionTestImage(testImageFilename.c_str(),
+                          bestBaselineFilename.c_str(),
+                          1,
+                          false,
+                          toleranceIntensity,
+                          toleranceRadius,
+                          toleranceNumberOfPixels);
+    }
+    else
+    {
+      RegressionTestImage(testImageFilename.c_str(),
+                          bestBaselineFilename.c_str(),
+                          1,
+                          true,
+                          toleranceIntensity,
+                          toleranceRadius,
+                          toleranceNumberOfPixels);
+    }
+  }
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "ITK test driver caught an ITK exception:\n";
     std::cerr << e << "\n";
     bestBaselineStatus = -1;
-    }
-  catch(const std::exception& e)
-    {
+  }
+  catch (const std::exception & e)
+  {
     std::cerr << "ITK test driver caught an exception:\n";
     std::cerr << e.what() << "\n";
     bestBaselineStatus = -1;
-    }
-  catch(...)
-    {
+  }
+  catch (...)
+  {
     std::cerr << "ITK test driver caught an unknown exception!!!\n";
     bestBaselineStatus = -1;
-    }
+  }
   std::cout << bestBaselineStatus << std::endl;
   return bestBaselineStatus;
 }
 
 // Regression Testing Code
-int RegressionTestImage (const char *testImageFilename,
-                         const char *baselineImageFilename,
-                         int reportErrors,
-                         bool createDifferenceImage,
-                         double intensityTolerance,
-                         int radiusTolerance,
-                         int numberOfPixelsTolerance)
+int
+RegressionTestImage(const char * testImageFilename,
+                    const char * baselineImageFilename,
+                    int          reportErrors,
+                    bool         createDifferenceImage,
+                    double       intensityTolerance,
+                    int          radiusTolerance,
+                    int          numberOfPixelsTolerance)
 {
   // Use the factory mechanism to read the test
   // and baseline files and convert them to double
-  using ImageType = itk::Image<double,ITK_TEST_DIMENSION_MAX>;
-  using OutputType = itk::Image<unsigned char,ITK_TEST_DIMENSION_MAX>;
-  using DiffOutputType = itk::Image<unsigned char,2>;
+  using ImageType = itk::Image<double, ITK_TEST_DIMENSION_MAX>;
+  using OutputType = itk::Image<unsigned char, ITK_TEST_DIMENSION_MAX>;
+  using DiffOutputType = itk::Image<unsigned char, 2>;
   using ReaderType = itk::ImageFileReader<ImageType>;
 
   // Read the baseline file
   ReaderType::Pointer baselineReader = ReaderType::New();
-    baselineReader->SetFileName(baselineImageFilename);
+  baselineReader->SetFileName(baselineImageFilename);
   try
-    {
+  {
     baselineReader->UpdateLargestPossibleRegion();
-    }
-  catch (itk::ExceptionObject& e)
-    {
-    std::cerr << "Exception detected while reading "
-              << baselineImageFilename << " : "  << e;
+  }
+  catch (itk::ExceptionObject & e)
+  {
+    std::cerr << "Exception detected while reading " << baselineImageFilename << " : " << e;
     return 1000;
-    }
+  }
 
   // Read the file generated by the test
   ReaderType::Pointer testReader = ReaderType::New();
-    testReader->SetFileName(testImageFilename);
+  testReader->SetFileName(testImageFilename);
   try
-    {
+  {
     testReader->UpdateLargestPossibleRegion();
-    }
-  catch (itk::ExceptionObject& e)
-    {
-    std::cerr << "Exception detected while reading "
-              << testImageFilename << " : "  << e << std::endl;
+  }
+  catch (itk::ExceptionObject & e)
+  {
+    std::cerr << "Exception detected while reading " << testImageFilename << " : " << e << std::endl;
     return 1000;
-    }
+  }
 
   // The sizes of the baseline and test image must match
   ImageType::SizeType baselineSize;
-  ImageType::Pointer baseline = baselineReader->GetOutput();
+  ImageType::Pointer  baseline = baselineReader->GetOutput();
   baselineSize = baseline->GetLargestPossibleRegion().GetSize();
   ImageType::SizeType testSize;
-  ImageType::Pointer test = testReader->GetOutput();
+  ImageType::Pointer  test = testReader->GetOutput();
   testSize = test->GetLargestPossibleRegion().GetSize();
 
   if (baselineSize != testSize)
-    {
-    std::cerr << "The size of the Baseline image and Test image do not match!"
-              << std::endl
-              << "Baseline image: " << baselineImageFilename
-              << " has size " << baselineSize << std::endl
-              << "Test image:     " << testImageFilename
-              << " has size " << testSize << std::endl;
+  {
+    std::cerr << "The size of the Baseline image and Test image do not match!" << std::endl
+              << "Baseline image: " << baselineImageFilename << " has size " << baselineSize << std::endl
+              << "Test image:     " << testImageFilename << " has size " << testSize << std::endl;
     return 1;
-    }
+  }
 
   // Now compare the two images
-  using DiffType = itk::Testing::ComparisonImageFilter<ImageType,ImageType>;
+  using DiffType = itk::Testing::ComparisonImageFilter<ImageType, ImageType>;
   DiffType::Pointer diff = DiffType::New();
-    diff->SetValidInput(baselineReader->GetOutput());
-    diff->SetTestInput(testReader->GetOutput());
+  diff->SetValidInput(baselineReader->GetOutput());
+  diff->SetTestInput(testReader->GetOutput());
 
-    diff->SetDifferenceThreshold( intensityTolerance );
-    diff->SetToleranceRadius( radiusTolerance );
+  diff->SetDifferenceThreshold(intensityTolerance);
+  diff->SetToleranceRadius(radiusTolerance);
 
-    diff->UpdateLargestPossibleRegion();
+  diff->UpdateLargestPossibleRegion();
 
   bool differenceFailed = false;
 
   const double averageIntensityDifference = diff->GetTotalDifference();
 
-  const unsigned long numberOfPixelsWithDifferences =
-                        diff->GetNumberOfPixelsWithDifferences();
+  const unsigned long numberOfPixelsWithDifferences = diff->GetNumberOfPixelsWithDifferences();
 
-  if( averageIntensityDifference > 0.0 )
+  if (averageIntensityDifference > 0.0)
+  {
+    if (static_cast<int>(numberOfPixelsWithDifferences) > numberOfPixelsTolerance)
     {
-    if( static_cast<int>(numberOfPixelsWithDifferences) >
-          numberOfPixelsTolerance )
-      {
       differenceFailed = true;
-      }
+    }
     else
-      {
-      differenceFailed = false;
-      }
-    }
-  else
     {
-    differenceFailed = false;
+      differenceFailed = false;
     }
+  }
+  else
+  {
+    differenceFailed = false;
+  }
 
   if (reportErrors)
-    {
-    using RescaleType = itk::RescaleIntensityImageFilter<ImageType,OutputType>;
-    using ExtractType = itk::ExtractImageFilter<OutputType,DiffOutputType>;
+  {
+    using RescaleType = itk::RescaleIntensityImageFilter<ImageType, OutputType>;
+    using ExtractType = itk::ExtractImageFilter<OutputType, DiffOutputType>;
     using WriterType = itk::ImageFileWriter<DiffOutputType>;
     using RegionType = itk::ImageRegion<ITK_TEST_DIMENSION_MAX>;
 
@@ -337,11 +328,9 @@ int RegressionTestImage (const char *testImageFilename,
 
     RescaleType::Pointer rescale = RescaleType::New();
 
-    const unsigned char nonPositiveMin =
-      itk::NumericTraits<unsigned char>::NonpositiveMin();
+    const unsigned char nonPositiveMin = itk::NumericTraits<unsigned char>::NonpositiveMin();
     rescale->SetOutputMinimum(nonPositiveMin);
-    const unsigned char unsignedCharMax =
-      itk::NumericTraits<unsigned char>::max();
+    const unsigned char unsignedCharMax = itk::NumericTraits<unsigned char>::max();
     rescale->SetOutputMaximum(unsignedCharMax);
     rescale->SetInput(diff->GetOutput());
     rescale->UpdateLargestPossibleRegion();
@@ -351,9 +340,9 @@ int RegressionTestImage (const char *testImageFilename,
 
     size = rescale->GetOutput()->GetLargestPossibleRegion().GetSize();
     for (unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; i++)
-      {
+    {
       size[i] = 0;
-      }
+    }
     region.SetSize(size);
 
     ExtractType::Pointer extract = ExtractType::New();
@@ -363,127 +352,120 @@ int RegressionTestImage (const char *testImageFilename,
     extract->SetExtractionRegion(region);
 
     WriterType::Pointer writer = WriterType::New();
-      writer->SetInput(extract->GetOutput());
-    if(createDifferenceImage)
-      {
+    writer->SetInput(extract->GetOutput());
+    if (createDifferenceImage)
+    {
       // if there are discrepencies, create an diff image
-      std::cout
-       << "<DartMeasurement name=\"ImageError\" type=\"numeric/double\">"
-       << averageIntensityDifference
-       <<  "</DartMeasurement>" << std::endl
+      std::cout << "<DartMeasurement name=\"ImageError\" type=\"numeric/double\">" << averageIntensityDifference
+                << "</DartMeasurement>" << std::endl
 
-       << "<DartMeasurement name=\"NumberOfPixelsError\" type=\"numeric/int\">"
-       << numberOfPixelsWithDifferences
-       <<  "</DartMeasurement>" << std::endl;
+                << "<DartMeasurement name=\"NumberOfPixelsError\" type=\"numeric/int\">"
+                << numberOfPixelsWithDifferences << "</DartMeasurement>" << std::endl;
 
       std::ostringstream diffName;
       diffName << testImageFilename << ".diff.png";
       try
-        {
+      {
         rescale->SetInput(diff->GetOutput());
         rescale->Update();
-        }
-      catch(const std::exception& e)
-        {
+      }
+      catch (const std::exception & e)
+      {
         std::cerr << "Error during rescale of " << diffName.str() << std::endl;
         std::cerr << e.what() << "\n";
-        }
+      }
       catch (...)
-        {
+      {
         std::cerr << "Error during rescale of " << diffName.str() << std::endl;
-        }
+      }
       writer->SetFileName(diffName.str().c_str());
       try
-        {
+      {
         writer->Update();
-        }
-      catch(const std::exception& e)
-        {
+      }
+      catch (const std::exception & e)
+      {
         std::cerr << "Error during write of " << diffName.str() << std::endl;
         std::cerr << e.what() << "\n";
-        }
+      }
       catch (...)
-        {
+      {
         std::cerr << "Error during write of " << diffName.str() << std::endl;
-        }
+      }
 
-      std::cout
-        << "<DartMeasurementFile name=\"DifferenceImage\" type=\"image/png\">";
+      std::cout << "<DartMeasurementFile name=\"DifferenceImage\" type=\"image/png\">";
       std::cout << diffName.str();
       std::cout << "</DartMeasurementFile>" << std::endl;
-      }
+    }
     std::ostringstream baseName;
     baseName << testImageFilename << ".base.png";
     try
-      {
+    {
       rescale->SetInput(baselineReader->GetOutput());
       rescale->Update();
-      }
-    catch(const std::exception& e)
-      {
+    }
+    catch (const std::exception & e)
+    {
       std::cerr << "Error during rescale of " << baseName.str() << std::endl;
       std::cerr << e.what() << "\n";
-      }
+    }
     catch (...)
-      {
+    {
       std::cerr << "Error during rescale of " << baseName.str() << std::endl;
-      }
+    }
     try
-      {
+    {
       writer->SetFileName(baseName.str().c_str());
       writer->Update();
-      }
-    catch(const std::exception& e)
-      {
+    }
+    catch (const std::exception & e)
+    {
       std::cerr << "Error during write of " << baseName.str() << std::endl;
       std::cerr << e.what() << "\n";
-      }
+    }
     catch (...)
-      {
+    {
       std::cerr << "Error during write of " << baseName.str() << std::endl;
-      }
+    }
 
-    std::cout
-      << "<DartMeasurementFile name=\"BaselineImage\" type=\"image/png\">";
+    std::cout << "<DartMeasurementFile name=\"BaselineImage\" type=\"image/png\">";
     std::cout << baseName.str();
     std::cout << "</DartMeasurementFile>" << std::endl;
 
     std::ostringstream testName;
     testName << testImageFilename << ".test.png";
     try
-      {
+    {
       rescale->SetInput(testReader->GetOutput());
       rescale->Update();
-      }
-    catch(const std::exception& e)
-      {
+    }
+    catch (const std::exception & e)
+    {
       std::cerr << "Error during rescale of " << testName.str() << std::endl;
       std::cerr << e.what() << "\n";
-      }
+    }
     catch (...)
-      {
+    {
       std::cerr << "Error during rescale of " << testName.str() << std::endl;
-      }
+    }
     try
-      {
+    {
       writer->SetFileName(testName.str().c_str());
       writer->Update();
-      }
-    catch(const std::exception& e)
-      {
+    }
+    catch (const std::exception & e)
+    {
       std::cerr << "Error during write of " << testName.str() << std::endl;
       std::cerr << e.what() << "\n";
-      }
+    }
     catch (...)
-      {
+    {
       std::cerr << "Error during write of " << testName.str() << std::endl;
-      }
+    }
 
     std::cout << "<DartMeasurementFile name=\"TestImage\" type=\"image/png\">";
     std::cout << testName.str();
     std::cout << "</DartMeasurementFile>" << std::endl;
-
-
-    }
+  }
   return differenceFailed;
 }

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
@@ -23,7 +23,7 @@
 #include "itkLabelToRGBImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 #include <sstream>
@@ -32,213 +32,193 @@ using ImageType = itk::Image<unsigned int, 2>;
 using RGBPixelType = itk::RGBPixel<unsigned char>;
 using RGBImageType = itk::Image<RGBPixelType, 2>;
 
-static void CreateIntensityImage(ImageType::Pointer image);
-static void CreateLabelImage(ImageType::Pointer image);
+static void
+CreateIntensityImage(ImageType::Pointer image);
+static void
+CreateLabelImage(ImageType::Pointer image);
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer labelImage = ImageType::New();
-    ImageType::Pointer intensityImage = ImageType::New();
-    int label = 1;
+  ImageType::Pointer labelImage = ImageType::New();
+  ImageType::Pointer intensityImage = ImageType::New();
+  int                label = 1;
 
-    if (argc < 2)
-    {
-        // Create a label image that is 0 in the background and where the
-        // objects are labeled
-        CreateLabelImage(labelImage);
-        labelImage->Print(std::cout);
-        // Create an intensity image.  Some LabelGeometry features (such as
-        // weighted centroid and integrated intensity) depend on an
-        // intensity image.
-        CreateIntensityImage(intensityImage);
-    }
-    else if (argc > 3)
-    {
-        using ImageReaderType = itk::ImageFileReader< ImageType  >;
-        ImageReaderType::Pointer labelReader =
-                ImageReaderType::New();
-        labelReader->SetFileName(argv[1]);
-        labelReader->Update();
+  if (argc < 2)
+  {
+    // Create a label image that is 0 in the background and where the
+    // objects are labeled
+    CreateLabelImage(labelImage);
+    labelImage->Print(std::cout);
+    // Create an intensity image.  Some LabelGeometry features (such as
+    // weighted centroid and integrated intensity) depend on an
+    // intensity image.
+    CreateIntensityImage(intensityImage);
+  }
+  else if (argc > 3)
+  {
+    using ImageReaderType = itk::ImageFileReader<ImageType>;
+    ImageReaderType::Pointer labelReader = ImageReaderType::New();
+    labelReader->SetFileName(argv[1]);
+    labelReader->Update();
 
-        labelImage = labelReader->GetOutput();
+    labelImage = labelReader->GetOutput();
 
-        ImageReaderType::Pointer intensityReader =
-                ImageReaderType::New();
-        intensityReader->SetFileName(argv[2]);
-        intensityReader->Update();
+    ImageReaderType::Pointer intensityReader = ImageReaderType::New();
+    intensityReader->SetFileName(argv[2]);
+    intensityReader->Update();
 
-        intensityImage = intensityReader->GetOutput();
+    intensityImage = intensityReader->GetOutput();
 
-        label = std::stoi(argv[3]);
-    }
+    label = std::stoi(argv[3]);
+  }
 
-    // NOTE: As of April 8, 2015 the filter does not work with non-zero
-    // origins
-    double origin[2] = {0.0, 0.0};
-    labelImage->SetOrigin(origin);
-    intensityImage->SetOrigin(origin);
+  // NOTE: As of April 8, 2015 the filter does not work with non-zero
+  // origins
+  double origin[2] = { 0.0, 0.0 };
+  labelImage->SetOrigin(origin);
+  intensityImage->SetOrigin(origin);
 
-    using LabelGeometryImageFilterType = itk::LabelGeometryImageFilter< ImageType >;
-    LabelGeometryImageFilterType::Pointer labelGeometryImageFilter = LabelGeometryImageFilterType::New();
-    labelGeometryImageFilter->SetInput( labelImage );
-    labelGeometryImageFilter->SetIntensityInput( intensityImage );
+  using LabelGeometryImageFilterType = itk::LabelGeometryImageFilter<ImageType>;
+  LabelGeometryImageFilterType::Pointer labelGeometryImageFilter = LabelGeometryImageFilterType::New();
+  labelGeometryImageFilter->SetInput(labelImage);
+  labelGeometryImageFilter->SetIntensityInput(intensityImage);
 
-    // These generate optional outputs.
-    labelGeometryImageFilter->CalculatePixelIndicesOn();
-    labelGeometryImageFilter->CalculateOrientedBoundingBoxOn();
-    labelGeometryImageFilter->CalculateOrientedLabelRegionsOn();
-    labelGeometryImageFilter->CalculateOrientedIntensityRegionsOn();
+  // These generate optional outputs.
+  labelGeometryImageFilter->CalculatePixelIndicesOn();
+  labelGeometryImageFilter->CalculateOrientedBoundingBoxOn();
+  labelGeometryImageFilter->CalculateOrientedLabelRegionsOn();
+  labelGeometryImageFilter->CalculateOrientedIntensityRegionsOn();
 
-    labelGeometryImageFilter->Update();
-    LabelGeometryImageFilterType::LabelsType allLabels =
-            labelGeometryImageFilter->GetLabels();
+  labelGeometryImageFilter->Update();
+  LabelGeometryImageFilterType::LabelsType allLabels = labelGeometryImageFilter->GetLabels();
 
-    using RGBFilterType = itk::LabelToRGBImageFilter<ImageType, RGBImageType>;
-    RGBFilterType::Pointer rgbLabelImage =
-            RGBFilterType::New();
-    rgbLabelImage->SetInput(labelImage);
+  using RGBFilterType = itk::LabelToRGBImageFilter<ImageType, RGBImageType>;
+  RGBFilterType::Pointer rgbLabelImage = RGBFilterType::New();
+  rgbLabelImage->SetInput(labelImage);
 
-    using RGBFilterType = itk::LabelToRGBImageFilter<ImageType, RGBImageType>;
-    RGBFilterType::Pointer rgbOrientedImage =
-            RGBFilterType::New();
-    rgbOrientedImage->SetInput(labelGeometryImageFilter->GetOrientedLabelImage(allLabels[label]));
+  using RGBFilterType = itk::LabelToRGBImageFilter<ImageType, RGBImageType>;
+  RGBFilterType::Pointer rgbOrientedImage = RGBFilterType::New();
+  rgbOrientedImage->SetInput(labelGeometryImageFilter->GetOrientedLabelImage(allLabels[label]));
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.ShareCameraOff();
-    viewer.InterpolateOff();
+  QuickView viewer;
+  viewer.ShareCameraOff();
+  viewer.InterpolateOff();
 
-    viewer.AddImage(
-            rgbLabelImage->GetOutput(),
-            true,
-            argc > 3 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated label image");
-    viewer.AddImage(
-            intensityImage.GetPointer(),
-            true,
-            argc > 3 ? itksys::SystemTools::GetFilenameName(argv[2]) : "Generated intensity image");
+  viewer.AddImage(rgbLabelImage->GetOutput(),
+                  true,
+                  argc > 3 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated label image");
+  viewer.AddImage(intensityImage.GetPointer(),
+                  true,
+                  argc > 3 ? itksys::SystemTools::GetFilenameName(argv[2]) : "Generated intensity image");
 
-    std::stringstream desc;
-    desc << "Oriented Label: " << allLabels[label];
-    viewer.AddImage(
-            rgbOrientedImage->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Oriented Label: " << allLabels[label];
+  viewer.AddImage(rgbOrientedImage->GetOutput(), true, desc.str());
 
-    std::stringstream desc2;
-    desc2 << "Oriented Intensity: " << allLabels[label];
-    viewer.AddImage(
-            labelGeometryImageFilter->GetOrientedIntensityImage(allLabels[label]),
-            true,
-            desc2.str());
-    viewer.Visualize();
+  std::stringstream desc2;
+  desc2 << "Oriented Intensity: " << allLabels[label];
+  viewer.AddImage(labelGeometryImageFilter->GetOrientedIntensityImage(allLabels[label]), true, desc2.str());
+  viewer.Visualize();
 #endif
 
-    LabelGeometryImageFilterType::LabelsType::iterator allLabelsIt;
-    std::cout << "Number of labels: "
-              << labelGeometryImageFilter->GetNumberOfLabels() << std::endl;
-    std::cout << std::endl;
+  LabelGeometryImageFilterType::LabelsType::iterator allLabelsIt;
+  std::cout << "Number of labels: " << labelGeometryImageFilter->GetNumberOfLabels() << std::endl;
+  std::cout << std::endl;
 
-    for( allLabelsIt = allLabels.begin(); allLabelsIt != allLabels.end(); allLabelsIt++ )
-    {
-        LabelGeometryImageFilterType::LabelPixelType labelValue = *allLabelsIt;
-        std::cout << "\tLabel: "
-                  << (int)labelValue << std::endl;
-        std::cout << "\tVolume: "
-                  << labelGeometryImageFilter->GetVolume(labelValue) << std::endl;
-        std::cout << "\tIntegrated Intensity: "
-                  << labelGeometryImageFilter->GetIntegratedIntensity(labelValue) << std::endl;
-        std::cout << "\tCentroid: "
-                  << labelGeometryImageFilter->GetCentroid(labelValue) << std::endl;
-        std::cout << "\tWeighted Centroid: "
-                  << labelGeometryImageFilter->GetWeightedCentroid(labelValue) << std::endl;
-        std::cout << "\tAxes Length: "
-                  << labelGeometryImageFilter->GetAxesLength(labelValue) << std::endl;
-        std::cout << "\tMajorAxisLength: "
-                  << labelGeometryImageFilter->GetMajorAxisLength(labelValue) << std::endl;
-        std::cout << "\tMinorAxisLength: "
-                  << labelGeometryImageFilter->GetMinorAxisLength(labelValue) << std::endl;
-        std::cout << "\tEccentricity: "
-                  << labelGeometryImageFilter->GetEccentricity(labelValue) << std::endl;
-        std::cout << "\tElongation: "
-                  << labelGeometryImageFilter->GetElongation(labelValue) << std::endl;
-        std::cout << "\tOrientation: "
-                  << labelGeometryImageFilter->GetOrientation(labelValue) << std::endl;
-        std::cout << "\tBounding box: "
-                  << labelGeometryImageFilter->GetBoundingBox(labelValue) << std::endl;
+  for (allLabelsIt = allLabels.begin(); allLabelsIt != allLabels.end(); allLabelsIt++)
+  {
+    LabelGeometryImageFilterType::LabelPixelType labelValue = *allLabelsIt;
+    std::cout << "\tLabel: " << (int)labelValue << std::endl;
+    std::cout << "\tVolume: " << labelGeometryImageFilter->GetVolume(labelValue) << std::endl;
+    std::cout << "\tIntegrated Intensity: " << labelGeometryImageFilter->GetIntegratedIntensity(labelValue)
+              << std::endl;
+    std::cout << "\tCentroid: " << labelGeometryImageFilter->GetCentroid(labelValue) << std::endl;
+    std::cout << "\tWeighted Centroid: " << labelGeometryImageFilter->GetWeightedCentroid(labelValue) << std::endl;
+    std::cout << "\tAxes Length: " << labelGeometryImageFilter->GetAxesLength(labelValue) << std::endl;
+    std::cout << "\tMajorAxisLength: " << labelGeometryImageFilter->GetMajorAxisLength(labelValue) << std::endl;
+    std::cout << "\tMinorAxisLength: " << labelGeometryImageFilter->GetMinorAxisLength(labelValue) << std::endl;
+    std::cout << "\tEccentricity: " << labelGeometryImageFilter->GetEccentricity(labelValue) << std::endl;
+    std::cout << "\tElongation: " << labelGeometryImageFilter->GetElongation(labelValue) << std::endl;
+    std::cout << "\tOrientation: " << labelGeometryImageFilter->GetOrientation(labelValue) << std::endl;
+    std::cout << "\tBounding box: " << labelGeometryImageFilter->GetBoundingBox(labelValue) << std::endl;
 
-        std::cout << std::endl << std::endl;
-    }
+    std::cout << std::endl << std::endl;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateIntensityImage(ImageType::Pointer image)
+void
+CreateIntensityImage(ImageType::Pointer image)
 {
-    // Create a random image.
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a random image.
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
-    // Make a random image
-    // Create an unchanging seed.
-    srand(1);
-    while(!imageIterator.IsAtEnd())
-    {
-        int randomNumber = rand() % 255;
-        imageIterator.Set( randomNumber );
-        ++imageIterator;
-    }
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
+  // Make a random image
+  // Create an unchanging seed.
+  srand(1);
+  while (!imageIterator.IsAtEnd())
+  {
+    int randomNumber = rand() % 255;
+    imageIterator.Set(randomNumber);
+    ++imageIterator;
+  }
 }
 
-void CreateLabelImage(ImageType::Pointer image)
+void
+CreateLabelImage(ImageType::Pointer image)
 {
-    // Create a black image with labeled squares.
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with labeled squares.
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(20);
+  ImageType::SizeType size;
+  size.Fill(20);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
-    image->SetRegions(region);
-    image->Allocate();
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,image->GetLargestPossibleRegion());
+  itk::ImageRegionIterator<ImageType> imageIterator(image, image->GetLargestPossibleRegion());
 
-    // Make a square
-    while(!imageIterator.IsAtEnd())
+  // Make a square
+  while (!imageIterator.IsAtEnd())
+  {
+    if ((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
+        (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10))
     {
-        if((imageIterator.GetIndex()[0] > 5 && imageIterator.GetIndex()[0] < 10) &&
-           (imageIterator.GetIndex()[1] > 5 && imageIterator.GetIndex()[1] < 10) )
-        {
-            imageIterator.Set(85);
-        }
-        else if((imageIterator.GetIndex()[0] > 11 && imageIterator.GetIndex()[0] < 17) &&
-                (imageIterator.GetIndex()[1] > 11 && imageIterator.GetIndex()[1] < 17) )
-        {
-            imageIterator.Set(127);
-        }
-        else if((imageIterator.GetIndex()[0] > 11 && imageIterator.GetIndex()[0] < 17) &&
-                (imageIterator.GetIndex()[1] > 1 && imageIterator.GetIndex()[1] < 5) )
-        {
-            imageIterator.Set(191);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(85);
     }
+    else if ((imageIterator.GetIndex()[0] > 11 && imageIterator.GetIndex()[0] < 17) &&
+             (imageIterator.GetIndex()[1] > 11 && imageIterator.GetIndex()[1] < 17))
+    {
+      imageIterator.Set(127);
+    }
+    else if ((imageIterator.GetIndex()[0] > 11 && imageIterator.GetIndex()[0] < 17) &&
+             (imageIterator.GetIndex()[1] > 1 && imageIterator.GetIndex()[1] < 5))
+    {
+      imageIterator.Set(191);
+    }
+    else
+    {
+      imageIterator.Set(0);
+    }
+
+    ++imageIterator;
+  }
 }

--- a/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
+++ b/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
@@ -24,121 +24,122 @@
 #include "itkImage.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 
-int main(int argc, char**argv)
+int
+main(int argc, char ** argv)
 {
-    if( argc < 10 )
-    {
-        std::cerr << "Missing arguments" << std::endl;
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0];
-        std::cerr << " inputLevelSetImage1 inputLevelSetImage2 inputLevelSetImage3";
-        std::cerr << " inputFeatureImage outputLevelSetImage";
-        std::cerr << " CurvatureWeight AreaWeight LaplacianWeight";
-        std::cerr << " VolumeWeight Volume OverlapWeight" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 10)
+  {
+    std::cerr << "Missing arguments" << std::endl;
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0];
+    std::cerr << " inputLevelSetImage1 inputLevelSetImage2 inputLevelSetImage3";
+    std::cerr << " inputFeatureImage outputLevelSetImage";
+    std::cerr << " CurvatureWeight AreaWeight LaplacianWeight";
+    std::cerr << " VolumeWeight Volume OverlapWeight" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    unsigned int nb_iteration = 50;
-    double rms = 0.;
-    double epsilon = 1.5;
-    double curvature_weight = std::stod( argv[6] );
-    double area_weight = std::stod( argv[7] );
-    double volume_weight = std::stod( argv[8] );
-    double volume = std::stod( argv[9] );
-    double overlap_weight = std::stod( argv[10] );
-    double l1 = 1.;
-    double l2 = 1.;
+  unsigned int nb_iteration = 50;
+  double       rms = 0.;
+  double       epsilon = 1.5;
+  double       curvature_weight = std::stod(argv[6]);
+  double       area_weight = std::stod(argv[7]);
+  double       volume_weight = std::stod(argv[8]);
+  double       volume = std::stod(argv[9]);
+  double       overlap_weight = std::stod(argv[10]);
+  double       l1 = 1.;
+  double       l2 = 1.;
 
-    constexpr unsigned int Dimension = 2;
-    using ScalarPixelType = float;
+  constexpr unsigned int Dimension = 2;
+  using ScalarPixelType = float;
 
-    using LevelSetImageType = itk::Image< ScalarPixelType, Dimension >;
-    using FeatureImageType = itk::Image< unsigned char, Dimension >;
-    using OutputImageType = itk::Image< unsigned char, Dimension >;
+  using LevelSetImageType = itk::Image<ScalarPixelType, Dimension>;
+  using FeatureImageType = itk::Image<unsigned char, Dimension>;
+  using OutputImageType = itk::Image<unsigned char, Dimension>;
 
-    using DataHelperType = itk::ScalarChanAndVeseLevelSetFunctionData< LevelSetImageType,
-            FeatureImageType >;
+  using DataHelperType = itk::ScalarChanAndVeseLevelSetFunctionData<LevelSetImageType, FeatureImageType>;
 
-    using SharedDataHelperType = itk::ConstrainedRegionBasedLevelSetFunctionSharedData<
-            LevelSetImageType, FeatureImageType, DataHelperType >;
+  using SharedDataHelperType =
+    itk::ConstrainedRegionBasedLevelSetFunctionSharedData<LevelSetImageType, FeatureImageType, DataHelperType>;
 
-    using LevelSetFunctionType = itk::ScalarChanAndVeseLevelSetFunction< LevelSetImageType,
-            FeatureImageType, SharedDataHelperType >;
+  using LevelSetFunctionType =
+    itk::ScalarChanAndVeseLevelSetFunction<LevelSetImageType, FeatureImageType, SharedDataHelperType>;
 
-    using MultiLevelSetType = itk::ScalarChanAndVeseSparseLevelSetImageFilter< LevelSetImageType,
-            FeatureImageType, OutputImageType, LevelSetFunctionType,
-            SharedDataHelperType >;
+  using MultiLevelSetType = itk::ScalarChanAndVeseSparseLevelSetImageFilter<LevelSetImageType,
+                                                                            FeatureImageType,
+                                                                            OutputImageType,
+                                                                            LevelSetFunctionType,
+                                                                            SharedDataHelperType>;
 
-    using LevelSetReaderType = itk::ImageFileReader< LevelSetImageType >;
-    using FeatureReaderType = itk::ImageFileReader< FeatureImageType >;
-    using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using LevelSetReaderType = itk::ImageFileReader<LevelSetImageType>;
+  using FeatureReaderType = itk::ImageFileReader<FeatureImageType>;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-    using DomainFunctionType = itk::AtanRegularizedHeavisideStepFunction< ScalarPixelType,
-            ScalarPixelType >;
+  using DomainFunctionType = itk::AtanRegularizedHeavisideStepFunction<ScalarPixelType, ScalarPixelType>;
 
-    DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();
-    domainFunction->SetEpsilon( epsilon );
+  DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();
+  domainFunction->SetEpsilon(epsilon);
 
-    LevelSetReaderType::Pointer contourReader1 = LevelSetReaderType::New();
-    contourReader1->SetFileName( argv[1] );
-    contourReader1->Update();
+  LevelSetReaderType::Pointer contourReader1 = LevelSetReaderType::New();
+  contourReader1->SetFileName(argv[1]);
+  contourReader1->Update();
 
-    LevelSetReaderType::Pointer contourReader2 = LevelSetReaderType::New();
-    contourReader2->SetFileName( argv[2] );
-    contourReader2->Update();
+  LevelSetReaderType::Pointer contourReader2 = LevelSetReaderType::New();
+  contourReader2->SetFileName(argv[2]);
+  contourReader2->Update();
 
-    LevelSetReaderType::Pointer contourReader3 = LevelSetReaderType::New();
-    contourReader3->SetFileName( argv[3] );
-    contourReader3->Update();
+  LevelSetReaderType::Pointer contourReader3 = LevelSetReaderType::New();
+  contourReader3->SetFileName(argv[3]);
+  contourReader3->Update();
 
-    FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
-    featureReader->SetFileName( argv[4] );
-    featureReader->Update();
+  FeatureReaderType::Pointer featureReader = FeatureReaderType::New();
+  featureReader->SetFileName(argv[4]);
+  featureReader->Update();
 
-    FeatureImageType::Pointer featureImage = featureReader->GetOutput();
-    LevelSetImageType::Pointer contourImage1 = contourReader1->GetOutput();
-    LevelSetImageType::Pointer contourImage2 = contourReader2->GetOutput();
-    LevelSetImageType::Pointer contourImage3 = contourReader3->GetOutput();
+  FeatureImageType::Pointer  featureImage = featureReader->GetOutput();
+  LevelSetImageType::Pointer contourImage1 = contourReader1->GetOutput();
+  LevelSetImageType::Pointer contourImage2 = contourReader2->GetOutput();
+  LevelSetImageType::Pointer contourImage3 = contourReader3->GetOutput();
 
-    MultiLevelSetType::Pointer levelSetFilter = MultiLevelSetType::New();
-    levelSetFilter->SetFunctionCount( 3 );
-    levelSetFilter->SetFeatureImage( featureImage );
-    levelSetFilter->SetLevelSet( 0, contourImage1 );
-    levelSetFilter->SetLevelSet( 1, contourImage2 );
-    levelSetFilter->SetLevelSet( 2, contourImage3 );
-    levelSetFilter->SetNumberOfIterations( nb_iteration );
-    levelSetFilter->SetMaximumRMSError( rms );
-    levelSetFilter->SetUseImageSpacing( 1 );
-    levelSetFilter->SetInPlace( false );
+  MultiLevelSetType::Pointer levelSetFilter = MultiLevelSetType::New();
+  levelSetFilter->SetFunctionCount(3);
+  levelSetFilter->SetFeatureImage(featureImage);
+  levelSetFilter->SetLevelSet(0, contourImage1);
+  levelSetFilter->SetLevelSet(1, contourImage2);
+  levelSetFilter->SetLevelSet(2, contourImage3);
+  levelSetFilter->SetNumberOfIterations(nb_iteration);
+  levelSetFilter->SetMaximumRMSError(rms);
+  levelSetFilter->SetUseImageSpacing(1);
+  levelSetFilter->SetInPlace(false);
 
-    for ( unsigned int i = 0; i < 3; i++ )
-    {
-        levelSetFilter->GetDifferenceFunction(i)->SetDomainFunction( domainFunction );
-        levelSetFilter->GetDifferenceFunction(i)->SetCurvatureWeight( curvature_weight );
-        levelSetFilter->GetDifferenceFunction(i)->SetAreaWeight( area_weight );
-        levelSetFilter->GetDifferenceFunction(i)->SetOverlapPenaltyWeight( overlap_weight );
-        levelSetFilter->GetDifferenceFunction(i)->SetVolumeMatchingWeight( volume_weight );
-        levelSetFilter->GetDifferenceFunction(i)->SetVolume( volume );
-        levelSetFilter->GetDifferenceFunction(i)->SetLambda1( l1 );
-        levelSetFilter->GetDifferenceFunction(i)->SetLambda2( l2 );
-    }
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    levelSetFilter->GetDifferenceFunction(i)->SetDomainFunction(domainFunction);
+    levelSetFilter->GetDifferenceFunction(i)->SetCurvatureWeight(curvature_weight);
+    levelSetFilter->GetDifferenceFunction(i)->SetAreaWeight(area_weight);
+    levelSetFilter->GetDifferenceFunction(i)->SetOverlapPenaltyWeight(overlap_weight);
+    levelSetFilter->GetDifferenceFunction(i)->SetVolumeMatchingWeight(volume_weight);
+    levelSetFilter->GetDifferenceFunction(i)->SetVolume(volume);
+    levelSetFilter->GetDifferenceFunction(i)->SetLambda1(l1);
+    levelSetFilter->GetDifferenceFunction(i)->SetLambda2(l2);
+  }
 
-    levelSetFilter->Update();
+  levelSetFilter->Update();
 
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput( levelSetFilter->GetOutput() );
-    writer->SetFileName( argv[5] );
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(levelSetFilter->GetOutput());
+  writer->SetFileName(argv[5]);
 
-    try
-    {
-        writer->Update();
-    }
-    catch( itk::ExceptionObject & excep )
-    {
-        std::cerr << "Exception caught !" << std::endl;
-        std::cerr << excep << std::endl;
-        return -1;
-    }
+  try
+  {
+    writer->Update();
+  }
+  catch (itk::ExceptionObject & excep)
+  {
+    std::cerr << "Exception caught !" << std::endl;
+    std::cerr << excep << std::endl;
+    return -1;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.cxx
+++ b/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.cxx
@@ -22,85 +22,86 @@
 #include "itkMultiScaleHessianBasedMeasureImageFilter.h"
 #include "itkRescaleIntensityImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc < 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName>";
     std::cerr << " [SigmaMinimum] [SigmaMaximum]";
     std::cerr << " [NumberOfSigmaSteps]";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
-  double sigmaMinimum = 1.0;
-  if( argc > 3 )
-    {
-    sigmaMinimum = std::stod( argv[3] );
-    }
+  double       sigmaMinimum = 1.0;
+  if (argc > 3)
+  {
+    sigmaMinimum = std::stod(argv[3]);
+  }
   double sigmaMaximum = 10.0;
-  if( argc > 4 )
-    {
-    sigmaMaximum = std::stod( argv[4] );
-    }
+  if (argc > 4)
+  {
+    sigmaMaximum = std::stod(argv[4]);
+  }
   unsigned int numberOfSigmaSteps = 10;
-  if( argc > 5 )
-    {
-    numberOfSigmaSteps = std::stoi( argv[5] );
-    }
+  if (argc > 5)
+  {
+    numberOfSigmaSteps = std::stoi(argv[5]);
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = float;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using HessianPixelType = itk::SymmetricSecondRankTensor< double, Dimension >;
-  using HessianImageType = itk::Image< HessianPixelType, Dimension >;
-  using ObjectnessFilterType = itk::HessianToObjectnessMeasureImageFilter< HessianImageType, ImageType >;
+  using HessianPixelType = itk::SymmetricSecondRankTensor<double, Dimension>;
+  using HessianImageType = itk::Image<HessianPixelType, Dimension>;
+  using ObjectnessFilterType = itk::HessianToObjectnessMeasureImageFilter<HessianImageType, ImageType>;
   ObjectnessFilterType::Pointer objectnessFilter = ObjectnessFilterType::New();
-  objectnessFilter->SetBrightObject( false );
-  objectnessFilter->SetScaleObjectnessMeasure( false );
-  objectnessFilter->SetAlpha( 0.5 );
-  objectnessFilter->SetBeta( 1.0 );
-  objectnessFilter->SetGamma( 5.0 );
+  objectnessFilter->SetBrightObject(false);
+  objectnessFilter->SetScaleObjectnessMeasure(false);
+  objectnessFilter->SetAlpha(0.5);
+  objectnessFilter->SetBeta(1.0);
+  objectnessFilter->SetGamma(5.0);
 
-  using MultiScaleEnhancementFilterType = itk::MultiScaleHessianBasedMeasureImageFilter< ImageType, HessianImageType, ImageType >;
-  MultiScaleEnhancementFilterType::Pointer multiScaleEnhancementFilter =
-    MultiScaleEnhancementFilterType::New();
-  multiScaleEnhancementFilter->SetInput( reader->GetOutput() );
-  multiScaleEnhancementFilter->SetHessianToMeasureFilter( objectnessFilter );
+  using MultiScaleEnhancementFilterType =
+    itk::MultiScaleHessianBasedMeasureImageFilter<ImageType, HessianImageType, ImageType>;
+  MultiScaleEnhancementFilterType::Pointer multiScaleEnhancementFilter = MultiScaleEnhancementFilterType::New();
+  multiScaleEnhancementFilter->SetInput(reader->GetOutput());
+  multiScaleEnhancementFilter->SetHessianToMeasureFilter(objectnessFilter);
   multiScaleEnhancementFilter->SetSigmaStepMethodToLogarithmic();
-  multiScaleEnhancementFilter->SetSigmaMinimum( sigmaMinimum );
-  multiScaleEnhancementFilter->SetSigmaMaximum( sigmaMaximum );
-  multiScaleEnhancementFilter->SetNumberOfSigmaSteps( numberOfSigmaSteps );
+  multiScaleEnhancementFilter->SetSigmaMinimum(sigmaMinimum);
+  multiScaleEnhancementFilter->SetSigmaMaximum(sigmaMaximum);
+  multiScaleEnhancementFilter->SetNumberOfSigmaSteps(numberOfSigmaSteps);
 
-  using OutputImageType = itk::Image< unsigned char, Dimension >;
-  using RescaleFilterType = itk::RescaleIntensityImageFilter< ImageType, OutputImageType >;
+  using OutputImageType = itk::Image<unsigned char, Dimension>;
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<ImageType, OutputImageType>;
   RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-  rescaleFilter->SetInput( multiScaleEnhancementFilter->GetOutput() );
+  rescaleFilter->SetInput(multiScaleEnhancementFilter->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( rescaleFilter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(rescaleFilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
@@ -43,27 +43,28 @@
 #include "itkImage.h"
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 
-int main(int argc, char**argv)
+int
+main(int argc, char ** argv)
 {
-  if( argc < 6 )
-    {
+  if (argc < 6)
+  {
     std::cerr << "Missing arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " featureImage outputImage";
     std::cerr << " startx starty seedValue" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   unsigned int nb_iteration = 500;
-  double rms = 0.;
-  double epsilon = 1.;
-  double curvature_weight = 0.;
-  double area_weight = 0.;
-  double reinitialization_weight = 0.;
-  double volume_weight = 0.;
-  double volume = 0.;
-  double l1 = 1.;
-  double l2 = 1.;
+  double       rms = 0.;
+  double       epsilon = 1.;
+  double       curvature_weight = 0.;
+  double       area_weight = 0.;
+  double       reinitialization_weight = 0.;
+  double       volume_weight = 0.;
+  double       volume = 0.;
+  double       l1 = 1.;
+  double       l2 = 1.;
 
   //
   //  We now define the image type using a particular pixel type and
@@ -72,40 +73,38 @@ int main(int argc, char**argv)
   //
   constexpr unsigned int Dimension = 2;
   using ScalarPixelType = float;
-  using InternalImageType = itk::Image< ScalarPixelType, Dimension >;
+  using InternalImageType = itk::Image<ScalarPixelType, Dimension>;
 
 
-  using DataHelperType = itk::ScalarChanAndVeseLevelSetFunctionData< InternalImageType,
-    InternalImageType >;
+  using DataHelperType = itk::ScalarChanAndVeseLevelSetFunctionData<InternalImageType, InternalImageType>;
 
-  using SharedDataHelperType = itk::ConstrainedRegionBasedLevelSetFunctionSharedData<
-    InternalImageType, InternalImageType, DataHelperType >;
+  using SharedDataHelperType =
+    itk::ConstrainedRegionBasedLevelSetFunctionSharedData<InternalImageType, InternalImageType, DataHelperType>;
 
-  using LevelSetFunctionType = itk::ScalarChanAndVeseLevelSetFunction< InternalImageType,
-    InternalImageType, SharedDataHelperType >;
+  using LevelSetFunctionType =
+    itk::ScalarChanAndVeseLevelSetFunction<InternalImageType, InternalImageType, SharedDataHelperType>;
 
 
   //  We declare now the type of the numerically discretized Step and Delta functions that
   //  will be used in the level-set computations for foreground and background regions
   //
-  using DomainFunctionType = itk::AtanRegularizedHeavisideStepFunction< ScalarPixelType,
-    ScalarPixelType >;
+  using DomainFunctionType = itk::AtanRegularizedHeavisideStepFunction<ScalarPixelType, ScalarPixelType>;
 
   DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();
-  domainFunction->SetEpsilon( epsilon );
+  domainFunction->SetEpsilon(epsilon);
 
   // We instantiate reader and writer types in the following lines.
   //
-  using ReaderType = itk::ImageFileReader< InternalImageType >;
-  using WriterType = itk::ImageFileWriter< InternalImageType >;
+  using ReaderType = itk::ImageFileReader<InternalImageType>;
+  using WriterType = itk::ImageFileWriter<InternalImageType>;
 
   ReaderType::Pointer reader = ReaderType::New();
   WriterType::Pointer writer = WriterType::New();
 
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
-  writer->SetFileName( argv[2] );
+  writer->SetFileName(argv[2]);
 
   InternalImageType::Pointer featureImage = reader->GetOutput();
 
@@ -113,9 +112,9 @@ int main(int argc, char**argv)
   //  will be used to generate the initial level set in the form of a distance
   //  map.
   //
-  using FastMarchingFilterType = itk::FastMarchingImageFilter< InternalImageType, InternalImageType >;
+  using FastMarchingFilterType = itk::FastMarchingImageFilter<InternalImageType, InternalImageType>;
 
-  FastMarchingFilterType::Pointer  fastMarching = FastMarchingFilterType::New();
+  FastMarchingFilterType::Pointer fastMarching = FastMarchingFilterType::New();
 
   //  The FastMarchingImageFilter requires the user to provide a seed
   //  point from which the level set will be generated. The user can actually
@@ -133,32 +132,32 @@ int main(int argc, char**argv)
 
   NodeContainer::Pointer seeds = NodeContainer::New();
 
-  InternalImageType::IndexType  seedPosition;
+  InternalImageType::IndexType seedPosition;
 
-  seedPosition[0] = std::stoi( argv[3] );
-  seedPosition[1] = std::stoi( argv[4] );
+  seedPosition[0] = std::stoi(argv[3]);
+  seedPosition[1] = std::stoi(argv[4]);
 
-  const double initialDistance = std::stod( argv[5] );
+  const double initialDistance = std::stod(argv[5]);
 
   NodeType node;
 
-  const double seedValue = - initialDistance;
+  const double seedValue = -initialDistance;
 
-  node.SetValue( seedValue );
-  node.SetIndex( seedPosition );
+  node.SetValue(seedValue);
+  node.SetIndex(seedPosition);
 
   //  The list of nodes is initialized and then every node is inserted using
   //  the \code{InsertElement()}.
   //
   seeds->Initialize();
-  seeds->InsertElement( 0, node );
+  seeds->InsertElement(0, node);
 
 
   //  The set of seed nodes is passed now to the
   //  FastMarchingImageFilter with the method
   //  \code{SetTrialPoints()}.
   //
-  fastMarching->SetTrialPoints(  seeds  );
+  fastMarching->SetTrialPoints(seeds);
 
 
   //  Since the FastMarchingImageFilter is used here just as a
@@ -166,7 +165,7 @@ int main(int argc, char**argv)
   //  Instead the constant value $1.0$ is passed using the
   //  \code{SetSpeedConstant()} method.
   //
-  fastMarching->SetSpeedConstant( 1.0 );
+  fastMarching->SetSpeedConstant(1.0);
 
   //  The FastMarchingImageFilter requires the user to specify the
   //  size of the image to be produced as output. This is done using the
@@ -175,29 +174,30 @@ int main(int argc, char**argv)
   //  only after the \code{Update()} methods of this filter has been called
   //  directly or indirectly.
   //
-  fastMarching->SetOutputSize(
-    featureImage->GetBufferedRegion().GetSize() );
+  fastMarching->SetOutputSize(featureImage->GetBufferedRegion().GetSize());
   fastMarching->Update();
 
   //  We declare now the type of the ScalarChanAndVeseSparseLevelSetImageFilter that
   //  will be used to generate a segmentation.
   //
 
-  using MultiLevelSetType = itk::ScalarChanAndVeseSparseLevelSetImageFilter< InternalImageType,
-    InternalImageType, InternalImageType, LevelSetFunctionType,
-    SharedDataHelperType >;
+  using MultiLevelSetType = itk::ScalarChanAndVeseSparseLevelSetImageFilter<InternalImageType,
+                                                                            InternalImageType,
+                                                                            InternalImageType,
+                                                                            LevelSetFunctionType,
+                                                                            SharedDataHelperType>;
 
   MultiLevelSetType::Pointer levelSetFilter = MultiLevelSetType::New();
 
   //  We set the function count to 1 since a single level-set is being evolved.
   //
-  levelSetFilter->SetFunctionCount( 1 );
+  levelSetFilter->SetFunctionCount(1);
 
   //  Set the feature image and initial level-set image as output of the
   //  fast marching image filter.
   //
-  levelSetFilter->SetFeatureImage( featureImage );
-  levelSetFilter->SetLevelSet( 0, fastMarching->GetOutput() );
+  levelSetFilter->SetFeatureImage(featureImage);
+  levelSetFilter->SetLevelSet(0, fastMarching->GetOutput());
 
   //  Once activiated the level set evolution will stop if the convergence
   //  criteria or if the maximum number of iterations is reached.  The
@@ -210,47 +210,46 @@ int main(int argc, char**argv)
   //  algorithm before the zero set leaks through the regions of low gradient
   //  in the contour of the anatomical structure to be segmented.
   //
-  levelSetFilter->SetNumberOfIterations( nb_iteration );
-  levelSetFilter->SetMaximumRMSError( rms );
+  levelSetFilter->SetNumberOfIterations(nb_iteration);
+  levelSetFilter->SetMaximumRMSError(rms);
 
   //  Often, in real applications, images have different pixel resolutions. In such
   //  cases, it is best to use the native spacings to compute derivatives etc rather
   //  than sampling the images.
   //
-  levelSetFilter->SetUseImageSpacing( 1 );
+  levelSetFilter->SetUseImageSpacing(1);
 
   //  For large images, we may want to compute the level-set over the initial supplied
   //  level-set image. This saves a lot of memory.
   //
-  levelSetFilter->SetInPlace( false );
+  levelSetFilter->SetInPlace(false);
 
   //  For the level set with phase 0, set different parameters and weights. This may
   //  to be set in a loop for the case of multiple level-sets evolving simultaneously.
   //
-  levelSetFilter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );
-  levelSetFilter->GetDifferenceFunction(0)->SetCurvatureWeight( curvature_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetAreaWeight( area_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetReinitializationSmoothingWeight( reinitialization_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetVolumeMatchingWeight( volume_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetVolume( volume );
-  levelSetFilter->GetDifferenceFunction(0)->SetLambda1( l1 );
-  levelSetFilter->GetDifferenceFunction(0)->SetLambda2( l2 );
+  levelSetFilter->GetDifferenceFunction(0)->SetDomainFunction(domainFunction);
+  levelSetFilter->GetDifferenceFunction(0)->SetCurvatureWeight(curvature_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetAreaWeight(area_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetReinitializationSmoothingWeight(reinitialization_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetVolumeMatchingWeight(volume_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetVolume(volume);
+  levelSetFilter->GetDifferenceFunction(0)->SetLambda1(l1);
+  levelSetFilter->GetDifferenceFunction(0)->SetLambda2(l2);
 
   levelSetFilter->Update();
 
-  writer->SetInput( levelSetFilter->GetOutput() );
+  writer->SetInput(levelSetFilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & excep )
-    {
+  }
+  catch (itk::ExceptionObject & excep)
+  {
     std::cerr << "Exception caught !" << std::endl;
     std::cerr << excep << std::endl;
     return -1;
-    }
+  }
 
   return EXIT_SUCCESS;
 }
-

--- a/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation2/Code.cxx
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation2/Code.cxx
@@ -15,7 +15,7 @@
  *  limitations under the License.
  *
  *=========================================================================*/
- // The use of the ScalarChanAndVeseDenseLevelSetImageFilter is
+// The use of the ScalarChanAndVeseDenseLevelSetImageFilter is
 // illustrated in the following example. The implementation of this filter in
 // ITK is based on the paper by Chan And Vese.  This
 // implementation extends the functionality of the
@@ -43,28 +43,29 @@
 #include "itkAtanRegularizedHeavisideStepFunction.h"
 
 
-int main(int argc, char**argv)
+int
+main(int argc, char ** argv)
 {
 
-  if( argc < 6 )
-    {
+  if (argc < 6)
+  {
     std::cerr << "Missing arguments" << std::endl;
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0] << " featureImage outputImage";
     std::cerr << " startx starty seedValue" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   unsigned int nb_iteration = 500;
-  double rms = 0.;
-  double epsilon = 1.;
-  double curvature_weight = 0.;
-  double area_weight = 0.;
-  double reinitialization_weight = 0.;
-  double volume_weight = 0.;
-  double volume = 0.;
-  double l1 = 1.;
-  double l2 = 1.;
+  double       rms = 0.;
+  double       epsilon = 1.;
+  double       curvature_weight = 0.;
+  double       area_weight = 0.;
+  double       reinitialization_weight = 0.;
+  double       volume_weight = 0.;
+  double       volume = 0.;
+  double       l1 = 1.;
+  double       l2 = 1.;
 
   //
   //  We now define the image type using a particular pixel type and
@@ -73,39 +74,37 @@ int main(int argc, char**argv)
   //
   constexpr unsigned int Dimension = 2;
   using ScalarPixelType = float;
-  using InternalImageType = itk::Image< ScalarPixelType, Dimension >;
+  using InternalImageType = itk::Image<ScalarPixelType, Dimension>;
 
-  using DataHelperType = itk::ScalarChanAndVeseLevelSetFunctionData< InternalImageType,
-    InternalImageType >;
+  using DataHelperType = itk::ScalarChanAndVeseLevelSetFunctionData<InternalImageType, InternalImageType>;
 
-  using SharedDataHelperType = itk::ConstrainedRegionBasedLevelSetFunctionSharedData<
-    InternalImageType, InternalImageType, DataHelperType >;
+  using SharedDataHelperType =
+    itk::ConstrainedRegionBasedLevelSetFunctionSharedData<InternalImageType, InternalImageType, DataHelperType>;
 
-  using LevelSetFunctionType = itk::ScalarChanAndVeseLevelSetFunction< InternalImageType,
-    InternalImageType, SharedDataHelperType >;
+  using LevelSetFunctionType =
+    itk::ScalarChanAndVeseLevelSetFunction<InternalImageType, InternalImageType, SharedDataHelperType>;
 
 
   //  We declare now the type of the numerically discretized Step and Delta functions that
   //  will be used in the level-set computations for foreground and background regions
   //
-  using DomainFunctionType = itk::AtanRegularizedHeavisideStepFunction< ScalarPixelType,
-    ScalarPixelType >;
+  using DomainFunctionType = itk::AtanRegularizedHeavisideStepFunction<ScalarPixelType, ScalarPixelType>;
 
   DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();
-  domainFunction->SetEpsilon( epsilon );
+  domainFunction->SetEpsilon(epsilon);
 
   // We instantiate reader and writer types in the following lines.
   //
-  using ReaderType = itk::ImageFileReader< InternalImageType >;
-  using WriterType = itk::ImageFileWriter< InternalImageType >;
+  using ReaderType = itk::ImageFileReader<InternalImageType>;
+  using WriterType = itk::ImageFileWriter<InternalImageType>;
 
   ReaderType::Pointer reader = ReaderType::New();
   WriterType::Pointer writer = WriterType::New();
 
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
-  writer->SetFileName( argv[2] );
+  writer->SetFileName(argv[2]);
 
   InternalImageType::Pointer featureImage = reader->GetOutput();
 
@@ -113,11 +112,9 @@ int main(int argc, char**argv)
   //  will be used to generate the initial level set in the form of a distance
   //  map.
   //
-  using FastMarchingFilterType = itk::FastMarchingImageFilter<
-    InternalImageType,
-    InternalImageType >;
+  using FastMarchingFilterType = itk::FastMarchingImageFilter<InternalImageType, InternalImageType>;
 
-  FastMarchingFilterType::Pointer  fastMarching = FastMarchingFilterType::New();
+  FastMarchingFilterType::Pointer fastMarching = FastMarchingFilterType::New();
 
 
   //  The FastMarchingImageFilter requires the user to provide a seed
@@ -136,32 +133,32 @@ int main(int argc, char**argv)
 
   NodeContainer::Pointer seeds = NodeContainer::New();
 
-  InternalImageType::IndexType  seedPosition;
+  InternalImageType::IndexType seedPosition;
 
-  seedPosition[0] = std::stoi( argv[3] );
-  seedPosition[1] = std::stoi( argv[4] );
+  seedPosition[0] = std::stoi(argv[3]);
+  seedPosition[1] = std::stoi(argv[4]);
 
-  const double initialDistance = std::stod( argv[5] );
+  const double initialDistance = std::stod(argv[5]);
 
   NodeType node;
 
-  const double seedValue = - initialDistance;
+  const double seedValue = -initialDistance;
 
-  node.SetValue( seedValue );
-  node.SetIndex( seedPosition );
+  node.SetValue(seedValue);
+  node.SetIndex(seedPosition);
 
   //  The list of nodes is initialized and then every node is inserted using
   //  the \code{InsertElement()}.
   //
   seeds->Initialize();
-  seeds->InsertElement( 0, node );
+  seeds->InsertElement(0, node);
 
 
   //  The set of seed nodes is passed now to the
   //  FastMarchingImageFilter with the method
   //  \code{SetTrialPoints()}.
   //
-  fastMarching->SetTrialPoints(  seeds  );
+  fastMarching->SetTrialPoints(seeds);
 
 
   //  Since the FastMarchingImageFilter is used here just as a
@@ -169,7 +166,7 @@ int main(int argc, char**argv)
   //  Instead the constant value $1.0$ is passed using the
   //  \code{SetSpeedConstant()} method.
   //
-  fastMarching->SetSpeedConstant( 1.0 );
+  fastMarching->SetSpeedConstant(1.0);
 
   //  The FastMarchingImageFilter requires the user to specify the
   //  size of the image to be produced as output. This is done using the
@@ -178,29 +175,30 @@ int main(int argc, char**argv)
   //  only after the \code{Update()} methods of this filter has been called
   //  directly or indirectly.
   //
-  fastMarching->SetOutputSize(
-    featureImage->GetBufferedRegion().GetSize() );
+  fastMarching->SetOutputSize(featureImage->GetBufferedRegion().GetSize());
   fastMarching->Update();
 
   //  We declare now the type of the ScalarChanAndVeseDenseLevelSetImageFilter that
   //  will be used to generate a segmentation.
   //
 
-  using MultiLevelSetType = itk::ScalarChanAndVeseDenseLevelSetImageFilter< InternalImageType,
-    InternalImageType, InternalImageType, LevelSetFunctionType,
-    SharedDataHelperType >;
+  using MultiLevelSetType = itk::ScalarChanAndVeseDenseLevelSetImageFilter<InternalImageType,
+                                                                           InternalImageType,
+                                                                           InternalImageType,
+                                                                           LevelSetFunctionType,
+                                                                           SharedDataHelperType>;
 
   MultiLevelSetType::Pointer levelSetFilter = MultiLevelSetType::New();
 
   //  We set the function count to 1 since a single level-set is being evolved.
   //
-  levelSetFilter->SetFunctionCount( 1 );
+  levelSetFilter->SetFunctionCount(1);
 
   //  Set the feature image and initial level-set image as output of the
   //  fast marching image filter.
   //
-  levelSetFilter->SetFeatureImage( featureImage );
-  levelSetFilter->SetLevelSet( 0, fastMarching->GetOutput() );
+  levelSetFilter->SetFeatureImage(featureImage);
+  levelSetFilter->SetLevelSet(0, fastMarching->GetOutput());
 
   //  Once activiated the level set evolution will stop if the convergence
   //  criteria or if the maximum number of iterations is reached.  The
@@ -213,47 +211,47 @@ int main(int argc, char**argv)
   //  algorithm before the zero set leaks through the regions of low gradient
   //  in the contour of the anatomical structure to be segmented.
   //
-  levelSetFilter->SetNumberOfIterations( nb_iteration );
-  levelSetFilter->SetMaximumRMSError( rms );
+  levelSetFilter->SetNumberOfIterations(nb_iteration);
+  levelSetFilter->SetMaximumRMSError(rms);
 
   //  Often, in real applications, images have different pixel resolutions. In such
   //  cases, it is best to use the native spacings to compute derivatives etc rather
   //  than sampling the images.
   //
-  levelSetFilter->SetUseImageSpacing( 1 );
+  levelSetFilter->SetUseImageSpacing(1);
 
   //  For large images, we may want to compute the level-set over the initial supplied
   //  level-set image. This saves a lot of memory.
   //
-  levelSetFilter->SetInPlace( false );
+  levelSetFilter->SetInPlace(false);
 
   //  For the level set with phase 0, set different parameters and weights. This may
   //  to be set in a loop for the case of multiple level-sets evolving simultaneously.
   //
-  levelSetFilter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );
-  levelSetFilter->GetDifferenceFunction(0)->SetCurvatureWeight( curvature_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetAreaWeight( area_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetReinitializationSmoothingWeight( reinitialization_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetVolumeMatchingWeight( volume_weight );
-  levelSetFilter->GetDifferenceFunction(0)->SetVolume( volume );
-  levelSetFilter->GetDifferenceFunction(0)->SetLambda1( l1 );
-  levelSetFilter->GetDifferenceFunction(0)->SetLambda2( l2 );
+  levelSetFilter->GetDifferenceFunction(0)->SetDomainFunction(domainFunction);
+  levelSetFilter->GetDifferenceFunction(0)->SetCurvatureWeight(curvature_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetAreaWeight(area_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetReinitializationSmoothingWeight(reinitialization_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetVolumeMatchingWeight(volume_weight);
+  levelSetFilter->GetDifferenceFunction(0)->SetVolume(volume);
+  levelSetFilter->GetDifferenceFunction(0)->SetLambda1(l1);
+  levelSetFilter->GetDifferenceFunction(0)->SetLambda2(l2);
 
   levelSetFilter->Update();
 
 
-  writer->SetInput( levelSetFilter->GetOutput() );
+  writer->SetInput(levelSetFilter->GetOutput());
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & excep )
-    {
+  }
+  catch (itk::ExceptionObject & excep)
+  {
     std::cerr << "Exception caught !" << std::endl;
     std::cerr << excep << std::endl;
     return -1;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Numerics/Optimizers/AmoebaOptimizer/Code.cxx
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/Code.cxx
@@ -21,46 +21,46 @@
 namespace
 {
 // Typedef the optimizer and cost function, for convenience
-    using OptimizerType = itk::AmoebaOptimizer;
-    using CostType = itk::ExampleCostFunction2;
-}
+using OptimizerType = itk::AmoebaOptimizer;
+using CostType = itk::ExampleCostFunction2;
+} // namespace
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
 
-    // Instantiate the optimizer
-    OptimizerType::Pointer optimizer = OptimizerType::New();
+  // Instantiate the optimizer
+  OptimizerType::Pointer optimizer = OptimizerType::New();
 
-    // Set properties pertinent to convergence
-    optimizer->SetMaximumNumberOfIterations( 100 );
-    optimizer->SetParametersConvergenceTolerance( 0.01 );
-    optimizer->SetFunctionConvergenceTolerance( 0.01 );
+  // Set properties pertinent to convergence
+  optimizer->SetMaximumNumberOfIterations(100);
+  optimizer->SetParametersConvergenceTolerance(0.01);
+  optimizer->SetFunctionConvergenceTolerance(0.01);
 
-    // Instantiate the cost function
-    // The cost function is a 2D paraboloid in the x-y plane
-    // with the equation f(x,y) = (x+5)^2+(y-7)^2 + 5
-    // and a global minimum at (x,y) = (-5, 7)
-    CostType::Pointer cost = CostType::New();
+  // Instantiate the cost function
+  // The cost function is a 2D paraboloid in the x-y plane
+  // with the equation f(x,y) = (x+5)^2+(y-7)^2 + 5
+  // and a global minimum at (x,y) = (-5, 7)
+  CostType::Pointer cost = CostType::New();
 
-    // Assign the cost function to the optimizer
-    optimizer->SetCostFunction( cost.GetPointer() );
+  // Assign the cost function to the optimizer
+  optimizer->SetCostFunction(cost.GetPointer());
 
-    // Set the initial parameters of the cost function
-    OptimizerType::ParametersType initial(2);
-    initial[0] = 123;
-    initial[1] = -97.4;
-    optimizer->SetInitialPosition( initial );
+  // Set the initial parameters of the cost function
+  OptimizerType::ParametersType initial(2);
+  initial[0] = 123;
+  initial[1] = -97.4;
+  optimizer->SetInitialPosition(initial);
 
-    // Begin the optimization!
-    optimizer->StartOptimization();
+  // Begin the optimization!
+  optimizer->StartOptimization();
 
-    // Print out some information about the optimization
-    std::cout << "Position: " << optimizer->GetCurrentPosition() << std::endl;
-    std::cout << "Value: " << optimizer->GetValue() << std::endl;
+  // Print out some information about the optimization
+  std::cout << "Position: " << optimizer->GetCurrentPosition() << std::endl;
+  std::cout << "Value: " << optimizer->GetValue() << std::endl;
 
-    // As expected, the position is near to (-5, 7) and the value to 5
-    // Position: [-5.003825599641884, 6.998563761340231]
-    // Value: 5.00002
-    return EXIT_SUCCESS;
-
+  // As expected, the position is near to (-5, 7) and the value to 5
+  // Position: [-5.003825599641884, 6.998563761340231]
+  // Value: 5.00002
+  return EXIT_SUCCESS;
 }

--- a/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
@@ -8,41 +8,50 @@
 
 namespace itk
 {
-    class ExampleCostFunction2 :
-            public SingleValuedCostFunction
-    {
-    public:
-        /** Standard class typedefs. */
-        typedef ExampleCostFunction2      Self;
-        typedef SingleValuedCostFunction  Superclass;
-        typedef SmartPointer<Self>        Pointer;
-        typedef SmartPointer<const Self>  ConstPointer;
+class ExampleCostFunction2 : public SingleValuedCostFunction
+{
+public:
+  /** Standard class typedefs. */
+  typedef ExampleCostFunction2     Self;
+  typedef SingleValuedCostFunction Superclass;
+  typedef SmartPointer<Self>       Pointer;
+  typedef SmartPointer<const Self> ConstPointer;
 
-        /** Method for creation through the object factory. */
-        itkNewMacro(Self);
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
 
-        /** Run-time type information (and related methods). */
-        itkTypeMacro(ExampleCostFunction2, SingleValuedCostfunction);
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ExampleCostFunction2, SingleValuedCostfunction);
 
-        unsigned int GetNumberOfParameters(void) const override { return 2; } // itk::CostFunction
+  unsigned int
+  GetNumberOfParameters(void) const override
+  {
+    return 2;
+  } // itk::CostFunction
 
-        MeasureType GetValue(const ParametersType & parameters) const override {
-            return pow(parameters[0]+5, 2)+pow(parameters[1]-7, 2)+5;
-        }
+  MeasureType
+  GetValue(const ParametersType & parameters) const override
+  {
+    return pow(parameters[0] + 5, 2) + pow(parameters[1] - 7, 2) + 5;
+  }
 
-        void GetDerivative(const ParametersType &,
-                           DerivativeType & /*derivative*/ ) const override {
-            throw itk::ExceptionObject( __FILE__, __LINE__, "No derivative is available for this cost function.");
-        }
+  void
+  GetDerivative(const ParametersType &, DerivativeType & /*derivative*/) const override
+  {
+    throw itk::ExceptionObject(__FILE__, __LINE__, "No derivative is available for this cost function.");
+  }
 
-    protected:
-        ExampleCostFunction2()= default;;
-        ~ExampleCostFunction2() override= default;;
+protected:
+  ExampleCostFunction2() = default;
+  ;
+  ~ExampleCostFunction2() override = default;
+  ;
 
-    private:
-        ExampleCostFunction2(const Self &) = delete; //purposely not implemented
-        void operator = (const Self &) = delete; //purposely not implemented
-    };
+private:
+  ExampleCostFunction2(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
+};
 
 } // end namespace itk
 

--- a/src/Numerics/Optimizers/ExhaustiveOptimizer/Code.cxx
+++ b/src/Numerics/Optimizers/ExhaustiveOptimizer/Code.cxx
@@ -29,120 +29,123 @@
 class CommandIterationUpdate : public itk::Command
 {
 public:
-    using Self = CommandIterationUpdate;
-    using Superclass = itk::Command;
-    using Pointer = itk::SmartPointer<Self>;
-    itkNewMacro( Self );
+  using Self = CommandIterationUpdate;
+  using Superclass = itk::Command;
+  using Pointer = itk::SmartPointer<Self>;
+  itkNewMacro(Self);
 
 protected:
-    CommandIterationUpdate() = default;;
+  CommandIterationUpdate() = default;
+  ;
 
 public:
-    using OptimizerType = itk::ExhaustiveOptimizerv4<double>;
-    using OptimizerPointer = const OptimizerType *;
+  using OptimizerType = itk::ExhaustiveOptimizerv4<double>;
+  using OptimizerPointer = const OptimizerType *;
 
-    void Execute(itk::Object *caller, const itk::EventObject & event) override
-    {
-        Execute( (const itk::Object *) caller, event);
-    }
+  void
+  Execute(itk::Object * caller, const itk::EventObject & event) override
+  {
+    Execute((const itk::Object *)caller, event);
+  }
 
-    void Execute(const itk::Object * object, const itk::EventObject & event) override
+  void
+  Execute(const itk::Object * object, const itk::EventObject & event) override
+  {
+    auto optimizer = static_cast<OptimizerPointer>(object);
+    if (!(itk::IterationEvent().CheckEvent(&event)))
     {
-        auto optimizer = static_cast< OptimizerPointer >( object );
-        if( !(itk::IterationEvent().CheckEvent( &event )) )
-        {
-            return;
-        }
-        std::cout << "Iteration: ";
-        std::cout << optimizer->GetCurrentIteration() << "   ";
-        std::cout << optimizer->GetCurrentIndex() << "   ";
-        std::cout << optimizer->GetCurrentValue() << "   ";
-        std::cout << optimizer->GetCurrentPosition() << "   ";
-        std::cout << std::endl;
+      return;
     }
+    std::cout << "Iteration: ";
+    std::cout << optimizer->GetCurrentIteration() << "   ";
+    std::cout << optimizer->GetCurrentIndex() << "   ";
+    std::cout << optimizer->GetCurrentValue() << "   ";
+    std::cout << optimizer->GetCurrentPosition() << "   ";
+    std::cout << std::endl;
+  }
 };
 
-int main (int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if (argc < 3)
-    {
-        std::cout << "Usage: " << argv[0] << " fixedImage movingImage" << std::endl;
-        return EXIT_FAILURE;
-    }
-    using FixedImageType = itk::Image<double, 2>;
-    using MovingImageType = itk::Image<double, 2>;
-    using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
-    using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
-    using TransformType = itk::Euler2DTransform< double >;
-    using OptimizerType = itk::ExhaustiveOptimizerv4< double >;
-    using MetricType = itk::MeanSquaresImageToImageMetricv4< FixedImageType, MovingImageType >;
-    using TransformInitializerType = itk::CenteredTransformInitializer< TransformType, FixedImageType,  MovingImageType >;
-    using RegistrationType = itk::ImageRegistrationMethodv4< FixedImageType, MovingImageType, TransformType >;
+  if (argc < 3)
+  {
+    std::cout << "Usage: " << argv[0] << " fixedImage movingImage" << std::endl;
+    return EXIT_FAILURE;
+  }
+  using FixedImageType = itk::Image<double, 2>;
+  using MovingImageType = itk::Image<double, 2>;
+  using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
+  using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
+  using TransformType = itk::Euler2DTransform<double>;
+  using OptimizerType = itk::ExhaustiveOptimizerv4<double>;
+  using MetricType = itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType>;
+  using TransformInitializerType = itk::CenteredTransformInitializer<TransformType, FixedImageType, MovingImageType>;
+  using RegistrationType = itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType, TransformType>;
 
-    FixedImageReaderType::Pointer     fixedImageReader    = FixedImageReaderType::New();
-    MovingImageReaderType::Pointer    movingImageReader    = MovingImageReaderType::New();
-    FixedImageType::Pointer           fixedImage    = FixedImageType::New();
-    MovingImageType::Pointer          movingImage    = MovingImageType::New();
-    TransformType::Pointer            transform    = TransformType::New();
-    MetricType::Pointer               metric       = MetricType::New();
-    OptimizerType::Pointer            optimizer    = OptimizerType::New();
-    RegistrationType::Pointer         registration = RegistrationType::New();
-    TransformInitializerType::Pointer initializer  = TransformInitializerType::New();
+  FixedImageReaderType::Pointer     fixedImageReader = FixedImageReaderType::New();
+  MovingImageReaderType::Pointer    movingImageReader = MovingImageReaderType::New();
+  FixedImageType::Pointer           fixedImage = FixedImageType::New();
+  MovingImageType::Pointer          movingImage = MovingImageType::New();
+  TransformType::Pointer            transform = TransformType::New();
+  MetricType::Pointer               metric = MetricType::New();
+  OptimizerType::Pointer            optimizer = OptimizerType::New();
+  RegistrationType::Pointer         registration = RegistrationType::New();
+  TransformInitializerType::Pointer initializer = TransformInitializerType::New();
 
-    fixedImageReader->SetFileName (argv[1]);
-    fixedImageReader->Update();
-    fixedImage = fixedImageReader->GetOutput();
+  fixedImageReader->SetFileName(argv[1]);
+  fixedImageReader->Update();
+  fixedImage = fixedImageReader->GetOutput();
 
-    movingImageReader->SetFileName (argv[2]);
-    movingImageReader->Update();
-    movingImage = movingImageReader->GetOutput();
+  movingImageReader->SetFileName(argv[2]);
+  movingImageReader->Update();
+  movingImage = movingImageReader->GetOutput();
 
-    // Create the Command observer and register it with the optimizer.
-    //
-    CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
-    optimizer->AddObserver( itk::IterationEvent(), observer );
+  // Create the Command observer and register it with the optimizer.
+  //
+  CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  optimizer->AddObserver(itk::IterationEvent(), observer);
 
-    unsigned int angles = 12;
-    OptimizerType::StepsType steps( transform->GetNumberOfParameters() );
-    steps[0] = int(angles/2);
-    steps[1] = 0;
-    steps[2] = 0;
-    optimizer->SetNumberOfSteps( steps );
+  unsigned int             angles = 12;
+  OptimizerType::StepsType steps(transform->GetNumberOfParameters());
+  steps[0] = int(angles / 2);
+  steps[1] = 0;
+  steps[2] = 0;
+  optimizer->SetNumberOfSteps(steps);
 
-    OptimizerType::ScalesType scales( transform->GetNumberOfParameters() );
-    scales[0] = 2.0 * itk::Math::pi / angles;
-    scales[1] = 1.0;
-    scales[2] = 1.0;
+  OptimizerType::ScalesType scales(transform->GetNumberOfParameters());
+  scales[0] = 2.0 * itk::Math::pi / angles;
+  scales[1] = 1.0;
+  scales[2] = 1.0;
 
-    optimizer->SetScales( scales );
+  optimizer->SetScales(scales);
 
-    initializer->SetTransform(   transform );
-    initializer->SetFixedImage(  fixedImage );
-    initializer->SetMovingImage( movingImage );
-    initializer->InitializeTransform();
+  initializer->SetTransform(transform);
+  initializer->SetFixedImage(fixedImage);
+  initializer->SetMovingImage(movingImage);
+  initializer->InitializeTransform();
 
-// Initialize registration
-    registration->SetMetric(           metric );
-    registration->SetOptimizer(        optimizer );
-    registration->SetFixedImage(       fixedImage );
-    registration->SetMovingImage(      movingImage );
-    registration->SetInitialTransform( transform );
-    registration->SetNumberOfLevels(   1);
-    try
-    {
-        registration->Update();
-        std::cout << "  MinimumMetricValue: " << optimizer->GetMinimumMetricValue() << std::endl;
-        std::cout << "  MaximumMetricValue: " << optimizer->GetMaximumMetricValue() << std::endl;
-        std::cout << "  MinimumMetricValuePosition: " << optimizer->GetMinimumMetricValuePosition() << std::endl;
-        std::cout << "  MaximumMetricValuePosition: " << optimizer->GetMaximumMetricValuePosition() << std::endl;
-        std::cout << "  StopConditionDescription: " << optimizer->GetStopConditionDescription() << std::endl;
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cerr << "ExceptionObject caught !" << std::endl;
-        std::cerr << err << std::endl;
-        return EXIT_FAILURE;
-    }
-    return EXIT_SUCCESS;
+  // Initialize registration
+  registration->SetMetric(metric);
+  registration->SetOptimizer(optimizer);
+  registration->SetFixedImage(fixedImage);
+  registration->SetMovingImage(movingImage);
+  registration->SetInitialTransform(transform);
+  registration->SetNumberOfLevels(1);
+  try
+  {
+    registration->Update();
+    std::cout << "  MinimumMetricValue: " << optimizer->GetMinimumMetricValue() << std::endl;
+    std::cout << "  MaximumMetricValue: " << optimizer->GetMaximumMetricValue() << std::endl;
+    std::cout << "  MinimumMetricValuePosition: " << optimizer->GetMinimumMetricValuePosition() << std::endl;
+    std::cout << "  MaximumMetricValuePosition: " << optimizer->GetMaximumMetricValuePosition() << std::endl;
+    std::cout << "  StopConditionDescription: " << optimizer->GetStopConditionDescription() << std::endl;
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
 }
-

--- a/src/Numerics/Optimizers/LevenbergMarquardtOptimization/Code.cxx
+++ b/src/Numerics/Optimizers/LevenbergMarquardtOptimization/Code.cxx
@@ -23,28 +23,28 @@
 using OptimizerType = itk::LevenbergMarquardtOptimizer;
 using CostType = itk::ExampleCostFunction;
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
 
-    // Instantiate the cost function and optimizer
-    CostType::Pointer cost = CostType::New();
-    OptimizerType::Pointer optimizer = OptimizerType::New();
+  // Instantiate the cost function and optimizer
+  CostType::Pointer      cost = CostType::New();
+  OptimizerType::Pointer optimizer = OptimizerType::New();
 
-    optimizer->SetNumberOfIterations( 100 );
-    optimizer->UseCostFunctionGradientOff();
-    optimizer->SetCostFunction( cost.GetPointer());
+  optimizer->SetNumberOfIterations(100);
+  optimizer->UseCostFunctionGradientOff();
+  optimizer->SetCostFunction(cost.GetPointer());
 
-    // This is the initial guess for the parameter values, which we set to one
-    CostType::ParametersType p(cost->GetNumberOfParameters());
-    p.Fill( 1 );
-    optimizer->SetInitialPosition(p);
-    optimizer->StartOptimization();
+  // This is the initial guess for the parameter values, which we set to one
+  CostType::ParametersType p(cost->GetNumberOfParameters());
+  p.Fill(1);
+  optimizer->SetInitialPosition(p);
+  optimizer->StartOptimization();
 
-    // Print out some information about the optimization
-    // The parameters come out to be near to, but not exactly [5.5, 0.5]
-    std::cout << "Position: " << optimizer->GetCurrentPosition() << std::endl;
-    std::cout << "Value: " << optimizer->GetValue() << std::endl;
+  // Print out some information about the optimization
+  // The parameters come out to be near to, but not exactly [5.5, 0.5]
+  std::cout << "Position: " << optimizer->GetCurrentPosition() << std::endl;
+  std::cout << "Value: " << optimizer->GetValue() << std::endl;
 
-    return EXIT_SUCCESS;
-
+  return EXIT_SUCCESS;
 }

--- a/src/Numerics/Optimizers/LevenbergMarquardtOptimization/itkExampleCostFunction.h
+++ b/src/Numerics/Optimizers/LevenbergMarquardtOptimization/itkExampleCostFunction.h
@@ -8,8 +8,7 @@
 
 namespace itk
 {
-class ExampleCostFunction :
-public MultipleValuedCostFunction
+class ExampleCostFunction : public MultipleValuedCostFunction
 {
 public:
   /** Standard class type alias. */
@@ -27,73 +26,83 @@ public:
   // The equation we're fitting is y=C*e^(K*x)
   // The free parameters which we're trying to fit are C and K
   // Therefore, there are two parameters
-  unsigned int GetNumberOfParameters() const override { return 2; }
+  unsigned int
+  GetNumberOfParameters() const override
+  {
+    return 2;
+  }
 
   // We will take a curve with concrete values for C and K,
   // which has been corrupted by Gaussian noise, and sample
   // it at 100 points on the interval [0,1].  Each of these
   // points will produce a residual with the expected value.
   // Therefore, there are 100 values (aka residuals).
-  unsigned int GetNumberOfValues() const override { return 100; }
+  unsigned int
+  GetNumberOfValues() const override
+  {
+    return 100;
+  }
 
   // Calculate the residual array, given a set of parameters.
   // We take parameters[0] to be C and parameters[1] to be K.
   // Therefore, this is a matter of calculating the value of y
   // at each of the sampled points, given the provided guesses
   // for C and K, and returning the difference from the data.
-  MeasureType GetValue(const ParametersType &parameters) const override
-    {
+  MeasureType
+  GetValue(const ParametersType & parameters) const override
+  {
     MeasureType residual(this->GetNumberOfValues());
-    double predictedC = parameters[0];
-    double predictedK = parameters[1];
+    double      predictedC = parameters[0];
+    double      predictedK = parameters[1];
     for (unsigned int i = 0; i < 100; ++i)
-      {      
-      double position = double(i)/100;
-      double prediction = predictedC*exp(position*predictedK);
+    {
+      double position = double(i) / 100;
+      double prediction = predictedC * exp(position * predictedK);
       residual[i] = prediction - y[i];
-      }
-    return residual;
     }
+    return residual;
+  }
 
   // The "derivative" is the Jacobian, which takes the derivative
   // of each residual with respect to each parameter.  Since this
   // class does not provide a derivative, any optimizer using this
   // cost function must be told explicitly not to ask for derivative,
   // otherwise an exception will the thrown.
-  void GetDerivative(const ParametersType & /*parameters*/, DerivativeType & /*derivative*/ ) const override
-    {
-    throw ExceptionObject(__FILE__,__LINE__,"No derivative available.");
-    }
+  void
+  GetDerivative(const ParametersType & /*parameters*/, DerivativeType & /*derivative*/) const override
+  {
+    throw ExceptionObject(__FILE__, __LINE__, "No derivative available.");
+  }
 
 protected:
   ExampleCostFunction()
-    {
+  {
     // Create some data
     // Take the curve y = C*e^(K*x), add noise, and sample at 100 points on [0,1]
     // C and K are our parameters
     // In the actual data, these parameters are 5.5 and 0.5
     using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
     GeneratorType::Pointer randomEngine = GeneratorType::New();
-    double actualC = 5.5;
-    double actualK = 0.5;
+    double                 actualC = 5.5;
+    double                 actualK = 0.5;
     for (unsigned int i = 0; i < 100; ++i)
-      {
-      double position = double(i)/100;
+    {
+      double position = double(i) / 100;
       this->x.push_back(position);
-      this->y.push_back(actualC*exp(position*actualK) +
-                        randomEngine->GetUniformVariate(0.0, 0.5));
-      }
-    };
-  ~ExampleCostFunction() override= default;;
+      this->y.push_back(actualC * exp(position * actualK) + randomEngine->GetUniformVariate(0.0, 0.5));
+    }
+  };
+  ~ExampleCostFunction() override = default;
+  ;
 
 private:
-  ExampleCostFunction(const Self &) = delete; //purposely not implemented
-  void operator = (const Self &) = delete; //purposely not implemented
+  ExampleCostFunction(const Self &) = delete; // purposely not implemented
+  void
+  operator=(const Self &) = delete; // purposely not implemented
 
   // The x and y positions of the data, created in the constructor
   std::vector<double> x;
   std::vector<double> y;
-
 };
 
 } // end namespace itk

--- a/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/Code.cxx
+++ b/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/Code.cxx
@@ -21,106 +21,103 @@
 #include "itkExpectationMaximizationMixtureModelEstimator.h"
 #include "itkNormalVariateGenerator.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    unsigned int numberOfClasses = 2;
-    using MeasurementVectorType = itk::Vector< double, 2 >;
-    using SampleType = itk::Statistics::ListSample< MeasurementVectorType >;
-    SampleType::Pointer sample = SampleType::New();
+  unsigned int numberOfClasses = 2;
+  using MeasurementVectorType = itk::Vector<double, 2>;
+  using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
+  SampleType::Pointer sample = SampleType::New();
 
 
-    using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
-    NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
+  using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
+  NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
 
-    // Create the first set of 2D Gaussian samples
-    normalGenerator->Initialize( 101 );
+  // Create the first set of 2D Gaussian samples
+  normalGenerator->Initialize(101);
 
-    MeasurementVectorType mv;
-    double mean = 100;
-    double standardDeviation = 30;
-    for ( unsigned int i = 0; i < 100; ++i )
-    {
-        mv[0] = ( normalGenerator->GetVariate() * standardDeviation ) + mean;
-        mv[1] = ( normalGenerator->GetVariate() * standardDeviation ) + mean;
-        sample->PushBack( mv );
-    }
+  MeasurementVectorType mv;
+  double                mean = 100;
+  double                standardDeviation = 30;
+  for (unsigned int i = 0; i < 100; ++i)
+  {
+    mv[0] = (normalGenerator->GetVariate() * standardDeviation) + mean;
+    mv[1] = (normalGenerator->GetVariate() * standardDeviation) + mean;
+    sample->PushBack(mv);
+  }
 
-    // Create the second set of 2D Gaussian samples
-    normalGenerator->Initialize( 3024 );
-    mean = 200;
-    standardDeviation = 30;
-    for ( unsigned int i = 0; i < 100; ++i )
-    {
-        mv[0] = ( normalGenerator->GetVariate() * standardDeviation ) + mean;
-        mv[1] = ( normalGenerator->GetVariate() * standardDeviation ) + mean;
-        sample->PushBack( mv );
-    }
+  // Create the second set of 2D Gaussian samples
+  normalGenerator->Initialize(3024);
+  mean = 200;
+  standardDeviation = 30;
+  for (unsigned int i = 0; i < 100; ++i)
+  {
+    mv[0] = (normalGenerator->GetVariate() * standardDeviation) + mean;
+    mv[1] = (normalGenerator->GetVariate() * standardDeviation) + mean;
+    sample->PushBack(mv);
+  }
 
-    using ParametersType = itk::Array< double >;
-    ParametersType params( 6 );
+  using ParametersType = itk::Array<double>;
+  ParametersType params(6);
 
-    // Create the first set of initial parameters
-    std::vector< ParametersType > initialParameters( numberOfClasses );
-    params[0] = 110.0; // mean of dimension 1
-    params[1] = 115.0; // mean of dimension 2
-    params[2] = 800.0; // covariance(0,0)
-    params[3] = 0; // covariance(0,1)
-    params[4] = 0; // covariance(1,0)
-    params[5] = 805.0; // covariance(1,1)
-    initialParameters[0] = params;
+  // Create the first set of initial parameters
+  std::vector<ParametersType> initialParameters(numberOfClasses);
+  params[0] = 110.0; // mean of dimension 1
+  params[1] = 115.0; // mean of dimension 2
+  params[2] = 800.0; // covariance(0,0)
+  params[3] = 0;     // covariance(0,1)
+  params[4] = 0;     // covariance(1,0)
+  params[5] = 805.0; // covariance(1,1)
+  initialParameters[0] = params;
 
-    // Create the second set of initial parameters
-    params[0] = 210.0; // mean of dimension 1
-    params[1] = 215.0; // mean of dimension 2
-    params[2] = 850.0; // covariance(0,0)
-    params[3] = 0; // covariance(0,1)
-    params[4] = 0; // covariance(1,0)
-    params[5] = 855.0; // covariance(1,1)
-    initialParameters[1] = params;
+  // Create the second set of initial parameters
+  params[0] = 210.0; // mean of dimension 1
+  params[1] = 215.0; // mean of dimension 2
+  params[2] = 850.0; // covariance(0,0)
+  params[3] = 0;     // covariance(0,1)
+  params[4] = 0;     // covariance(1,0)
+  params[5] = 855.0; // covariance(1,1)
+  initialParameters[1] = params;
 
-    using ComponentType = itk::Statistics::GaussianMixtureModelComponent< SampleType >;
+  using ComponentType = itk::Statistics::GaussianMixtureModelComponent<SampleType>;
 
-    // Create the components
-    std::vector< ComponentType::Pointer > components;
-    for ( unsigned int i = 0; i < numberOfClasses; i++ )
-    {
-        components.push_back( ComponentType::New() );
-        (components[i])->SetSample( sample );
-        (components[i])->SetParameters( initialParameters[i] );
-    }
+  // Create the components
+  std::vector<ComponentType::Pointer> components;
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    components.push_back(ComponentType::New());
+    (components[i])->SetSample(sample);
+    (components[i])->SetParameters(initialParameters[i]);
+  }
 
-    using EstimatorType = itk::Statistics::ExpectationMaximizationMixtureModelEstimator<
-            SampleType >;
-    EstimatorType::Pointer estimator = EstimatorType::New();
+  using EstimatorType = itk::Statistics::ExpectationMaximizationMixtureModelEstimator<SampleType>;
+  EstimatorType::Pointer estimator = EstimatorType::New();
 
-    estimator->SetSample( sample );
-    estimator->SetMaximumIteration( 200 );
+  estimator->SetSample(sample);
+  estimator->SetMaximumIteration(200);
 
-    itk::Array< double > initialProportions(numberOfClasses);
-    initialProportions[0] = 0.5;
-    initialProportions[1] = 0.5;
+  itk::Array<double> initialProportions(numberOfClasses);
+  initialProportions[0] = 0.5;
+  initialProportions[1] = 0.5;
 
-    estimator->SetInitialProportions( initialProportions );
+  estimator->SetInitialProportions(initialProportions);
 
-    for ( unsigned int i = 0; i < numberOfClasses; i++)
-    {
-        estimator->AddComponent( (ComponentType::Superclass*)
-                                         (components[i]).GetPointer() );
-    }
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    estimator->AddComponent((ComponentType::Superclass *)(components[i]).GetPointer());
+  }
 
-    estimator->Update();
+  estimator->Update();
 
-    // Output the results
-    for ( unsigned int i = 0; i < numberOfClasses; i++ )
-    {
-        std::cout << "Cluster[" << i << "]" << std::endl;
-        std::cout << "    Parameters:" << std::endl;
-        std::cout << "         " << (components[i])->GetFullParameters()
-                  << std::endl;
-        std::cout << "    Proportion: ";
-        std::cout << "         " << estimator->GetProportions()[i] << std::endl;
-    }
+  // Output the results
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    std::cout << "Cluster[" << i << "]" << std::endl;
+    std::cout << "    Parameters:" << std::endl;
+    std::cout << "         " << (components[i])->GetFullParameters() << std::endl;
+    std::cout << "    Proportion: ";
+    std::cout << "         " << estimator->GetProportions()[i] << std::endl;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/Code.cxx
+++ b/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/Code.cxx
@@ -21,71 +21,67 @@
 #include "itkImageToHistogramFilter.h"
 #include "itkImageRandomIteratorWithIndex.h"
 
-int main(int argc, char* argv[])
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << argv[0] << "InputFileName NumberOfBins" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   constexpr unsigned int MeasurementVectorSize = 1; // Grayscale
-  const auto binsPerDimension = static_cast< unsigned int >( std::stoi( argv[2] ) );
+  const auto             binsPerDimension = static_cast<unsigned int>(std::stoi(argv[2]));
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   ImageType::Pointer image = reader->GetOutput();
 
-  using ImageToHistogramFilterType = itk::Statistics::ImageToHistogramFilter< ImageType >;
+  using ImageToHistogramFilterType = itk::Statistics::ImageToHistogramFilter<ImageType>;
 
-  ImageToHistogramFilterType::HistogramType::MeasurementVectorType
-    lowerBound(binsPerDimension);
+  ImageToHistogramFilterType::HistogramType::MeasurementVectorType lowerBound(binsPerDimension);
   lowerBound.Fill(0);
 
-  ImageToHistogramFilterType::HistogramType::MeasurementVectorType
-    upperBound(binsPerDimension);
+  ImageToHistogramFilterType::HistogramType::MeasurementVectorType upperBound(binsPerDimension);
   upperBound.Fill(255);
 
-  ImageToHistogramFilterType::HistogramType::SizeType
-    size(MeasurementVectorSize);
+  ImageToHistogramFilterType::HistogramType::SizeType size(MeasurementVectorSize);
   size.Fill(binsPerDimension);
 
-  ImageToHistogramFilterType::Pointer imageToHistogramFilter =
-    ImageToHistogramFilterType::New();
-  imageToHistogramFilter->SetInput( image );
-  imageToHistogramFilter->SetHistogramBinMinimum( lowerBound );
-  imageToHistogramFilter->SetHistogramBinMaximum( upperBound );
-  imageToHistogramFilter->SetHistogramSize( size );
+  ImageToHistogramFilterType::Pointer imageToHistogramFilter = ImageToHistogramFilterType::New();
+  imageToHistogramFilter->SetInput(image);
+  imageToHistogramFilter->SetHistogramBinMinimum(lowerBound);
+  imageToHistogramFilter->SetHistogramBinMaximum(upperBound);
+  imageToHistogramFilter->SetHistogramSize(size);
 
   try
-    {
+  {
     imageToHistogramFilter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  ImageToHistogramFilterType::HistogramType* histogram =
-    imageToHistogramFilter->GetOutput();
+  ImageToHistogramFilterType::HistogramType * histogram = imageToHistogramFilter->GetOutput();
 
   std::cout << "Frequency = [ ";
-  for(unsigned int i = 0; i < histogram->GetSize()[0]; ++i)
-    {
+  for (unsigned int i = 0; i < histogram->GetSize()[0]; ++i)
+  {
     std::cout << histogram->GetFrequency(i);
 
-    if( i != histogram->GetSize()[0] - 1 )
-      {
+    if (i != histogram->GetSize()[0] - 1)
+    {
       std::cout << "," << std::endl;
-      }
     }
+  }
 
   std::cout << " ]" << std::endl;
 

--- a/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/Code.cxx
+++ b/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/Code.cxx
@@ -24,150 +24,155 @@
 #include "itkRescaleIntensityImageFilter.h"
 
 using RGBPixelType = itk::RGBPixel<unsigned char>;
-using RGBImageType = itk::Image< RGBPixelType, 2>;
+using RGBImageType = itk::Image<RGBPixelType, 2>;
 
-using UnsignedCharImageType = itk::Image< unsigned char, 2>;
+using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(RGBImageType::Pointer image);
+static void
+            CreateImage(RGBImageType::Pointer image);
 static void CreateHalfMask(itk::ImageRegion<2>, UnsignedCharImageType::Pointer mask);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    constexpr unsigned int MeasurementVectorSize = 3; // RGB
+  constexpr unsigned int MeasurementVectorSize = 3; // RGB
 
-    RGBImageType::Pointer image = RGBImageType::New();
-    CreateImage(image);
+  RGBImageType::Pointer image = RGBImageType::New();
+  CreateImage(image);
 
-    UnsignedCharImageType::Pointer mask = UnsignedCharImageType::New();
-    CreateHalfMask(image->GetLargestPossibleRegion(), mask);
+  UnsignedCharImageType::Pointer mask = UnsignedCharImageType::New();
+  CreateHalfMask(image->GetLargestPossibleRegion(), mask);
 
-    using HistogramFilterType = itk::Statistics::MaskedImageToHistogramFilter< RGBImageType, UnsignedCharImageType >;
-    using HistogramMeasurementVectorType = HistogramFilterType::HistogramMeasurementVectorType;
-    using HistogramSizeType = HistogramFilterType::HistogramSizeType;
-    using HistogramType = HistogramFilterType::HistogramType;
+  using HistogramFilterType = itk::Statistics::MaskedImageToHistogramFilter<RGBImageType, UnsignedCharImageType>;
+  using HistogramMeasurementVectorType = HistogramFilterType::HistogramMeasurementVectorType;
+  using HistogramSizeType = HistogramFilterType::HistogramSizeType;
+  using HistogramType = HistogramFilterType::HistogramType;
 
-    HistogramFilterType::Pointer histogramFilter = HistogramFilterType::New();
-    histogramFilter->SetInput(image);
-    histogramFilter->SetMaskImage(mask);
-    histogramFilter->SetAutoMinimumMaximum(true);
+  HistogramFilterType::Pointer histogramFilter = HistogramFilterType::New();
+  histogramFilter->SetInput(image);
+  histogramFilter->SetMaskImage(mask);
+  histogramFilter->SetAutoMinimumMaximum(true);
 
-    HistogramSizeType histogramSize( MeasurementVectorSize );
+  HistogramSizeType histogramSize(MeasurementVectorSize);
 
-    histogramSize[0] = 4;  // number of bins for the Red   channel
-    histogramSize[1] = 4;  // number of bins for the Green channel
-    histogramSize[2] = 4;  // number of bins for the Blue  channel
+  histogramSize[0] = 4; // number of bins for the Red   channel
+  histogramSize[1] = 4; // number of bins for the Green channel
+  histogramSize[2] = 4; // number of bins for the Blue  channel
 
-    histogramFilter->SetHistogramSize(histogramSize);
-    histogramFilter->SetMarginalScale(10); // Required (could this be set in the filter?)
-    histogramFilter->Update();
+  histogramFilter->SetHistogramSize(histogramSize);
+  histogramFilter->SetMarginalScale(10); // Required (could this be set in the filter?)
+  histogramFilter->Update();
 
-    const HistogramType * histogram = histogramFilter->GetOutput();
+  const HistogramType * histogram = histogramFilter->GetOutput();
 
-    HistogramType::ConstIterator histogramIterator = histogram->Begin();
+  HistogramType::ConstIterator histogramIterator = histogram->Begin();
 
-    //std::string filename = "/home/doriad/histogram.txt";
-    //std::ofstream fout(filename.c_str());
+  // std::string filename = "/home/doriad/histogram.txt";
+  // std::ofstream fout(filename.c_str());
 
-    while( histogramIterator  != histogram->End() )
-    {
-        //std::cout << "Index = " << histogramIterator.GetMeasurementVector() << "Frequency = " << histogramIterator.GetFrequency() << std::endl;
-        //std::cout << "Index = " << histogramIterator.GetIndex() << "Frequency = " << histogramIterator.GetFrequency() << std::endl;
-        //fout << "Index = " << histogram->GetIndex(histogramItr.GetMeasurementVector()) << "Frequency = " << histogramItr.GetFrequency() << std::endl;
-        ++histogramIterator;
-    }
-    //fout.close();
+  while (histogramIterator != histogram->End())
+  {
+    // std::cout << "Index = " << histogramIterator.GetMeasurementVector() << "Frequency = " <<
+    // histogramIterator.GetFrequency() << std::endl; std::cout << "Index = " << histogramIterator.GetIndex() <<
+    // "Frequency = " << histogramIterator.GetFrequency() << std::endl; fout << "Index = " <<
+    // histogram->GetIndex(histogramItr.GetMeasurementVector()) << "Frequency = " << histogramItr.GetFrequency() <<
+    // std::endl;
+    ++histogramIterator;
+  }
+  // fout.close();
 
-    HistogramType::MeasurementVectorType mv(3);
-    mv[0] = 255;
-    mv[1] = 0;
-    mv[2] = 0;
-    std::cout << "Frequency = " << histogram->GetFrequency(histogram->GetIndex(mv)) << std::endl;
-    return EXIT_SUCCESS;
+  HistogramType::MeasurementVectorType mv(3);
+  mv[0] = 255;
+  mv[1] = 0;
+  mv[2] = 0;
+  std::cout << "Frequency = " << histogram->GetFrequency(histogram->GetIndex(mv)) << std::endl;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(RGBImageType::Pointer image)
+void
+CreateImage(RGBImageType::Pointer image)
 {
-    // Create a black image with a red square and a green square.
-    // This should produce a histogram with very strong spikes.
-    RGBImageType::SizeType   size;
-    size[0] = 3;
-    size[1] = 3;
+  // Create a black image with a red square and a green square.
+  // This should produce a histogram with very strong spikes.
+  RGBImageType::SizeType size;
+  size[0] = 3;
+  size[1] = 3;
 
-    RGBImageType::IndexType  start;
-    start[0] = 0;
-    start[1] = 0;
+  RGBImageType::IndexType start;
+  start[0] = 0;
+  start[1] = 0;
 
-    RGBImageType::RegionType region;
-    region.SetIndex(start);
-    region.SetSize(size);
+  RGBImageType::RegionType region;
+  region.SetIndex(start);
+  region.SetSize(size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIteratorWithIndex< RGBImageType > iterator( image, image->GetLargestPossibleRegion() );
-    iterator.GoToBegin();
+  itk::ImageRegionIteratorWithIndex<RGBImageType> iterator(image, image->GetLargestPossibleRegion());
+  iterator.GoToBegin();
 
-    RGBPixelType redPixel;
-    redPixel.SetRed(255);
-    redPixel.SetGreen(0);
-    redPixel.SetBlue(0);
+  RGBPixelType redPixel;
+  redPixel.SetRed(255);
+  redPixel.SetGreen(0);
+  redPixel.SetBlue(0);
 
-    RGBPixelType blackPixel;
-    blackPixel.SetRed(0);
-    blackPixel.SetGreen(0);
-    blackPixel.SetBlue(0);
+  RGBPixelType blackPixel;
+  blackPixel.SetRed(0);
+  blackPixel.SetGreen(0);
+  blackPixel.SetBlue(0);
 
-    itk::ImageRegionIterator<RGBImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<RGBImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        imageIterator.Set(blackPixel);
-        ++imageIterator;
-    }
+  while (!imageIterator.IsAtEnd())
+  {
+    imageIterator.Set(blackPixel);
+    ++imageIterator;
+  }
 
-    RGBImageType::IndexType index;
-    index[0] = 0; index[1] = 0;
-    image->SetPixel(index, redPixel);
+  RGBImageType::IndexType index;
+  index[0] = 0;
+  index[1] = 0;
+  image->SetPixel(index, redPixel);
 
-    index[0] = 1; index[1] = 0;
-    image->SetPixel(index, redPixel);
+  index[0] = 1;
+  index[1] = 0;
+  image->SetPixel(index, redPixel);
 }
 
 void CreateHalfMask(itk::ImageRegion<2> region, UnsignedCharImageType::Pointer mask)
 {
-    mask->SetRegions(region);
-    mask->Allocate();
-    mask->FillBuffer(0);
+  mask->SetRegions(region);
+  mask->Allocate();
+  mask->FillBuffer(0);
 
-    itk::Size<2> regionSize = region.GetSize();
+  itk::Size<2> regionSize = region.GetSize();
 
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(mask,region);
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(mask, region);
 
-    // Make the left half of the mask white and the right half black
-    while(!imageIterator.IsAtEnd())
+  // Make the left half of the mask white and the right half black
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > regionSize[0] / 2)
     {
-        if(imageIterator.GetIndex()[0] > regionSize[0] / 2)
-        {
-            imageIterator.Set(0);
-        }
-        else
-        {
-            imageIterator.Set(1);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(0);
+    }
+    else
+    {
+      imageIterator.Set(1);
     }
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< UnsignedCharImageType, UnsignedCharImageType >;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetInput(mask);
-    rescaleFilter->Update();
+    ++imageIterator;
+  }
 
-    using WriterType = itk::ImageFileWriter< UnsignedCharImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetFileName("mask.png");
-    writer->SetInput(rescaleFilter->GetOutput());
-    writer->Update();
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<UnsignedCharImageType, UnsignedCharImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetInput(mask);
+  rescaleFilter->Update();
 
+  using WriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("mask.png");
+  writer->SetInput(rescaleFilter->GetOutput());
+  writer->Update();
 }
-

--- a/src/Numerics/Statistics/ComputeTextureFeatures/Code.cxx
+++ b/src/Numerics/Statistics/ComputeTextureFeatures/Code.cxx
@@ -23,7 +23,8 @@ using ImageType = itk::Image<float, 2>;
 
 static void CreateImage(ImageType::Pointer);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);
@@ -33,16 +34,17 @@ int main(int, char *[])
   textureFilter->SetInput(image);
   textureFilter->Update();
 
-  const TextureFilterType::FeatureValueVector* output = textureFilter->GetFeatureMeans();
-  for(unsigned int i = 0; i < output->size(); ++i)
-    {
+  const TextureFilterType::FeatureValueVector * output = textureFilter->GetFeatureMeans();
+  for (unsigned int i = 0; i < output->size(); ++i)
+  {
     std::cout << (*output)[i] << std::endl;
-    }
+  }
 
   return EXIT_SUCCESS;
 }
 
-static void CreateImage(ImageType::Pointer image)
+static void
+CreateImage(ImageType::Pointer image)
 {
   itk::Index<2> index;
   index.Fill(0);
@@ -54,4 +56,3 @@ static void CreateImage(ImageType::Pointer image)
   image->SetRegions(region);
   image->Allocate();
 }
-

--- a/src/Numerics/Statistics/CreateGaussianDistribution/Code.cxx
+++ b/src/Numerics/Statistics/CreateGaussianDistribution/Code.cxx
@@ -17,11 +17,12 @@
  *=========================================================================*/
 #include "itkGaussianDistribution.h"
 
-int main(int, char* [] )
+int
+main(int, char *[])
 {
-    itk::Statistics::GaussianDistribution::Pointer gaussian = itk::Statistics::GaussianDistribution::New();
-    gaussian->SetMean(2.0);
-    gaussian->SetVariance(1.0);
-    std::cout << gaussian->EvaluatePDF(2.1) << std::endl;
-    return EXIT_SUCCESS;
+  itk::Statistics::GaussianDistribution::Pointer gaussian = itk::Statistics::GaussianDistribution::New();
+  gaussian->SetMean(2.0);
+  gaussian->SetVariance(1.0);
+  std::cout << gaussian->EvaluatePDF(2.1) << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Code.cxx
+++ b/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Code.cxx
@@ -20,53 +20,54 @@
 #include "itkHistogram.h"
 
 using MeasurementVectorType = itk::Vector<unsigned char, 1>;
-using SampleType = itk::Statistics::ListSample< MeasurementVectorType >;
+using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
 
-using HistogramType = itk::Statistics::Histogram< float,
-        itk::Statistics::DenseFrequencyContainer2 >;
+using HistogramType = itk::Statistics::Histogram<float, itk::Statistics::DenseFrequencyContainer2>;
 
-void CreateSample(SampleType::Pointer image);
+void
+CreateSample(SampleType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    SampleType::Pointer sample = SampleType::New();
-    CreateSample(sample);
+  SampleType::Pointer sample = SampleType::New();
+  CreateSample(sample);
 
-    using SampleToHistogramFilterType = itk::Statistics::SampleToHistogramFilter<SampleType, HistogramType>;
-    SampleToHistogramFilterType::Pointer sampleToHistogramFilter =
-            SampleToHistogramFilterType::New();
-    sampleToHistogramFilter->SetInput(sample);
+  using SampleToHistogramFilterType = itk::Statistics::SampleToHistogramFilter<SampleType, HistogramType>;
+  SampleToHistogramFilterType::Pointer sampleToHistogramFilter = SampleToHistogramFilterType::New();
+  sampleToHistogramFilter->SetInput(sample);
 
-    SampleToHistogramFilterType::HistogramSizeType histogramSize(1);
-    histogramSize.Fill(10);
-    sampleToHistogramFilter->SetHistogramSize(histogramSize);
+  SampleToHistogramFilterType::HistogramSizeType histogramSize(1);
+  histogramSize.Fill(10);
+  sampleToHistogramFilter->SetHistogramSize(histogramSize);
 
-    sampleToHistogramFilter->Update();
+  sampleToHistogramFilter->Update();
 
-    const HistogramType* histogram = sampleToHistogramFilter->GetOutput();
-    std::cout << "Histogram vector size: " << histogram->GetMeasurementVectorSize() << std::endl;
+  const HistogramType * histogram = sampleToHistogramFilter->GetOutput();
+  std::cout << "Histogram vector size: " << histogram->GetMeasurementVectorSize() << std::endl;
 
 
-    for(unsigned int i = 0; i < histogram->GetSize()[0]; i++)
-    {
-        std::cout << "Frequency of " << i << " : (" << histogram->GetBinMin(0, i) << " to " << histogram->GetBinMax(0, i) << ") = " << histogram->GetFrequency(i) << std::endl;
-    }
+  for (unsigned int i = 0; i < histogram->GetSize()[0]; i++)
+  {
+    std::cout << "Frequency of " << i << " : (" << histogram->GetBinMin(0, i) << " to " << histogram->GetBinMax(0, i)
+              << ") = " << histogram->GetFrequency(i) << std::endl;
+  }
 
-    std::cout << "Total count " << histogram->GetTotalFrequency() << std::endl;
+  std::cout << "Total count " << histogram->GetTotalFrequency() << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateSample(SampleType::Pointer sample)
+void
+CreateSample(SampleType::Pointer sample)
 {
-    MeasurementVectorType mv;
-    mv[0] = 1.0;
-    sample->PushBack(mv);
+  MeasurementVectorType mv;
+  mv[0] = 1.0;
+  sample->PushBack(mv);
 
-    mv[0] = 1.0;
-    sample->PushBack(mv);
+  mv[0] = 1.0;
+  sample->PushBack(mv);
 
-    mv[0] = 2.0;
-    sample->PushBack(mv);
-
+  mv[0] = 2.0;
+  sample->PushBack(mv);
 }

--- a/src/Numerics/Statistics/CreateListOfSampleMeasurements/Code.cxx
+++ b/src/Numerics/Statistics/CreateListOfSampleMeasurements/Code.cxx
@@ -18,57 +18,49 @@
 #include "itkListSample.h"
 #include "itkVector.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using MeasurementVectorType = itk::Vector<float, 3>;
-    using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
-    SampleType::Pointer sample = SampleType::New();
+  using MeasurementVectorType = itk::Vector<float, 3>;
+  using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
+  SampleType::Pointer sample = SampleType::New();
 
-    MeasurementVectorType mv;
-    mv[0] = 1.0;
-    mv[1] = 2.0;
-    mv[2] = 4.0;
+  MeasurementVectorType mv;
+  mv[0] = 1.0;
+  mv[1] = 2.0;
+  mv[2] = 4.0;
 
-    sample->PushBack(mv);
+  sample->PushBack(mv);
 
-    sample->Resize(3);
+  sample->Resize(3);
 
-    mv[0] = 2.0;
-    mv[1] = 4.0;
-    mv[2] = 5.0;
-    sample->SetMeasurementVector(1, mv);
+  mv[0] = 2.0;
+  mv[1] = 4.0;
+  mv[2] = 5.0;
+  sample->SetMeasurementVector(1, mv);
 
-    mv[0] = 3.0;
-    mv[1] = 8.0;
-    mv[2] = 6.0;
-    sample->SetMeasurementVector(2, mv);
+  mv[0] = 3.0;
+  mv[1] = 8.0;
+  mv[2] = 6.0;
+  sample->SetMeasurementVector(2, mv);
 
-    for(unsigned long i = 0; i < sample->Size(); ++i)
-    {
-        std::cout << "id = " << i
-                  << "\t measurement vector = "
-                  << sample->GetMeasurementVector(i)
-                  << "\t frequency = "
-                  << sample->GetFrequency(i)
-                  << std::endl;
-    }
+  for (unsigned long i = 0; i < sample->Size(); ++i)
+  {
+    std::cout << "id = " << i << "\t measurement vector = " << sample->GetMeasurementVector(i)
+              << "\t frequency = " << sample->GetFrequency(i) << std::endl;
+  }
 
-    SampleType::Iterator iter = sample->Begin();
+  SampleType::Iterator iter = sample->Begin();
 
-    while( iter != sample->End() )
-    {
-        std::cout << "id = " << iter.GetInstanceIdentifier()
-                  << "\t measurement vector = "
-                  << iter.GetMeasurementVector()
-                  << "\t frequency = "
-                  << iter.GetFrequency()
-                  << std::endl;
-        ++iter;
-    }
+  while (iter != sample->End())
+  {
+    std::cout << "id = " << iter.GetInstanceIdentifier() << "\t measurement vector = " << iter.GetMeasurementVector()
+              << "\t frequency = " << iter.GetFrequency() << std::endl;
+    ++iter;
+  }
 
-    std::cout << "Size = " << sample->Size() << std::endl;
-    std::cout << "Total frequency = "
-              << sample->GetTotalFrequency() << std::endl;
+  std::cout << "Size = " << sample->Size() << std::endl;
+  std::cout << "Total frequency = " << sample->GetTotalFrequency() << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/Code.cxx
+++ b/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/Code.cxx
@@ -20,50 +20,50 @@
 #include "itkRandomImageSource.h"
 #include "itkComposeImageFilter.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using FloatImage2DType = itk::Image<float,2>;
+  using FloatImage2DType = itk::Image<float, 2>;
 
-    itk::RandomImageSource<FloatImage2DType>::Pointer random;
-    random = itk::RandomImageSource<FloatImage2DType>::New();
+  itk::RandomImageSource<FloatImage2DType>::Pointer random;
+  random = itk::RandomImageSource<FloatImage2DType>::New();
 
-    random->SetMin(    0.0 );
-    random->SetMax( 1000.0 );
+  random->SetMin(0.0);
+  random->SetMax(1000.0);
 
-    using SpacingValueType = FloatImage2DType::SpacingValueType;
-    using SizeValueType = FloatImage2DType::SizeValueType;
-    using PointValueType = FloatImage2DType::PointValueType;
+  using SpacingValueType = FloatImage2DType::SpacingValueType;
+  using SizeValueType = FloatImage2DType::SizeValueType;
+  using PointValueType = FloatImage2DType::PointValueType;
 
-    SizeValueType size[2] = {20, 20};
-    random->SetSize( size );
+  SizeValueType size[2] = { 20, 20 };
+  random->SetSize(size);
 
-    SpacingValueType spacing[2] = {0.7, 2.1};
-    random->SetSpacing( spacing );
+  SpacingValueType spacing[2] = { 0.7, 2.1 };
+  random->SetSpacing(spacing);
 
-    PointValueType origin[2] = {15, 400};
-    random->SetOrigin( origin );
+  PointValueType origin[2] = { 15, 400 };
+  random->SetOrigin(origin);
 
-    using MeasurementVectorType = itk::FixedArray< float, 1 >;
-    using ArrayImageType = itk::Image< MeasurementVectorType, 2 >;
-    using CasterType = itk::ComposeImageFilter< FloatImage2DType, ArrayImageType >;
+  using MeasurementVectorType = itk::FixedArray<float, 1>;
+  using ArrayImageType = itk::Image<MeasurementVectorType, 2>;
+  using CasterType = itk::ComposeImageFilter<FloatImage2DType, ArrayImageType>;
 
-    CasterType::Pointer caster = CasterType::New();
-    caster->SetInput( random->GetOutput() );
-    caster->Update();
+  CasterType::Pointer caster = CasterType::New();
+  caster->SetInput(random->GetOutput());
+  caster->Update();
 
-    using SampleType = itk::Statistics::ImageToListSampleAdaptor< ArrayImageType >;
-    SampleType::Pointer sample = SampleType::New();
+  using SampleType = itk::Statistics::ImageToListSampleAdaptor<ArrayImageType>;
+  SampleType::Pointer sample = SampleType::New();
 
-    sample->SetImage( caster->GetOutput() );
+  sample->SetImage(caster->GetOutput());
 
-    SampleType::Iterator iter = sample->Begin();
+  SampleType::Iterator iter = sample->Begin();
 
-    while( iter != sample->End() )
-    {
-        std::cout << iter.GetMeasurementVector() << std::endl;
-        ++iter;
-    }
+  while (iter != sample->End())
+  {
+    std::cout << iter.GetMeasurementVector() << std::endl;
+    ++iter;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Numerics/Statistics/CreateListOfSamplesWithIDs/Code.cxx
+++ b/src/Numerics/Statistics/CreateListOfSamplesWithIDs/Code.cxx
@@ -19,70 +19,60 @@
 #include "itkMembershipSample.h"
 #include "itkVector.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using MeasurementVectorType = itk::Vector< float, 3 >;
-    using SampleType = itk::Statistics::ListSample< MeasurementVectorType >;
-    SampleType::Pointer sample = SampleType::New();
-    MeasurementVectorType mv;
+  using MeasurementVectorType = itk::Vector<float, 3>;
+  using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
+  SampleType::Pointer   sample = SampleType::New();
+  MeasurementVectorType mv;
 
-    mv[0] = 1.0;
-    mv[1] = 2.0;
-    mv[2] = 4.0;
-    sample->PushBack(mv);
+  mv[0] = 1.0;
+  mv[1] = 2.0;
+  mv[2] = 4.0;
+  sample->PushBack(mv);
 
-    mv[0] = 2.0;
-    mv[1] = 4.0;
-    mv[2] = 5.0;
-    sample->PushBack(mv);
+  mv[0] = 2.0;
+  mv[1] = 4.0;
+  mv[2] = 5.0;
+  sample->PushBack(mv);
 
-    mv[0] = 3.0;
-    mv[1] = 8.0;
-    mv[2] = 6.0;
-    sample->PushBack(mv);
-    using MembershipSampleType = itk::Statistics::MembershipSample< SampleType >;
+  mv[0] = 3.0;
+  mv[1] = 8.0;
+  mv[2] = 6.0;
+  sample->PushBack(mv);
+  using MembershipSampleType = itk::Statistics::MembershipSample<SampleType>;
 
-    MembershipSampleType::Pointer membershipSample =
-            MembershipSampleType::New();
+  MembershipSampleType::Pointer membershipSample = MembershipSampleType::New();
 
-    membershipSample->SetSample(sample);
-    membershipSample->SetNumberOfClasses(2);
+  membershipSample->SetSample(sample);
+  membershipSample->SetNumberOfClasses(2);
 
-    membershipSample->AddInstance(0U, 0UL );
-    membershipSample->AddInstance(0U, 1UL );
-    membershipSample->AddInstance(1U, 2UL );
+  membershipSample->AddInstance(0U, 0UL);
+  membershipSample->AddInstance(0U, 1UL);
+  membershipSample->AddInstance(1U, 2UL);
 
-    MembershipSampleType::ConstIterator iter = membershipSample->Begin();
-    while ( iter != membershipSample->End() )
-    {
-        std::cout << "instance identifier = " << iter.GetInstanceIdentifier()
-                  << "\t measurement vector = "
-                  << iter.GetMeasurementVector()
-                  << "\t frequency = "
-                  << iter.GetFrequency()
-                  << "\t class label = "
-                  << iter.GetClassLabel()
-                  << std::endl;
-        ++iter;
-    }
+  MembershipSampleType::ConstIterator iter = membershipSample->Begin();
+  while (iter != membershipSample->End())
+  {
+    std::cout << "instance identifier = " << iter.GetInstanceIdentifier()
+              << "\t measurement vector = " << iter.GetMeasurementVector() << "\t frequency = " << iter.GetFrequency()
+              << "\t class label = " << iter.GetClassLabel() << std::endl;
+    ++iter;
+  }
 
 
-    MembershipSampleType::ClassSampleType::ConstPointer classSample =
-            membershipSample->GetClassSample( 0 );
+  MembershipSampleType::ClassSampleType::ConstPointer classSample = membershipSample->GetClassSample(0);
 
-    MembershipSampleType::ClassSampleType::ConstIterator c_iter =
-            classSample->Begin();
+  MembershipSampleType::ClassSampleType::ConstIterator c_iter = classSample->Begin();
 
-    while ( c_iter != classSample->End() )
-    {
-        std::cout << "instance identifier = " << c_iter.GetInstanceIdentifier()
-                  << "\t measurement vector = "
-                  << c_iter.GetMeasurementVector()
-                  << "\t frequency = "
-                  << c_iter.GetFrequency() << std::endl;
-        ++c_iter;
-    }
+  while (c_iter != classSample->End())
+  {
+    std::cout << "instance identifier = " << c_iter.GetInstanceIdentifier()
+              << "\t measurement vector = " << c_iter.GetMeasurementVector()
+              << "\t frequency = " << c_iter.GetFrequency() << std::endl;
+    ++c_iter;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Numerics/Statistics/DistributeSamplingUsingGMM/Code.cxx
+++ b/src/Numerics/Statistics/DistributeSamplingUsingGMM/Code.cxx
@@ -21,91 +21,89 @@
 #include "itkExpectationMaximizationMixtureModelEstimator.h"
 #include "itkNormalVariateGenerator.h"
 
-int main(int, char*[])
+int
+main(int, char *[])
 {
-    unsigned int numberOfClasses = 2;
-    using MeasurementVectorType = itk::Vector< double, 1 >;
-    using SampleType = itk::Statistics::ListSample< MeasurementVectorType >;
-    SampleType::Pointer sample = SampleType::New();
+  unsigned int numberOfClasses = 2;
+  using MeasurementVectorType = itk::Vector<double, 1>;
+  using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
+  SampleType::Pointer sample = SampleType::New();
 
-    using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
-    NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
+  using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
+  NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
 
-    normalGenerator->Initialize(101);
+  normalGenerator->Initialize(101);
 
-    MeasurementVectorType mv;
-    double mean = 100;
-    double standardDeviation = 30;
-    for(unsigned int i = 0; i < 10; ++i )
-    {
-        mv[0] = ( normalGenerator->GetVariate() * standardDeviation ) + mean;
-        std::cout << "m[" << i << "] = " << mv[0] << std::endl;
-        sample->PushBack( mv );
-    }
+  MeasurementVectorType mv;
+  double                mean = 100;
+  double                standardDeviation = 30;
+  for (unsigned int i = 0; i < 10; ++i)
+  {
+    mv[0] = (normalGenerator->GetVariate() * standardDeviation) + mean;
+    std::cout << "m[" << i << "] = " << mv[0] << std::endl;
+    sample->PushBack(mv);
+  }
 
-    normalGenerator->Initialize(3024);
-    mean = 200;
-    standardDeviation = 30;
-    for(unsigned int i = 0; i < 10; ++i )
-    {
-        mv[0] = ( normalGenerator->GetVariate() * standardDeviation ) + mean;
-        std::cout << "m[" << i << "] = " << mv[0] << std::endl;
-        sample->PushBack( mv );
-    }
+  normalGenerator->Initialize(3024);
+  mean = 200;
+  standardDeviation = 30;
+  for (unsigned int i = 0; i < 10; ++i)
+  {
+    mv[0] = (normalGenerator->GetVariate() * standardDeviation) + mean;
+    std::cout << "m[" << i << "] = " << mv[0] << std::endl;
+    sample->PushBack(mv);
+  }
 
-    using ParametersType = itk::Array< double >;
-    ParametersType params1( 2 );
+  using ParametersType = itk::Array<double>;
+  ParametersType params1(2);
 
-    std::vector< ParametersType > initialParameters( numberOfClasses );
-    params1[0] = 110.0;
-    params1[1] = 50.0;
-    initialParameters[0] = params1;
+  std::vector<ParametersType> initialParameters(numberOfClasses);
+  params1[0] = 110.0;
+  params1[1] = 50.0;
+  initialParameters[0] = params1;
 
-    ParametersType params2( 2 );
-    params2[0] = 210.0;
-    params2[1] = 50.0;
-    initialParameters[1] = params2;
+  ParametersType params2(2);
+  params2[0] = 210.0;
+  params2[1] = 50.0;
+  initialParameters[1] = params2;
 
-    using ComponentType = itk::Statistics::GaussianMixtureModelComponent< SampleType >;
+  using ComponentType = itk::Statistics::GaussianMixtureModelComponent<SampleType>;
 
-    std::vector< ComponentType::Pointer > components;
-    for ( unsigned int i = 0; i < numberOfClasses; i++ )
-    {
-        components.push_back( ComponentType::New() );
-        components[i]->SetSample( sample );
-        components[i]->SetParameters( initialParameters[i] );
-    }
+  std::vector<ComponentType::Pointer> components;
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    components.push_back(ComponentType::New());
+    components[i]->SetSample(sample);
+    components[i]->SetParameters(initialParameters[i]);
+  }
 
-    using EstimatorType = itk::Statistics::ExpectationMaximizationMixtureModelEstimator<
-            SampleType >;
-    EstimatorType::Pointer estimator = EstimatorType::New();
+  using EstimatorType = itk::Statistics::ExpectationMaximizationMixtureModelEstimator<SampleType>;
+  EstimatorType::Pointer estimator = EstimatorType::New();
 
-    estimator->SetSample(sample);
-    estimator->SetMaximumIteration(500);
+  estimator->SetSample(sample);
+  estimator->SetMaximumIteration(500);
 
-    itk::Array< double > initialProportions(numberOfClasses);
-    initialProportions[0] = 0.5;
-    initialProportions[1] = 0.5;
+  itk::Array<double> initialProportions(numberOfClasses);
+  initialProportions[0] = 0.5;
+  initialProportions[1] = 0.5;
 
-    estimator->SetInitialProportions( initialProportions );
+  estimator->SetInitialProportions(initialProportions);
 
-    for(unsigned int i = 0; i < numberOfClasses; i++)
-    {
-        estimator->AddComponent( (ComponentType::Superclass*)
-                                         components[i].GetPointer() );
-    }
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    estimator->AddComponent((ComponentType::Superclass *)components[i].GetPointer());
+  }
 
-    estimator->Update();
+  estimator->Update();
 
-    for(unsigned int i = 0; i < numberOfClasses; i++ )
-    {
-        std::cout << "Cluster[" << i << "]" << std::endl;
-        std::cout << "    Parameters:" << std::endl;
-        std::cout << "         " << components[i]->GetFullParameters()
-                  << std::endl;
-        std::cout << "    Proportion: ";
-        std::cout << "         " << estimator->GetProportions()[i] << std::endl;
-    }
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    std::cout << "Cluster[" << i << "]" << std::endl;
+    std::cout << "    Parameters:" << std::endl;
+    std::cout << "         " << components[i]->GetFullParameters() << std::endl;
+    std::cout << "    Proportion: ";
+    std::cout << "         " << estimator->GetProportions()[i] << std::endl;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/Code.cxx
+++ b/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/Code.cxx
@@ -32,292 +32,295 @@ using ImageType = itk::Image<PixelType, 2>;
 
 #undef USE_CONTROLLED_IMAGE
 #ifdef USE_CONTROLLED_IMAGE
-  static void ControlledImage(ImageType::Pointer image);
+static void
+ControlledImage(ImageType::Pointer image);
 #else
-  static void RandomImage(ImageType::Pointer image);
+static void
+RandomImage(ImageType::Pointer image);
 #endif
 
-int main(int  /*argc*/, char* /*argv*/[])
+int
+main(int /*argc*/, char * /*argv*/[])
 {
 
-    ImageType::Pointer image = ImageType::New();
+  ImageType::Pointer image = ImageType::New();
 
 #ifdef USE_CONTROLLED_IMAGE
-    ControlledImage(image);
+  ControlledImage(image);
 #else
-    RandomImage(image);
+  RandomImage(image);
 #endif
 
-    using ImageToListSampleFilterType = itk::Statistics::ImageToListSampleFilter<ImageType>;
-    ImageToListSampleFilterType::Pointer imageToListSampleFilter = ImageToListSampleFilterType::New();
-    imageToListSampleFilter->SetInput(image);
-    imageToListSampleFilter->Update();
+  using ImageToListSampleFilterType = itk::Statistics::ImageToListSampleFilter<ImageType>;
+  ImageToListSampleFilterType::Pointer imageToListSampleFilter = ImageToListSampleFilterType::New();
+  imageToListSampleFilter->SetInput(image);
+  imageToListSampleFilter->Update();
 
-    unsigned int numberOfClasses = 3;
+  unsigned int numberOfClasses = 3;
 
-    using ParametersType = itk::Array< double >;
-    ParametersType params( numberOfClasses + numberOfClasses*numberOfClasses ); // 3 for means and 9 for 3x3 covariance
+  using ParametersType = itk::Array<double>;
+  ParametersType params(numberOfClasses + numberOfClasses * numberOfClasses); // 3 for means and 9 for 3x3 covariance
 
-    // Create the first set (for the first cluster/model) of initial parameters
-    std::vector< ParametersType > initialParameters( numberOfClasses );
-    for(unsigned int i = 0; i < 3; i++)
+  // Create the first set (for the first cluster/model) of initial parameters
+  std::vector<ParametersType> initialParameters(numberOfClasses);
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    params[i] = 5.0; // mean of dimension i
+  }
+  unsigned int counter = 0;
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    for (unsigned int j = 0; j < 3; j++)
     {
-        params[i] = 5.0; // mean of dimension i
+      if (i == j)
+      {
+        params[3 + counter] = 5; // diagonal
+      }
+      else
+      {
+        params[3 + counter] = 0; // off-diagonal
+      }
+      counter++;
     }
-    unsigned int counter = 0;
-    for(unsigned int i = 0; i < 3; i++)
+  }
+
+
+  initialParameters[0] = params;
+
+  // Create the second set (for the second cluster/model) of initial parameters
+  params[0] = 210.0;
+  params[1] = 5.0;
+  params[2] = 5.0;
+  counter = 0;
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    for (unsigned int j = 0; j < 3; j++)
     {
-        for(unsigned int j = 0; j < 3; j++)
-        {
-            if(i == j)
-            {
-                params[3+counter] = 5; // diagonal
-            }
-            else
-            {
-                params[3+counter] = 0; // off-diagonal
-            }
-            counter++;
-        }
+      if (i == j)
+      {
+        params[3 + counter] = 5; // diagonal
+      }
+      else
+      {
+        params[3 + counter] = 0; // off-diagonal
+      }
+      counter++;
     }
+  }
+  initialParameters[1] = params;
 
-
-    initialParameters[0] = params;
-
-    // Create the second set (for the second cluster/model) of initial parameters
-    params[0] = 210.0;
-    params[1] = 5.0;
-    params[2] = 5.0;
-    counter = 0;
-    for(unsigned int i = 0; i < 3; i++)
+  // Create the third set (for the third cluster/model) of initial parameters
+  params[0] = 5.0;
+  params[1] = 210.0;
+  params[2] = 5.0;
+  counter = 0;
+  for (unsigned int i = 0; i < 3; i++)
+  {
+    for (unsigned int j = 0; j < 3; j++)
     {
-        for(unsigned int j = 0; j < 3; j++)
-        {
-            if(i == j)
-            {
-                params[3+counter] = 5; // diagonal
-            }
-            else
-            {
-                params[3+counter] = 0; // off-diagonal
-            }
-            counter++;
-        }
+      if (i == j)
+      {
+        params[3 + counter] = 5; // diagonal
+      }
+      else
+      {
+        params[3 + counter] = 0; // off-diagonal
+      }
+      counter++;
     }
-    initialParameters[1] = params;
+  }
+  initialParameters[2] = params;
 
-    // Create the third set (for the third cluster/model) of initial parameters
-    params[0] = 5.0;
-    params[1] = 210.0;
-    params[2] = 5.0;
-    counter = 0;
-    for(unsigned int i = 0; i < 3; i++)
-    {
-        for(unsigned int j = 0; j < 3; j++)
-        {
-            if(i == j)
-            {
-                params[3+counter] = 5; // diagonal
-            }
-            else
-            {
-                params[3+counter] = 0; // off-diagonal
-            }
-            counter++;
-        }
-    }
-    initialParameters[2] = params;
+  std::cout << "Initial parameters: " << std::endl;
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    std::cout << initialParameters[i] << std::endl;
+  }
 
-    std::cout << "Initial parameters: " << std::endl;
-    for ( unsigned int i = 0; i < numberOfClasses; i++ )
-    {
-        std::cout << initialParameters[i] << std::endl;
-    }
+  using ComponentType = itk::Statistics::GaussianMixtureModelComponent<ImageToListSampleFilterType::ListSampleType>;
 
-    using ComponentType = itk::Statistics::GaussianMixtureModelComponent< ImageToListSampleFilterType::ListSampleType >;
+  std::cout << "Number of samples: " << imageToListSampleFilter->GetOutput()->GetTotalFrequency() << std::endl;
 
-    std::cout << "Number of samples: " << imageToListSampleFilter->GetOutput()->GetTotalFrequency() << std::endl;
-
-    // Create the components
-    std::vector< ComponentType::Pointer > components;
-    for ( unsigned int i = 0; i < numberOfClasses; i++ )
-    {
-        components.push_back( ComponentType::New() );
-        (components[i])->SetSample( imageToListSampleFilter->GetOutput() );
-        (components[i])->SetParameters( initialParameters[i] );
-    }
+  // Create the components
+  std::vector<ComponentType::Pointer> components;
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    components.push_back(ComponentType::New());
+    (components[i])->SetSample(imageToListSampleFilter->GetOutput());
+    (components[i])->SetParameters(initialParameters[i]);
+  }
 
 
-    using EstimatorType = itk::Statistics::ExpectationMaximizationMixtureModelEstimator<
-            ImageToListSampleFilterType::ListSampleType >;
-    EstimatorType::Pointer estimator = EstimatorType::New();
+  using EstimatorType =
+    itk::Statistics::ExpectationMaximizationMixtureModelEstimator<ImageToListSampleFilterType::ListSampleType>;
+  EstimatorType::Pointer estimator = EstimatorType::New();
 
-    estimator->SetSample( imageToListSampleFilter->GetOutput() );
-    estimator->SetMaximumIteration( 200 );
+  estimator->SetSample(imageToListSampleFilter->GetOutput());
+  estimator->SetMaximumIteration(200);
 
-    itk::Array< double > initialProportions(numberOfClasses);
-    initialProportions[0] = 0.33;
-    initialProportions[1] = 0.33;
-    initialProportions[2] = 0.33;
+  itk::Array<double> initialProportions(numberOfClasses);
+  initialProportions[0] = 0.33;
+  initialProportions[1] = 0.33;
+  initialProportions[2] = 0.33;
 
-    std::cout << "Initial proportions: " << initialProportions << std::endl;
+  std::cout << "Initial proportions: " << initialProportions << std::endl;
 
-    estimator->SetInitialProportions( initialProportions );
+  estimator->SetInitialProportions(initialProportions);
 
-    for ( unsigned int i = 0; i < numberOfClasses; i++)
-    {
-        estimator->AddComponent( components[i]);
-    }
-    //itk::SimpleFilterWatcher watcher(estimator);
-    estimator->Update();
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    estimator->AddComponent(components[i]);
+  }
+  // itk::SimpleFilterWatcher watcher(estimator);
+  estimator->Update();
 
-    // Output the results
-    for ( unsigned int i = 0; i < numberOfClasses; i++ )
-    {
-        std::cout << "Cluster[" << i << "]" << std::endl;
-        std::cout << "    Parameters:" << std::endl;
-        std::cout << "         " << (components[i])->GetFullParameters()
-                  << std::endl;
-        std::cout << "    Proportion: ";
-        // Outputs: // mean of dimension 1, mean of dimension 2, covariance(0,0), covariance(0,1), covariance(1,0), covariance(1,1)
-        std::cout << "         " << estimator->GetProportions()[i] << std::endl;
-    }
+  // Output the results
+  for (unsigned int i = 0; i < numberOfClasses; i++)
+  {
+    std::cout << "Cluster[" << i << "]" << std::endl;
+    std::cout << "    Parameters:" << std::endl;
+    std::cout << "         " << (components[i])->GetFullParameters() << std::endl;
+    std::cout << "    Proportion: ";
+    // Outputs: // mean of dimension 1, mean of dimension 2, covariance(0,0), covariance(0,1), covariance(1,0),
+    // covariance(1,1)
+    std::cout << "         " << estimator->GetProportions()[i] << std::endl;
+  }
 
-    // Display the membership of each sample
-    using FilterType = itk::Statistics::SampleClassifierFilter< ImageToListSampleFilterType::ListSampleType >;
+  // Display the membership of each sample
+  using FilterType = itk::Statistics::SampleClassifierFilter<ImageToListSampleFilterType::ListSampleType>;
 
-    using DecisionRuleType = itk::Statistics::MaximumDecisionRule;
-    DecisionRuleType::Pointer    decisionRule = DecisionRuleType::New();
+  using DecisionRuleType = itk::Statistics::MaximumDecisionRule;
+  DecisionRuleType::Pointer decisionRule = DecisionRuleType::New();
 
-    using ClassLabelVectorObjectType = FilterType::ClassLabelVectorObjectType;
-    using ClassLabelVectorType = FilterType::ClassLabelVectorType;
+  using ClassLabelVectorObjectType = FilterType::ClassLabelVectorObjectType;
+  using ClassLabelVectorType = FilterType::ClassLabelVectorType;
 
-    ClassLabelVectorObjectType::Pointer  classLabelsObject = ClassLabelVectorObjectType::New();
-    ClassLabelVectorType & classLabelVector  = classLabelsObject->Get();
+  ClassLabelVectorObjectType::Pointer classLabelsObject = ClassLabelVectorObjectType::New();
+  ClassLabelVectorType &              classLabelVector = classLabelsObject->Get();
 
-    using ClassLabelType = FilterType::ClassLabelType;
+  using ClassLabelType = FilterType::ClassLabelType;
 
-    ClassLabelType  class0 = 0;
-    classLabelVector.push_back( class0 );
+  ClassLabelType class0 = 0;
+  classLabelVector.push_back(class0);
 
-    ClassLabelType  class1 = 1;
-    classLabelVector.push_back( class1 );
+  ClassLabelType class1 = 1;
+  classLabelVector.push_back(class1);
 
-    ClassLabelType  class2 = 2;
-    classLabelVector.push_back( class2 );
+  ClassLabelType class2 = 2;
+  classLabelVector.push_back(class2);
 
-    FilterType::Pointer sampleClassifierFilter = FilterType::New();
-    sampleClassifierFilter->SetInput( imageToListSampleFilter->GetOutput() );
-    sampleClassifierFilter->SetNumberOfClasses( numberOfClasses );
-    sampleClassifierFilter->SetClassLabels( classLabelsObject );
-    sampleClassifierFilter->SetDecisionRule( decisionRule );
-    sampleClassifierFilter->SetMembershipFunctions( estimator->GetOutput() );
-    sampleClassifierFilter->Update();
+  FilterType::Pointer sampleClassifierFilter = FilterType::New();
+  sampleClassifierFilter->SetInput(imageToListSampleFilter->GetOutput());
+  sampleClassifierFilter->SetNumberOfClasses(numberOfClasses);
+  sampleClassifierFilter->SetClassLabels(classLabelsObject);
+  sampleClassifierFilter->SetDecisionRule(decisionRule);
+  sampleClassifierFilter->SetMembershipFunctions(estimator->GetOutput());
+  sampleClassifierFilter->Update();
 
-    const FilterType::MembershipSampleType* membershipSample = sampleClassifierFilter->GetOutput();
-    FilterType::MembershipSampleType::ConstIterator iter = membershipSample->Begin();
+  const FilterType::MembershipSampleType *        membershipSample = sampleClassifierFilter->GetOutput();
+  FilterType::MembershipSampleType::ConstIterator iter = membershipSample->Begin();
 
-    while ( iter != membershipSample->End() )
-    {
-        std::cout << (int)iter.GetMeasurementVector()[0] << " " << (int)iter.GetMeasurementVector()[1] << " " << (int)iter.GetMeasurementVector()[2]
-                  << " : " << iter.GetClassLabel() << std::endl;
-        ++iter;
-    }
+  while (iter != membershipSample->End())
+  {
+    std::cout << (int)iter.GetMeasurementVector()[0] << " " << (int)iter.GetMeasurementVector()[1] << " "
+              << (int)iter.GetMeasurementVector()[2] << " : " << iter.GetClassLabel() << std::endl;
+    ++iter;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 #ifdef USE_CONTROLLED_IMAGE
-void ControlledImage(ImageType::Pointer image)
+void
+ControlledImage(ImageType::Pointer image)
 {
-    // Create an image
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    size[0] = 10;
-    size[1] = 10;
+  ImageType::SizeType size;
+  size[0] = 10;
+  size[1] = 10;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a red and a green square
-    itk::CovariantVector<unsigned char, 3> green;
-    green[0] = 0;
-    green[1] = 255;
-    green[2] = 0;
+  // Make a red and a green square
+  itk::CovariantVector<unsigned char, 3> green;
+  green[0] = 0;
+  green[1] = 255;
+  green[2] = 0;
 
-    itk::CovariantVector<unsigned char, 3> red;
-    red[0] = 255;
-    red[1] = 0;
-    red[2] = 0;
+  itk::CovariantVector<unsigned char, 3> red;
+  red[0] = 255;
+  red[1] = 0;
+  red[2] = 0;
 
-    itk::CovariantVector<unsigned char, 3> black;
-    black[0] = 0;
-    black[1] = 0;
-    black[2] = 0;
+  itk::CovariantVector<unsigned char, 3> black;
+  black[0] = 0;
+  black[1] = 0;
+  black[2] = 0;
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
-    imageIterator.GoToBegin();
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
+  imageIterator.GoToBegin();
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 2 && imageIterator.GetIndex()[0] < 5 && imageIterator.GetIndex()[1] > 2 &&
+        imageIterator.GetIndex()[1] < 5)
     {
-        if(imageIterator.GetIndex()[0] > 2 && imageIterator.GetIndex()[0] < 5 &&
-           imageIterator.GetIndex()[1] > 2 && imageIterator.GetIndex()[1] < 5)
-        {
-            imageIterator.Set(green);
-        }
-        else if(imageIterator.GetIndex()[0] > 6 && imageIterator.GetIndex()[0] < 9 &&
-                imageIterator.GetIndex()[1] > 6 && imageIterator.GetIndex()[1] < 9)
-        {
-            imageIterator.Set(red);
-        }
-        else
-        {
-            imageIterator.Set(black);
-        }
-        ++imageIterator;
+      imageIterator.Set(green);
     }
-
+    else if (imageIterator.GetIndex()[0] > 6 && imageIterator.GetIndex()[0] < 9 && imageIterator.GetIndex()[1] > 6 &&
+             imageIterator.GetIndex()[1] < 9)
+    {
+      imageIterator.Set(red);
+    }
+    else
+    {
+      imageIterator.Set(black);
+    }
+    ++imageIterator;
+  }
 }
 #else
 
-void RandomImage(ImageType::Pointer image)
+void
+RandomImage(ImageType::Pointer image)
 {
-    // Create an image
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    size[0] = 10;
-    size[1] = 10;
+  ImageType::SizeType size;
+  size[0] = 10;
+  size[1] = 10;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
-    imageIterator.GoToBegin();
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
+  imageIterator.GoToBegin();
 
-    while(!imageIterator.IsAtEnd())
-    {
-        // Get a random color
-        itk::CovariantVector<unsigned char, 3> pixel;
-        pixel[0] = rand() * 255;
-        pixel[1] = rand() * 255;
-        pixel[2] = rand() * 255;
-        imageIterator.Set(pixel);
-        ++imageIterator;
-    }
-
+  while (!imageIterator.IsAtEnd())
+  {
+    // Get a random color
+    itk::CovariantVector<unsigned char, 3> pixel;
+    pixel[0] = rand() * 255;
+    pixel[1] = rand() * 255;
+    pixel[2] = rand() * 255;
+    imageIterator.Set(pixel);
+    ++imageIterator;
+  }
 }
 #endif

--- a/src/Numerics/Statistics/HistogramCreationAndBinAccess/Code.cxx
+++ b/src/Numerics/Statistics/HistogramCreationAndBinAccess/Code.cxx
@@ -19,30 +19,30 @@
 #include "itkHistogram.h"
 #include "itkDenseFrequencyContainer2.h"
 
-int main()
+int
+main()
 {
   using MeasurementType = float;
   using FrequencyContainerType = itk::Statistics::DenseFrequencyContainer2;
 
   constexpr unsigned int numberOfComponents = 2;
-  using HistogramType = itk::Statistics::Histogram< MeasurementType,
-    FrequencyContainerType >;
+  using HistogramType = itk::Statistics::Histogram<MeasurementType, FrequencyContainerType>;
 
   HistogramType::Pointer histogram = HistogramType::New();
-  histogram->SetMeasurementVectorSize( numberOfComponents );
+  histogram->SetMeasurementVectorSize(numberOfComponents);
 
   // We initialize it as a 3x3 histogram with equal size intervals.
 
-  HistogramType::SizeType size( numberOfComponents );
+  HistogramType::SizeType size(numberOfComponents);
   size.Fill(3);
-  HistogramType::MeasurementVectorType lowerBound( numberOfComponents );
-  HistogramType::MeasurementVectorType upperBound( numberOfComponents );
+  HistogramType::MeasurementVectorType lowerBound(numberOfComponents);
+  HistogramType::MeasurementVectorType upperBound(numberOfComponents);
   lowerBound[0] = 1.1;
   lowerBound[1] = 2.6;
   upperBound[0] = 7.1;
   upperBound[1] = 8.6;
 
-  histogram->Initialize( size, lowerBound, upperBound );
+  histogram->Initialize(size, lowerBound, upperBound);
 
   // Now the histogram is ready for storing frequency values. There
   // are three ways of accessing data elements in the histogram:
@@ -68,13 +68,11 @@ int main()
   // GetFrequency(index) method. We can use the
   // GetFrequency(instance identifier) method for the same purpose.
 
-  HistogramType::IndexType index( numberOfComponents );
+  HistogramType::IndexType index(numberOfComponents);
   index[0] = 0;
   index[1] = 2;
-  std::cout << "Frequency of the bin at index " << index
-            << " is " << histogram->GetFrequency(index)
-            << " and the bin's instance identifier is "
-            << histogram->GetInstanceIdentifier(index) << std::endl;
+  std::cout << "Frequency of the bin at index " << index << " is " << histogram->GetFrequency(index)
+            << " and the bin's instance identifier is " << histogram->GetInstanceIdentifier(index) << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/Numerics/Statistics/SpatialSearch/Code.cxx
+++ b/src/Numerics/Statistics/SpatialSearch/Code.cxx
@@ -20,57 +20,57 @@
 #include "itkWeightedCentroidKdTreeGenerator.h"
 #include "itkEuclideanDistanceMetric.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    using MeasurementVectorType = itk::Vector< float, 2 >;
+  using MeasurementVectorType = itk::Vector<float, 2>;
 
-    using SampleType = itk::Statistics::ListSample< MeasurementVectorType >;
-    SampleType::Pointer sample = SampleType::New();
-    sample->SetMeasurementVectorSize( 2 );
+  using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;
+  SampleType::Pointer sample = SampleType::New();
+  sample->SetMeasurementVectorSize(2);
 
-    MeasurementVectorType mv;
-    for (unsigned int i = 0; i < 100; ++i )
-    {
-        mv[0] = static_cast<float>(i);
-        mv[1] = static_cast<float>(i);
-        sample->PushBack( mv );
-    }
+  MeasurementVectorType mv;
+  for (unsigned int i = 0; i < 100; ++i)
+  {
+    mv[0] = static_cast<float>(i);
+    mv[1] = static_cast<float>(i);
+    sample->PushBack(mv);
+  }
 
-    using TreeGeneratorType = itk::Statistics::KdTreeGenerator< SampleType >;
-    TreeGeneratorType::Pointer treeGenerator = TreeGeneratorType::New();
-    treeGenerator->SetSample( sample );
-    treeGenerator->SetBucketSize( 16 );
-    treeGenerator->Update();
+  using TreeGeneratorType = itk::Statistics::KdTreeGenerator<SampleType>;
+  TreeGeneratorType::Pointer treeGenerator = TreeGeneratorType::New();
+  treeGenerator->SetSample(sample);
+  treeGenerator->SetBucketSize(16);
+  treeGenerator->Update();
 
-    using TreeType = TreeGeneratorType::KdTreeType;
+  using TreeType = TreeGeneratorType::KdTreeType;
 
-    TreeType::Pointer tree = treeGenerator->GetOutput();
+  TreeType::Pointer tree = treeGenerator->GetOutput();
 
-    MeasurementVectorType queryPoint;
-    queryPoint[0] = 10.0;
-    queryPoint[1] = 7.0;
+  MeasurementVectorType queryPoint;
+  queryPoint[0] = 10.0;
+  queryPoint[1] = 7.0;
 
-    // K-Neighbor search
-    std::cout << "K-Neighbor search:" << std::endl;
-    unsigned int numberOfNeighbors = 3;
-    TreeType::InstanceIdentifierVectorType neighbors;
-    tree->Search( queryPoint, numberOfNeighbors, neighbors );
+  // K-Neighbor search
+  std::cout << "K-Neighbor search:" << std::endl;
+  unsigned int                           numberOfNeighbors = 3;
+  TreeType::InstanceIdentifierVectorType neighbors;
+  tree->Search(queryPoint, numberOfNeighbors, neighbors);
 
-    for (unsigned long neighbor : neighbors)
-    {
-        std::cout << tree->GetMeasurementVector( neighbor ) << std::endl;
-    }
+  for (unsigned long neighbor : neighbors)
+  {
+    std::cout << tree->GetMeasurementVector(neighbor) << std::endl;
+  }
 
-    // Radius search
-    std::cout << "Radius search:" << std::endl;
-    double radius = 4.0;
-    tree->Search( queryPoint, radius, neighbors );
-    std::cout << "There are " << neighbors.size() << " neighbors." << std::endl;
-    for (unsigned long neighbor : neighbors)
-    {
-        std::cout << tree->GetMeasurementVector( neighbor ) << std::endl;
-    }
+  // Radius search
+  std::cout << "Radius search:" << std::endl;
+  double radius = 4.0;
+  tree->Search(queryPoint, radius, neighbors);
+  std::cout << "There are " << neighbors.size() << " neighbors." << std::endl;
+  for (unsigned long neighbor : neighbors)
+  {
+    std::cout << tree->GetMeasurementVector(neighbor) << std::endl;
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Registration/Common/ComputeMeanSquareBetweenTwoImages/Code.cxx
+++ b/src/Registration/Common/ComputeMeanSquareBetweenTwoImages/Code.cxx
@@ -21,56 +21,57 @@
 #include "itkLinearInterpolateImageFunction.h"
 #include "itkTranslationTransform.h"
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    using ImageType = itk::Image< double, 2 >;
-    using ReaderType = itk::ImageFileReader<ImageType>;
+  using ImageType = itk::Image<double, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
 
-    if (argc < 3)
+  if (argc < 3)
+  {
+    std::cout << "Usage: " << argv[0] << " imageFile1 imageFile2" << std::endl;
+    return EXIT_FAILURE;
+  }
+  ReaderType::Pointer fixedReader = ReaderType::New();
+  fixedReader->SetFileName(argv[1]);
+  fixedReader->Update();
+
+  ReaderType::Pointer movingReader = ReaderType::New();
+  movingReader->SetFileName(argv[2]);
+  movingReader->Update();
+
+  ImageType::Pointer fixedImage = fixedReader->GetOutput();
+  ImageType::Pointer movingImage = movingReader->GetOutput();
+
+  using MetricType = itk::MeanSquaresImageToImageMetric<ImageType, ImageType>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double>;
+  using TransformType = itk::TranslationTransform<double, 2>;
+
+  MetricType::Pointer    metric = MetricType::New();
+  TransformType::Pointer transform = TransformType::New();
+
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  interpolator->SetInputImage(fixedImage);
+
+  metric->SetFixedImage(fixedImage);
+  metric->SetMovingImage(movingImage);
+  metric->SetFixedImageRegion(fixedImage->GetLargestPossibleRegion());
+  metric->SetTransform(transform);
+  metric->SetInterpolator(interpolator);
+
+  TransformType::ParametersType params(transform->GetNumberOfParameters());
+  params.Fill(0.0);
+
+  metric->Initialize();
+  for (double x = -10.0; x <= 10.0; x += 5.0)
+  {
+    params(0) = x;
+    for (double y = -10.0; y <= 10.0; y += 5.0)
     {
-        std::cout << "Usage: " << argv[0] << " imageFile1 imageFile2" << std::endl;
-        return EXIT_FAILURE;
+      params(1) = y;
+      std::cout << params << ": " << metric->GetValue(params) << std::endl;
     }
-    ReaderType::Pointer fixedReader = ReaderType::New();
-    fixedReader->SetFileName(argv[1]);
-    fixedReader->Update();
+  }
 
-    ReaderType::Pointer movingReader = ReaderType::New();
-    movingReader->SetFileName(argv[2]);
-    movingReader->Update();
-
-    ImageType::Pointer fixedImage = fixedReader->GetOutput();
-    ImageType::Pointer movingImage = movingReader->GetOutput();
-
-    using MetricType = itk::MeanSquaresImageToImageMetric < ImageType , ImageType >;
-    using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double >;
-    using TransformType = itk::TranslationTransform < double , 2 >;
-
-    MetricType::Pointer metric = MetricType::New();
-    TransformType::Pointer transform = TransformType::New();
-
-    InterpolatorType::Pointer interpolator = InterpolatorType::New();
-    interpolator->SetInputImage( fixedImage );
-
-    metric->SetFixedImage( fixedImage );
-    metric->SetMovingImage( movingImage );
-    metric->SetFixedImageRegion( fixedImage->GetLargestPossibleRegion() );
-    metric->SetTransform( transform );
-    metric->SetInterpolator( interpolator );
-
-    TransformType::ParametersType params(transform->GetNumberOfParameters());
-    params.Fill(0.0);
-
-    metric->Initialize();
-    for (double x = -10.0; x <= 10.0; x+=5.0)
-    {
-        params(0) = x;
-        for (double y = -10.0; y <= 10.0; y+=5.0)
-        {
-            params(1) = y;
-            std::cout << params << ": " << metric->GetValue( params ) << std::endl;
-        }
-    }
-
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Registration/Common/GlobalRegistrationOfTwoImages/Code.cxx
+++ b/src/Registration/Common/GlobalRegistrationOfTwoImages/Code.cxx
@@ -32,318 +32,306 @@
 constexpr unsigned int Dimension = 2;
 using PixelType = unsigned char;
 
-using ImageType = itk::Image< PixelType, Dimension >;
+using ImageType = itk::Image<PixelType, Dimension>;
 
-static void CreateEllipseImage(ImageType::Pointer image);
-static void CreateSphereImage(ImageType::Pointer image);
+static void
+CreateEllipseImage(ImageType::Pointer image);
+static void
+CreateSphereImage(ImageType::Pointer image);
 
-int main(int, char *[] )
+int
+main(int, char *[])
 {
-    //  The transform that will map the fixed image into the moving image.
-    using TransformType = itk::TranslationTransform< double, Dimension >;
+  //  The transform that will map the fixed image into the moving image.
+  using TransformType = itk::TranslationTransform<double, Dimension>;
 
-    //  An optimizer is required to explore the parameter space of the transform
-    //  in search of optimal values of the metric.
-    using OptimizerType = itk::RegularStepGradientDescentOptimizer;
+  //  An optimizer is required to explore the parameter space of the transform
+  //  in search of optimal values of the metric.
+  using OptimizerType = itk::RegularStepGradientDescentOptimizer;
 
-    //  The metric will compare how well the two images match each other. Metric
-    //  types are usually parameterized by the image types as it can be seen in
-    //  the following type declaration.
-    using MetricType = itk::MeanSquaresImageToImageMetric<
-            ImageType,
-            ImageType >;
+  //  The metric will compare how well the two images match each other. Metric
+  //  types are usually parameterized by the image types as it can be seen in
+  //  the following type declaration.
+  using MetricType = itk::MeanSquaresImageToImageMetric<ImageType, ImageType>;
 
-    //  Finally, the type of the interpolator is declared. The interpolator will
-    //  evaluate the intensities of the moving image at non-grid positions.
-    using InterpolatorType = itk:: LinearInterpolateImageFunction<
-            ImageType,
-            double          >;
+  //  Finally, the type of the interpolator is declared. The interpolator will
+  //  evaluate the intensities of the moving image at non-grid positions.
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, double>;
 
-    //  The registration method type is instantiated using the types of the
-    //  fixed and moving images. This class is responsible for interconnecting
-    //  all the components that we have described so far.
-    using RegistrationType = itk::ImageRegistrationMethod<
-            ImageType,
-            ImageType >;
+  //  The registration method type is instantiated using the types of the
+  //  fixed and moving images. This class is responsible for interconnecting
+  //  all the components that we have described so far.
+  using RegistrationType = itk::ImageRegistrationMethod<ImageType, ImageType>;
 
-    // Create components
-    MetricType::Pointer         metric        = MetricType::New();
-    TransformType::Pointer      transform     = TransformType::New();
-    OptimizerType::Pointer      optimizer     = OptimizerType::New();
-    InterpolatorType::Pointer   interpolator  = InterpolatorType::New();
-    RegistrationType::Pointer   registration  = RegistrationType::New();
+  // Create components
+  MetricType::Pointer       metric = MetricType::New();
+  TransformType::Pointer    transform = TransformType::New();
+  OptimizerType::Pointer    optimizer = OptimizerType::New();
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  RegistrationType::Pointer registration = RegistrationType::New();
 
-    // Each component is now connected to the instance of the registration method.
-    registration->SetMetric(        metric        );
-    registration->SetOptimizer(     optimizer     );
-    registration->SetTransform(     transform     );
-    registration->SetInterpolator(  interpolator  );
+  // Each component is now connected to the instance of the registration method.
+  registration->SetMetric(metric);
+  registration->SetOptimizer(optimizer);
+  registration->SetTransform(transform);
+  registration->SetInterpolator(interpolator);
 
-    // Get the two images
-    ImageType::Pointer  fixedImage  = ImageType::New();
-    ImageType::Pointer movingImage = ImageType::New();
+  // Get the two images
+  ImageType::Pointer fixedImage = ImageType::New();
+  ImageType::Pointer movingImage = ImageType::New();
 
-    CreateSphereImage(fixedImage);
-    CreateEllipseImage(movingImage);
+  CreateSphereImage(fixedImage);
+  CreateEllipseImage(movingImage);
 
-    // Write the two synthetic inputs
-    using WriterType = itk::ImageFileWriter< ImageType >;
+  // Write the two synthetic inputs
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
-    WriterType::Pointer      fixedWriter =  WriterType::New();
-    fixedWriter->SetFileName("fixed.png");
-    fixedWriter->SetInput( fixedImage);
-    fixedWriter->Update();
+  WriterType::Pointer fixedWriter = WriterType::New();
+  fixedWriter->SetFileName("fixed.png");
+  fixedWriter->SetInput(fixedImage);
+  fixedWriter->Update();
 
-    WriterType::Pointer      movingWriter =  WriterType::New();
-    movingWriter->SetFileName("moving.png");
-    movingWriter->SetInput( movingImage);
-    movingWriter->Update();
+  WriterType::Pointer movingWriter = WriterType::New();
+  movingWriter->SetFileName("moving.png");
+  movingWriter->SetInput(movingImage);
+  movingWriter->Update();
 
-    // Set the registration inputs
-    registration->SetFixedImage(fixedImage);
-    registration->SetMovingImage(movingImage);
+  // Set the registration inputs
+  registration->SetFixedImage(fixedImage);
+  registration->SetMovingImage(movingImage);
 
-    registration->SetFixedImageRegion(
-            fixedImage->GetLargestPossibleRegion() );
+  registration->SetFixedImageRegion(fixedImage->GetLargestPossibleRegion());
 
-    //  Initialize the transform
-    using ParametersType = RegistrationType::ParametersType;
-    ParametersType initialParameters( transform->GetNumberOfParameters() );
+  //  Initialize the transform
+  using ParametersType = RegistrationType::ParametersType;
+  ParametersType initialParameters(transform->GetNumberOfParameters());
 
-    initialParameters[0] = 0.0;  // Initial offset along X
-    initialParameters[1] = 0.0;  // Initial offset along Y
+  initialParameters[0] = 0.0; // Initial offset along X
+  initialParameters[1] = 0.0; // Initial offset along Y
 
-    registration->SetInitialTransformParameters( initialParameters );
+  registration->SetInitialTransformParameters(initialParameters);
 
-    optimizer->SetMaximumStepLength( 4.00 );
-    optimizer->SetMinimumStepLength( 0.01 );
+  optimizer->SetMaximumStepLength(4.00);
+  optimizer->SetMinimumStepLength(0.01);
 
-    // Set a stopping criterion
-    optimizer->SetNumberOfIterations( 200 );
+  // Set a stopping criterion
+  optimizer->SetNumberOfIterations(200);
 
-    // Connect an observer
-    //CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
-    //optimizer->AddObserver( itk::IterationEvent(), observer );
+  // Connect an observer
+  // CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
+  // optimizer->AddObserver( itk::IterationEvent(), observer );
 
-    try
-    {
-        registration->Update();
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cerr << "ExceptionObject caught !" << std::endl;
-        std::cerr << err << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    registration->Update();
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cerr << "ExceptionObject caught !" << std::endl;
+    std::cerr << err << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    //  The result of the registration process is an array of parameters that
-    //  defines the spatial transformation in an unique way. This final result is
-    //  obtained using the \code{GetLastTransformParameters()} method.
+  //  The result of the registration process is an array of parameters that
+  //  defines the spatial transformation in an unique way. This final result is
+  //  obtained using the \code{GetLastTransformParameters()} method.
 
-    ParametersType finalParameters = registration->GetLastTransformParameters();
+  ParametersType finalParameters = registration->GetLastTransformParameters();
 
-    //  In the case of the \doxygen{TranslationTransform}, there is a
-    //  straightforward interpretation of the parameters.  Each element of the
-    //  array corresponds to a translation along one spatial dimension.
+  //  In the case of the \doxygen{TranslationTransform}, there is a
+  //  straightforward interpretation of the parameters.  Each element of the
+  //  array corresponds to a translation along one spatial dimension.
 
-    const double TranslationAlongX = finalParameters[0];
-    const double TranslationAlongY = finalParameters[1];
+  const double TranslationAlongX = finalParameters[0];
+  const double TranslationAlongY = finalParameters[1];
 
-    //  The optimizer can be queried for the actual number of iterations
-    //  performed to reach convergence.  The \code{GetCurrentIteration()}
-    //  method returns this value. A large number of iterations may be an
-    //  indication that the maximum step length has been set too small, which
-    //  is undesirable since it results in long computational times.
+  //  The optimizer can be queried for the actual number of iterations
+  //  performed to reach convergence.  The \code{GetCurrentIteration()}
+  //  method returns this value. A large number of iterations may be an
+  //  indication that the maximum step length has been set too small, which
+  //  is undesirable since it results in long computational times.
 
-    const unsigned int numberOfIterations = optimizer->GetCurrentIteration();
+  const unsigned int numberOfIterations = optimizer->GetCurrentIteration();
 
-    //  The value of the image metric corresponding to the last set of parameters
-    //  can be obtained with the \code{GetValue()} method of the optimizer.
+  //  The value of the image metric corresponding to the last set of parameters
+  //  can be obtained with the \code{GetValue()} method of the optimizer.
 
-    const double bestValue = optimizer->GetValue();
+  const double bestValue = optimizer->GetValue();
 
-    // Print out results
-    //
-    std::cout << "Result = " << std::endl;
-    std::cout << " Translation X = " << TranslationAlongX  << std::endl;
-    std::cout << " Translation Y = " << TranslationAlongY  << std::endl;
-    std::cout << " Iterations    = " << numberOfIterations << std::endl;
-    std::cout << " Metric value  = " << bestValue          << std::endl;
+  // Print out results
+  //
+  std::cout << "Result = " << std::endl;
+  std::cout << " Translation X = " << TranslationAlongX << std::endl;
+  std::cout << " Translation Y = " << TranslationAlongY << std::endl;
+  std::cout << " Iterations    = " << numberOfIterations << std::endl;
+  std::cout << " Metric value  = " << bestValue << std::endl;
 
-    //  It is common, as the last step of a registration task, to use the
-    //  resulting transform to map the moving image into the fixed image space.
-    //  This is easily done with the \doxygen{ResampleImageFilter}. Please
-    //  refer to Section~\ref{sec:ResampleImageFilter} for details on the use
-    //  of this filter.  First, a ResampleImageFilter type is instantiated
-    //  using the image types. It is convenient to use the fixed image type as
-    //  the output type since it is likely that the transformed moving image
-    //  will be compared with the fixed image.
+  //  It is common, as the last step of a registration task, to use the
+  //  resulting transform to map the moving image into the fixed image space.
+  //  This is easily done with the \doxygen{ResampleImageFilter}. Please
+  //  refer to Section~\ref{sec:ResampleImageFilter} for details on the use
+  //  of this filter.  First, a ResampleImageFilter type is instantiated
+  //  using the image types. It is convenient to use the fixed image type as
+  //  the output type since it is likely that the transformed moving image
+  //  will be compared with the fixed image.
 
-    using ResampleFilterType = itk::ResampleImageFilter<
-            ImageType,
-            ImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
-    //  A resampling filter is created and the moving image is connected as  its input.
+  //  A resampling filter is created and the moving image is connected as  its input.
 
-    ResampleFilterType::Pointer resampler = ResampleFilterType::New();
-    resampler->SetInput( movingImage);
+  ResampleFilterType::Pointer resampler = ResampleFilterType::New();
+  resampler->SetInput(movingImage);
 
-    //  The Transform that is produced as output of the Registration method is
-    //  also passed as input to the resampling filter. Note the use of the
-    //  methods \code{GetOutput()} and \code{Get()}. This combination is needed
-    //  here because the registration method acts as a filter whose output is a
-    //  transform decorated in the form of a \doxygen{DataObject}. For details in
-    //  this construction you may want to read the documentation of the
-    //  \doxygen{DataObjectDecorator}.
+  //  The Transform that is produced as output of the Registration method is
+  //  also passed as input to the resampling filter. Note the use of the
+  //  methods \code{GetOutput()} and \code{Get()}. This combination is needed
+  //  here because the registration method acts as a filter whose output is a
+  //  transform decorated in the form of a \doxygen{DataObject}. For details in
+  //  this construction you may want to read the documentation of the
+  //  \doxygen{DataObjectDecorator}.
 
-    resampler->SetTransform( registration->GetOutput()->Get() );
+  resampler->SetTransform(registration->GetOutput()->Get());
 
-    //  As described in Section \ref{sec:ResampleImageFilter}, the
-    //  ResampleImageFilter requires additional parameters to be specified, in
-    //  particular, the spacing, origin and size of the output image. The default
-    //  pixel value is also set to a distinct gray level in order to highlight
-    //  the regions that are mapped outside of the moving image.
+  //  As described in Section \ref{sec:ResampleImageFilter}, the
+  //  ResampleImageFilter requires additional parameters to be specified, in
+  //  particular, the spacing, origin and size of the output image. The default
+  //  pixel value is also set to a distinct gray level in order to highlight
+  //  the regions that are mapped outside of the moving image.
 
-    resampler->SetSize( fixedImage->GetLargestPossibleRegion().GetSize() );
-    resampler->SetOutputOrigin(  fixedImage->GetOrigin() );
-    resampler->SetOutputSpacing( fixedImage->GetSpacing() );
-    resampler->SetOutputDirection( fixedImage->GetDirection() );
-    resampler->SetDefaultPixelValue( 100 );
+  resampler->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
+  resampler->SetOutputOrigin(fixedImage->GetOrigin());
+  resampler->SetOutputSpacing(fixedImage->GetSpacing());
+  resampler->SetOutputDirection(fixedImage->GetDirection());
+  resampler->SetDefaultPixelValue(100);
 
-    //  The output of the filter is passed to a writer that will store the
-    //  image in a file. An \doxygen{CastImageFilter} is used to convert the
-    //  pixel type of the resampled image to the final type used by the
-    //  writer. The cast and writer filters are instantiated below.
+  //  The output of the filter is passed to a writer that will store the
+  //  image in a file. An \doxygen{CastImageFilter} is used to convert the
+  //  pixel type of the resampled image to the final type used by the
+  //  writer. The cast and writer filters are instantiated below.
 
-    using CastFilterType = itk::CastImageFilter<
-            ImageType,
-            ImageType >;
+  using CastFilterType = itk::CastImageFilter<ImageType, ImageType>;
 
-    WriterType::Pointer      writer =  WriterType::New();
-    CastFilterType::Pointer  caster =  CastFilterType::New();
-    writer->SetFileName("output.png");
+  WriterType::Pointer     writer = WriterType::New();
+  CastFilterType::Pointer caster = CastFilterType::New();
+  writer->SetFileName("output.png");
 
-    caster->SetInput( resampler->GetOutput() );
-    writer->SetInput( caster->GetOutput()   );
-    writer->Update();
+  caster->SetInput(resampler->GetOutput());
+  writer->SetInput(caster->GetOutput());
+  writer->Update();
 
-    /*
-    //  The fixed image and the transformed moving image can easily be compared
-    //  using the \doxygen{SubtractImageFilter}. This pixel-wise filter computes
-    //  the difference between homologous pixels of its two input images.
+  /*
+  //  The fixed image and the transformed moving image can easily be compared
+  //  using the \doxygen{SubtractImageFilter}. This pixel-wise filter computes
+  //  the difference between homologous pixels of its two input images.
 
 
-    using DifferenceFilterType = itk::SubtractImageFilter<
-        FixedImageType,
-        FixedImageType,
-        FixedImageType >;
+  using DifferenceFilterType = itk::SubtractImageFilter<
+      FixedImageType,
+      FixedImageType,
+      FixedImageType >;
 
-    DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
+  DifferenceFilterType::Pointer difference = DifferenceFilterType::New();
 
-    difference->SetInput1( fixedImageReader->GetOutput() );
-    difference->SetInput2( resampler->GetOutput() );
-    */
+  difference->SetInput1( fixedImageReader->GetOutput() );
+  difference->SetInput2( resampler->GetOutput() );
+  */
 
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateEllipseImage(ImageType::Pointer image)
+void
+CreateEllipseImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 20;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 20;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  65;
-    translation[ 1 ] =  45;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 65;
+  translation[1] = 45;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
-
+  image->Graft(imageFilter->GetOutput());
 }
 
-void CreateSphereImage(ImageType::Pointer image)
+void
+CreateSphereImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 10;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 10;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  50;
-    translation[ 1 ] =  50;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 50;
+  translation[1] = 50;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
+  image->Graft(imageFilter->GetOutput());
 }
-

--- a/src/Registration/Common/MatchFeaturePoints/Code.cxx
+++ b/src/Registration/Common/MatchFeaturePoints/Code.cxx
@@ -23,82 +23,89 @@
 
 using ImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(ImageType::Pointer image, const unsigned int x);
+static void
+CreateImage(ImageType::Pointer image, const unsigned int x);
 
-int main(int  /*argc*/, char * /*argv*/[])
+int
+main(int /*argc*/, char * /*argv*/[])
 {
-    // Create input images
-    ImageType::Pointer fixedImage = ImageType::New();
-    CreateImage(fixedImage, 40);
+  // Create input images
+  ImageType::Pointer fixedImage = ImageType::New();
+  CreateImage(fixedImage, 40);
 
-    ImageType::Pointer movingImage = ImageType::New();
-    CreateImage(movingImage, 50);
+  ImageType::Pointer movingImage = ImageType::New();
+  CreateImage(movingImage, 50);
 
-//  using WriterType = itk::ImageFileWriter<ImageType>;
-//  WriterType::Pointer writer = WriterType::New();
-//  writer->SetFileName("input.png");
-//  writer->SetInput(input);
-//  writer->Update();
+  //  using WriterType = itk::ImageFileWriter<ImageType>;
+  //  WriterType::Pointer writer = WriterType::New();
+  //  writer->SetFileName("input.png");
+  //  writer->SetInput(input);
+  //  writer->Update();
 
-    //  using BlockMatchingImageFilterType = itk::BlockMatchingImageFilter<ImageType, ImageType, PointSetType>;
-    using BlockMatchingImageFilterType = itk::BlockMatchingImageFilter<ImageType>;
-    BlockMatchingImageFilterType::Pointer blockMatchingImageFilter =
-            BlockMatchingImageFilterType::New();
+  //  using BlockMatchingImageFilterType = itk::BlockMatchingImageFilter<ImageType, ImageType, PointSetType>;
+  using BlockMatchingImageFilterType = itk::BlockMatchingImageFilter<ImageType>;
+  BlockMatchingImageFilterType::Pointer blockMatchingImageFilter = BlockMatchingImageFilterType::New();
 
-    // Generate feature points
-//  using PointSetType = itk::PointSet< float, 2>;
-    using PointSetType = BlockMatchingImageFilterType::FeaturePointsType;
-    using PointType = PointSetType::PointType;
-    using PointsContainerPointer = PointSetType::PointsContainerPointer;
+  // Generate feature points
+  //  using PointSetType = itk::PointSet< float, 2>;
+  using PointSetType = BlockMatchingImageFilterType::FeaturePointsType;
+  using PointType = PointSetType::PointType;
+  using PointsContainerPointer = PointSetType::PointsContainerPointer;
 
-    PointSetType::Pointer   pointSet = PointSetType::New();
-    PointsContainerPointer  points = pointSet->GetPoints();
+  PointSetType::Pointer  pointSet = PointSetType::New();
+  PointsContainerPointer points = pointSet->GetPoints();
 
-    PointType p0, p1, p2, p3;
+  PointType p0, p1, p2, p3;
 
-    p0[0]=  40.0; p0[1]= 40.0;
-    p1[0]=  40.0; p1[1]= 60.0;
-    p2[0]=  60.0; p2[1]= 40.0;
-    p3[0]=  60.0; p2[1]= 60.0;
+  p0[0] = 40.0;
+  p0[1] = 40.0;
+  p1[0] = 40.0;
+  p1[1] = 60.0;
+  p2[0] = 60.0;
+  p2[1] = 40.0;
+  p3[0] = 60.0;
+  p2[1] = 60.0;
 
-    points->InsertElement(0, p0);
-    points->InsertElement(1, p1);
-    points->InsertElement(2, p2);
-    points->InsertElement(3, p3);
+  points->InsertElement(0, p0);
+  points->InsertElement(1, p1);
+  points->InsertElement(2, p2);
+  points->InsertElement(3, p3);
 
-    blockMatchingImageFilter->SetFixedImage(fixedImage);
-    blockMatchingImageFilter->SetMovingImage(movingImage);
-    blockMatchingImageFilter->SetFeaturePoints(pointSet);
-    blockMatchingImageFilter->UpdateLargestPossibleRegion();
+  blockMatchingImageFilter->SetFixedImage(fixedImage);
+  blockMatchingImageFilter->SetMovingImage(movingImage);
+  blockMatchingImageFilter->SetFeaturePoints(pointSet);
+  blockMatchingImageFilter->UpdateLargestPossibleRegion();
 
-    typename BlockMatchingImageFilterType::DisplacementsType * displacements =
-            blockMatchingImageFilter->GetDisplacements();
+  typename BlockMatchingImageFilterType::DisplacementsType * displacements =
+    blockMatchingImageFilter->GetDisplacements();
 
-    std::cout << "There are " << displacements->GetNumberOfPoints() << " displacements." << std::endl;
+  std::cout << "There are " << displacements->GetNumberOfPoints() << " displacements." << std::endl;
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image, const unsigned int x)
+void
+CreateImage(ImageType::Pointer image, const unsigned int x)
 {
-    // Allocate empty image
-    itk::Index<2> start; start.Fill(0);
-    itk::Size<2> size; size.Fill(100);
-    ImageType::RegionType region(start, size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  // Allocate empty image
+  itk::Index<2> start;
+  start.Fill(0);
+  itk::Size<2> size;
+  size.Fill(100);
+  ImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a white square
-    for(unsigned int r = x; r < x+20; r++)
+  // Make a white square
+  for (unsigned int r = x; r < x + 20; r++)
+  {
+    for (unsigned int c = 40; c < 60; c++)
     {
-        for(unsigned int c = 40; c < 60; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
-            image->SetPixel(pixelIndex, 255);
-        }
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }
-

--- a/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
+++ b/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
@@ -20,80 +20,80 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkRecursiveMultiResolutionPyramidImageFilter.h"
 
-using UnsignedCharImageType = itk::Image< unsigned char, 2 >;
+using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    CreateImage(image);
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  CreateImage(image);
 
-    using FloatImageType = itk::Image<float, 2 >;
+  using FloatImageType = itk::Image<float, 2>;
 
-    unsigned int numberOfLevels = 4;
+  unsigned int numberOfLevels = 4;
 
-    using RecursiveMultiResolutionPyramidImageFilterType = itk::RecursiveMultiResolutionPyramidImageFilter<
-            UnsignedCharImageType, FloatImageType>;
-    RecursiveMultiResolutionPyramidImageFilterType::Pointer recursiveMultiResolutionPyramidImageFilter =
-            RecursiveMultiResolutionPyramidImageFilterType::New();
-    recursiveMultiResolutionPyramidImageFilter->SetInput(image);
-    recursiveMultiResolutionPyramidImageFilter->SetNumberOfLevels(numberOfLevels);
-    recursiveMultiResolutionPyramidImageFilter->Update();
+  using RecursiveMultiResolutionPyramidImageFilterType =
+    itk::RecursiveMultiResolutionPyramidImageFilter<UnsignedCharImageType, FloatImageType>;
+  RecursiveMultiResolutionPyramidImageFilterType::Pointer recursiveMultiResolutionPyramidImageFilter =
+    RecursiveMultiResolutionPyramidImageFilterType::New();
+  recursiveMultiResolutionPyramidImageFilter->SetInput(image);
+  recursiveMultiResolutionPyramidImageFilter->SetNumberOfLevels(numberOfLevels);
+  recursiveMultiResolutionPyramidImageFilter->Update();
 
-    // This outputs the levels (0 is the lowest resolution)
-    for(unsigned int i = 0; i < numberOfLevels; ++i)
-    {
-        // Scale so we can write to a PNG
-        using RescaleFilterType = itk::RescaleIntensityImageFilter< FloatImageType, UnsignedCharImageType >;
-        RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-        rescaleFilter->SetInput(recursiveMultiResolutionPyramidImageFilter->GetOutput(i));
-        rescaleFilter->SetOutputMinimum(0);
-        rescaleFilter->SetOutputMaximum(255);
-        rescaleFilter->Update();
+  // This outputs the levels (0 is the lowest resolution)
+  for (unsigned int i = 0; i < numberOfLevels; ++i)
+  {
+    // Scale so we can write to a PNG
+    using RescaleFilterType = itk::RescaleIntensityImageFilter<FloatImageType, UnsignedCharImageType>;
+    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+    rescaleFilter->SetInput(recursiveMultiResolutionPyramidImageFilter->GetOutput(i));
+    rescaleFilter->SetOutputMinimum(0);
+    rescaleFilter->SetOutputMaximum(255);
+    rescaleFilter->Update();
 
-        using FileWriterType = itk::ImageFileWriter<UnsignedCharImageType>;
-        FileWriterType::Pointer writer = FileWriterType::New();
-        std::stringstream ss;
-        ss << "output_" << i << ".png";
-        std::cout << "Writing " << ss.str() << std::endl;
-        writer->SetFileName(ss.str());
-        writer->SetInput(rescaleFilter->GetOutput());
-        writer->Update();
-    }
+    using FileWriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+    FileWriterType::Pointer writer = FileWriterType::New();
+    std::stringstream       ss;
+    ss << "output_" << i << ".png";
+    std::cout << "Writing " << ss.str() << std::endl;
+    writer->SetFileName(ss.str());
+    writer->SetInput(rescaleFilter->GetOutput());
+    writer->Update();
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    // Create a black image with 2 white regions
+  // Create a black image with 2 white regions
 
-    UnsignedCharImageType::IndexType start;
-    start.Fill(0);
+  UnsignedCharImageType::IndexType start;
+  start.Fill(0);
 
-    UnsignedCharImageType::SizeType size;
-    size.Fill(200);
+  UnsignedCharImageType::SizeType size;
+  size.Fill(200);
 
-    UnsignedCharImageType::RegionType region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  UnsignedCharImageType::RegionType region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            UnsignedCharImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      UnsignedCharImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 255);
-
-        }
+      image->SetPixel(pixelIndex, 255);
     }
-
+  }
 }
-

--- a/src/Registration/Common/MutualInformation/Code.cxx
+++ b/src/Registration/Common/MutualInformation/Code.cxx
@@ -31,330 +31,319 @@
 constexpr unsigned int Dimension = 2;
 using PixelType = unsigned char;
 
-using ImageType = itk::Image< PixelType, Dimension >;
+using ImageType = itk::Image<PixelType, Dimension>;
 
-static void CreateEllipseImage(ImageType::Pointer image);
-static void CreateCircleImage(ImageType::Pointer image);
+static void
+CreateEllipseImage(ImageType::Pointer image);
+static void
+CreateCircleImage(ImageType::Pointer image);
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-    // Generate synthetic fixed and moving images
-    ImageType::Pointer  fixedImage = ImageType::New();
-    CreateCircleImage(fixedImage);
-    ImageType::Pointer movingImage = ImageType::New();
-    CreateEllipseImage(movingImage);
+  // Generate synthetic fixed and moving images
+  ImageType::Pointer fixedImage = ImageType::New();
+  CreateCircleImage(fixedImage);
+  ImageType::Pointer movingImage = ImageType::New();
+  CreateEllipseImage(movingImage);
 
-    // Write the two synthetic inputs
-    using WriterType = itk::ImageFileWriter< ImageType >;
+  // Write the two synthetic inputs
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
-    WriterType::Pointer      fixedWriter =  WriterType::New();
-    fixedWriter->SetFileName("fixed.png");
-    fixedWriter->SetInput( fixedImage);
-    fixedWriter->Update();
+  WriterType::Pointer fixedWriter = WriterType::New();
+  fixedWriter->SetFileName("fixed.png");
+  fixedWriter->SetInput(fixedImage);
+  fixedWriter->Update();
 
-    WriterType::Pointer      movingWriter =  WriterType::New();
-    movingWriter->SetFileName("moving.png");
-    movingWriter->SetInput( movingImage);
-    movingWriter->Update();
+  WriterType::Pointer movingWriter = WriterType::New();
+  movingWriter->SetFileName("moving.png");
+  movingWriter->SetInput(movingImage);
+  movingWriter->Update();
 
-    // We use floats internally
-    using InternalImageType = itk::Image< float, 2>;
+  // We use floats internally
+  using InternalImageType = itk::Image<float, 2>;
 
-    // Normalize the images
-    using NormalizeFilterType = itk::NormalizeImageFilter<ImageType, InternalImageType>;
+  // Normalize the images
+  using NormalizeFilterType = itk::NormalizeImageFilter<ImageType, InternalImageType>;
 
-    NormalizeFilterType::Pointer fixedNormalizer = NormalizeFilterType::New();
-    NormalizeFilterType::Pointer movingNormalizer = NormalizeFilterType::New();
+  NormalizeFilterType::Pointer fixedNormalizer = NormalizeFilterType::New();
+  NormalizeFilterType::Pointer movingNormalizer = NormalizeFilterType::New();
 
-    fixedNormalizer->SetInput(  fixedImage);
-    movingNormalizer->SetInput( movingImage);
+  fixedNormalizer->SetInput(fixedImage);
+  movingNormalizer->SetInput(movingImage);
 
-    // Smooth the normalized images
-    using GaussianFilterType = itk::DiscreteGaussianImageFilter<InternalImageType,InternalImageType>;
+  // Smooth the normalized images
+  using GaussianFilterType = itk::DiscreteGaussianImageFilter<InternalImageType, InternalImageType>;
 
-    GaussianFilterType::Pointer fixedSmoother  = GaussianFilterType::New();
-    GaussianFilterType::Pointer movingSmoother = GaussianFilterType::New();
+  GaussianFilterType::Pointer fixedSmoother = GaussianFilterType::New();
+  GaussianFilterType::Pointer movingSmoother = GaussianFilterType::New();
 
-    fixedSmoother->SetVariance( 2.0 );
-    movingSmoother->SetVariance( 2.0 );
+  fixedSmoother->SetVariance(2.0);
+  movingSmoother->SetVariance(2.0);
 
-    fixedSmoother->SetInput( fixedNormalizer->GetOutput() );
-    movingSmoother->SetInput( movingNormalizer->GetOutput() );
+  fixedSmoother->SetInput(fixedNormalizer->GetOutput());
+  movingSmoother->SetInput(movingNormalizer->GetOutput());
 
-    using TransformType = itk::TranslationTransform< double, Dimension >;
-    using OptimizerType = itk::GradientDescentOptimizer;
-    using InterpolatorType = itk::LinearInterpolateImageFunction<
-            InternalImageType,
-            double             >;
-    using RegistrationType = itk::ImageRegistrationMethod<
-            InternalImageType,
-            InternalImageType >;
-    using MetricType = itk::MutualInformationImageToImageMetric<
-            InternalImageType,
-            InternalImageType >;
+  using TransformType = itk::TranslationTransform<double, Dimension>;
+  using OptimizerType = itk::GradientDescentOptimizer;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<InternalImageType, double>;
+  using RegistrationType = itk::ImageRegistrationMethod<InternalImageType, InternalImageType>;
+  using MetricType = itk::MutualInformationImageToImageMetric<InternalImageType, InternalImageType>;
 
-    TransformType::Pointer      transform     = TransformType::New();
-    OptimizerType::Pointer      optimizer     = OptimizerType::New();
-    InterpolatorType::Pointer   interpolator  = InterpolatorType::New();
-    RegistrationType::Pointer   registration  = RegistrationType::New();
+  TransformType::Pointer    transform = TransformType::New();
+  OptimizerType::Pointer    optimizer = OptimizerType::New();
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  RegistrationType::Pointer registration = RegistrationType::New();
 
-    registration->SetOptimizer(     optimizer     );
-    registration->SetTransform(     transform     );
-    registration->SetInterpolator(  interpolator  );
+  registration->SetOptimizer(optimizer);
+  registration->SetTransform(transform);
+  registration->SetInterpolator(interpolator);
 
-    MetricType::Pointer         metric        = MetricType::New();
-    registration->SetMetric( metric  );
+  MetricType::Pointer metric = MetricType::New();
+  registration->SetMetric(metric);
 
-    //  The metric requires a number of parameters to be selected, including
-    //  the standard deviation of the Gaussian kernel for the fixed image
-    //  density estimate, the standard deviation of the kernel for the moving
-    //  image density and the number of samples use to compute the densities
-    //  and entropy values. Details on the concepts behind the computation of
-    //  the metric can be found in Section
-    //  \ref{sec:MutualInformationMetric}.  Experience has
-    //  shown that a kernel standard deviation of $0.4$ works well for images
-    //  which have been normalized to a mean of zero and unit variance.  We
-    //  will follow this empirical rule in this example.
+  //  The metric requires a number of parameters to be selected, including
+  //  the standard deviation of the Gaussian kernel for the fixed image
+  //  density estimate, the standard deviation of the kernel for the moving
+  //  image density and the number of samples use to compute the densities
+  //  and entropy values. Details on the concepts behind the computation of
+  //  the metric can be found in Section
+  //  \ref{sec:MutualInformationMetric}.  Experience has
+  //  shown that a kernel standard deviation of $0.4$ works well for images
+  //  which have been normalized to a mean of zero and unit variance.  We
+  //  will follow this empirical rule in this example.
 
-    metric->SetFixedImageStandardDeviation(  0.4 );
-    metric->SetMovingImageStandardDeviation( 0.4 );
+  metric->SetFixedImageStandardDeviation(0.4);
+  metric->SetMovingImageStandardDeviation(0.4);
 
-    registration->SetFixedImage(    fixedSmoother->GetOutput()    );
-    registration->SetMovingImage(   movingSmoother->GetOutput()   );
+  registration->SetFixedImage(fixedSmoother->GetOutput());
+  registration->SetMovingImage(movingSmoother->GetOutput());
 
-    fixedNormalizer->Update();
-    ImageType::RegionType fixedImageRegion =
-            fixedNormalizer->GetOutput()->GetBufferedRegion();
-    registration->SetFixedImageRegion( fixedImageRegion );
+  fixedNormalizer->Update();
+  ImageType::RegionType fixedImageRegion = fixedNormalizer->GetOutput()->GetBufferedRegion();
+  registration->SetFixedImageRegion(fixedImageRegion);
 
-    using ParametersType = RegistrationType::ParametersType;
-    ParametersType initialParameters( transform->GetNumberOfParameters() );
+  using ParametersType = RegistrationType::ParametersType;
+  ParametersType initialParameters(transform->GetNumberOfParameters());
 
-    initialParameters[0] = 0.0;  // Initial offset along X
-    initialParameters[1] = 0.0;  // Initial offset along Y
+  initialParameters[0] = 0.0; // Initial offset along X
+  initialParameters[1] = 0.0; // Initial offset along Y
 
-    registration->SetInitialTransformParameters( initialParameters );
+  registration->SetInitialTransformParameters(initialParameters);
 
-    //  Software Guide : BeginLatex
-    //
-    //  We should now define the number of spatial samples to be considered in
-    //  the metric computation. Note that we were forced to postpone this setting
-    //  until we had done the preprocessing of the images because the number of
-    //  samples is usually defined as a fraction of the total number of pixels in
-    //  the fixed image.
-    //
-    //  The number of spatial samples can usually be as low as $1\%$ of the total
-    //  number of pixels in the fixed image. Increasing the number of samples
-    //  improves the smoothness of the metric from one iteration to another and
-    //  therefore helps when this metric is used in conjunction with optimizers
-    //  that rely of the continuity of the metric values. The trade-off, of
-    //  course, is that a larger number of samples result in longer computation
-    //  times per every evaluation of the metric.
-    //
-    //  It has been demonstrated empirically that the number of samples is not a
-    //  critical parameter for the registration process. When you start fine
-    //  tuning your own registration process, you should start using high values
-    //  of number of samples, for example in the range of $20\%$ to $50\%$ of the
-    //  number of pixels in the fixed image. Once you have succeeded to register
-    //  your images you can then reduce the number of samples progressively until
-    //  you find a good compromise on the time it takes to compute one evaluation
-    //  of the Metric. Note that it is not useful to have very fast evaluations
-    //  of the Metric if the noise in their values results in more iterations
-    //  being required by the optimizer to converge. You must then study the
-    //  behavior of the metric values as the iterations progress.
+  //  Software Guide : BeginLatex
+  //
+  //  We should now define the number of spatial samples to be considered in
+  //  the metric computation. Note that we were forced to postpone this setting
+  //  until we had done the preprocessing of the images because the number of
+  //  samples is usually defined as a fraction of the total number of pixels in
+  //  the fixed image.
+  //
+  //  The number of spatial samples can usually be as low as $1\%$ of the total
+  //  number of pixels in the fixed image. Increasing the number of samples
+  //  improves the smoothness of the metric from one iteration to another and
+  //  therefore helps when this metric is used in conjunction with optimizers
+  //  that rely of the continuity of the metric values. The trade-off, of
+  //  course, is that a larger number of samples result in longer computation
+  //  times per every evaluation of the metric.
+  //
+  //  It has been demonstrated empirically that the number of samples is not a
+  //  critical parameter for the registration process. When you start fine
+  //  tuning your own registration process, you should start using high values
+  //  of number of samples, for example in the range of $20\%$ to $50\%$ of the
+  //  number of pixels in the fixed image. Once you have succeeded to register
+  //  your images you can then reduce the number of samples progressively until
+  //  you find a good compromise on the time it takes to compute one evaluation
+  //  of the Metric. Note that it is not useful to have very fast evaluations
+  //  of the Metric if the noise in their values results in more iterations
+  //  being required by the optimizer to converge. You must then study the
+  //  behavior of the metric values as the iterations progress.
 
-    const unsigned int numberOfPixels = fixedImageRegion.GetNumberOfPixels();
+  const unsigned int numberOfPixels = fixedImageRegion.GetNumberOfPixels();
 
-    const auto numberOfSamples = static_cast< unsigned int >( numberOfPixels * 0.01 );
+  const auto numberOfSamples = static_cast<unsigned int>(numberOfPixels * 0.01);
 
-    metric->SetNumberOfSpatialSamples( numberOfSamples );
+  metric->SetNumberOfSpatialSamples(numberOfSamples);
 
-    //  Since larger values of mutual information indicate better matches than
-    //  smaller values, we need to maximize the cost function in this example.
-    //  By default the GradientDescentOptimizer class is set to minimize the
-    //  value of the cost-function. It is therefore necessary to modify its
-    //  default behavior by invoking the \code{MaximizeOn()} method.
-    //  Additionally, we need to define the optimizer's step size using the
-    //  \code{SetLearningRate()} method.
+  //  Since larger values of mutual information indicate better matches than
+  //  smaller values, we need to maximize the cost function in this example.
+  //  By default the GradientDescentOptimizer class is set to minimize the
+  //  value of the cost-function. It is therefore necessary to modify its
+  //  default behavior by invoking the \code{MaximizeOn()} method.
+  //  Additionally, we need to define the optimizer's step size using the
+  //  \code{SetLearningRate()} method.
 
-    optimizer->SetLearningRate( 15.0 );
-    optimizer->SetNumberOfIterations( 200 );
-    optimizer->MaximizeOn(); // We want to maximize mutual information (the default of the optimizer is to minimize)
+  optimizer->SetLearningRate(15.0);
+  optimizer->SetNumberOfIterations(200);
+  optimizer->MaximizeOn(); // We want to maximize mutual information (the default of the optimizer is to minimize)
 
-    // Note that large values of the learning rate will make the optimizer
-    // unstable. Small values, on the other hand, may result in the optimizer
-    // needing too many iterations in order to walk to the extrema of the cost
-    // function. The easy way of fine tuning this parameter is to start with
-    // small values, probably in the range of $\{5.0,10.0\}$. Once the other
-    // registration parameters have been tuned for producing convergence, you
-    // may want to revisit the learning rate and start increasing its value until
-    // you observe that the optimization becomes unstable.  The ideal value for
-    // this parameter is the one that results in a minimum number of iterations
-    // while still keeping a stable path on the parametric space of the
-    // optimization. Keep in mind that this parameter is a multiplicative factor
-    // applied on the gradient of the Metric. Therefore, its effect on the
-    // optimizer step length is proportional to the Metric values themselves.
-    // Metrics with large values will require you to use smaller values for the
-    // learning rate in order to maintain a similar optimizer behavior.
+  // Note that large values of the learning rate will make the optimizer
+  // unstable. Small values, on the other hand, may result in the optimizer
+  // needing too many iterations in order to walk to the extrema of the cost
+  // function. The easy way of fine tuning this parameter is to start with
+  // small values, probably in the range of $\{5.0,10.0\}$. Once the other
+  // registration parameters have been tuned for producing convergence, you
+  // may want to revisit the learning rate and start increasing its value until
+  // you observe that the optimization becomes unstable.  The ideal value for
+  // this parameter is the one that results in a minimum number of iterations
+  // while still keeping a stable path on the parametric space of the
+  // optimization. Keep in mind that this parameter is a multiplicative factor
+  // applied on the gradient of the Metric. Therefore, its effect on the
+  // optimizer step length is proportional to the Metric values themselves.
+  // Metrics with large values will require you to use smaller values for the
+  // learning rate in order to maintain a similar optimizer behavior.
 
-    try
-    {
-        registration->Update();
-        std::cout << "Optimizer stop condition: "
-                  << registration->GetOptimizer()->GetStopConditionDescription()
-                  << std::endl;
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cout << "ExceptionObject caught !" << std::endl;
-        std::cout << err << std::endl;
-        return EXIT_FAILURE;
-    }
+  try
+  {
+    registration->Update();
+    std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
+              << std::endl;
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cout << "ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    ParametersType finalParameters = registration->GetLastTransformParameters();
+  ParametersType finalParameters = registration->GetLastTransformParameters();
 
-    double TranslationAlongX = finalParameters[0];
-    double TranslationAlongY = finalParameters[1];
+  double TranslationAlongX = finalParameters[0];
+  double TranslationAlongY = finalParameters[1];
 
-    unsigned int numberOfIterations = optimizer->GetCurrentIteration();
+  unsigned int numberOfIterations = optimizer->GetCurrentIteration();
 
-    double bestValue = optimizer->GetValue();
+  double bestValue = optimizer->GetValue();
 
 
-    // Print out results
-    std::cout << std::endl;
-    std::cout << "Result = " << std::endl;
-    std::cout << " Translation X = " << TranslationAlongX  << std::endl;
-    std::cout << " Translation Y = " << TranslationAlongY  << std::endl;
-    std::cout << " Iterations    = " << numberOfIterations << std::endl;
-    std::cout << " Metric value  = " << bestValue          << std::endl;
-    std::cout << " Numb. Samples = " << numberOfSamples    << std::endl;
+  // Print out results
+  std::cout << std::endl;
+  std::cout << "Result = " << std::endl;
+  std::cout << " Translation X = " << TranslationAlongX << std::endl;
+  std::cout << " Translation Y = " << TranslationAlongY << std::endl;
+  std::cout << " Iterations    = " << numberOfIterations << std::endl;
+  std::cout << " Metric value  = " << bestValue << std::endl;
+  std::cout << " Numb. Samples = " << numberOfSamples << std::endl;
 
-    using ResampleFilterType = itk::ResampleImageFilter<
-            ImageType,
-            ImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType>;
 
-    TransformType::Pointer finalTransform = TransformType::New();
+  TransformType::Pointer finalTransform = TransformType::New();
 
-    finalTransform->SetParameters( finalParameters );
-    finalTransform->SetFixedParameters( transform->GetFixedParameters() );
+  finalTransform->SetParameters(finalParameters);
+  finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-    ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  ResampleFilterType::Pointer resample = ResampleFilterType::New();
 
-    resample->SetTransform( finalTransform );
-    resample->SetInput( movingImage);
+  resample->SetTransform(finalTransform);
+  resample->SetInput(movingImage);
 
-    resample->SetSize(    fixedImage->GetLargestPossibleRegion().GetSize() );
-    resample->SetOutputOrigin(  fixedImage->GetOrigin() );
-    resample->SetOutputSpacing( fixedImage->GetSpacing() );
-    resample->SetOutputDirection( fixedImage->GetDirection() );
-    resample->SetDefaultPixelValue( 100 );
+  resample->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
+  resample->SetOutputOrigin(fixedImage->GetOrigin());
+  resample->SetOutputSpacing(fixedImage->GetSpacing());
+  resample->SetOutputDirection(fixedImage->GetDirection());
+  resample->SetDefaultPixelValue(100);
 
-    WriterType::Pointer      writer =  WriterType::New();
-    writer->SetFileName("output.png");
-    writer->SetInput( resample->GetOutput()   );
-    writer->Update();
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName("output.png");
+  writer->SetInput(resample->GetOutput());
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateEllipseImage(ImageType::Pointer image)
+void
+CreateEllipseImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 20;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 20;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  65;
-    translation[ 1 ] =  45;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 65;
+  translation[1] = 45;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
-
+  image->Graft(imageFilter->GetOutput());
 }
 
-void CreateCircleImage(ImageType::Pointer image)
+void
+CreateCircleImage(ImageType::Pointer image)
 {
-    using EllipseType = itk::EllipseSpatialObject< Dimension >;
+  using EllipseType = itk::EllipseSpatialObject<Dimension>;
 
-    using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<
-            EllipseType, ImageType >;
+  using SpatialObjectToImageFilterType = itk::SpatialObjectToImageFilter<EllipseType, ImageType>;
 
-    SpatialObjectToImageFilterType::Pointer imageFilter =
-            SpatialObjectToImageFilterType::New();
+  SpatialObjectToImageFilterType::Pointer imageFilter = SpatialObjectToImageFilterType::New();
 
-    ImageType::SizeType size;
-    size[ 0 ] =  100;
-    size[ 1 ] =  100;
+  ImageType::SizeType size;
+  size[0] = 100;
+  size[1] = 100;
 
-    imageFilter->SetSize( size );
+  imageFilter->SetSize(size);
 
-    ImageType::SpacingType spacing;
-    spacing.Fill(1);
-    imageFilter->SetSpacing(spacing);
+  ImageType::SpacingType spacing;
+  spacing.Fill(1);
+  imageFilter->SetSpacing(spacing);
 
-    EllipseType::Pointer ellipse    = EllipseType::New();
-    EllipseType::ArrayType radiusArray;
-    radiusArray[0] = 10;
-    radiusArray[1] = 10;
-    ellipse->SetRadiusInObjectSpace(radiusArray);
+  EllipseType::Pointer   ellipse = EllipseType::New();
+  EllipseType::ArrayType radiusArray;
+  radiusArray[0] = 10;
+  radiusArray[1] = 10;
+  ellipse->SetRadiusInObjectSpace(radiusArray);
 
-    using TransformType = EllipseType::TransformType;
-    TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
+  using TransformType = EllipseType::TransformType;
+  TransformType::Pointer transform = TransformType::New();
+  transform->SetIdentity();
 
-    TransformType::OutputVectorType  translation;
-    translation[ 0 ] =  50;
-    translation[ 1 ] =  50;
-    transform->Translate( translation, false );
+  TransformType::OutputVectorType translation;
+  translation[0] = 50;
+  translation[1] = 50;
+  transform->Translate(translation, false);
 
-    ellipse->SetObjectToParentTransform( transform );
+  ellipse->SetObjectToParentTransform(transform);
 
-    imageFilter->SetInput(ellipse);
+  imageFilter->SetInput(ellipse);
 
-    ellipse->SetDefaultInsideValue(255);
-    ellipse->SetDefaultOutsideValue(0);
-    imageFilter->SetUseObjectValue( true );
-    imageFilter->SetOutsideValue( 0 );
+  ellipse->SetDefaultInsideValue(255);
+  ellipse->SetDefaultOutsideValue(0);
+  imageFilter->SetUseObjectValue(true);
+  imageFilter->SetOutsideValue(0);
 
-    imageFilter->Update();
+  imageFilter->Update();
 
-    image->Graft(imageFilter->GetOutput());
+  image->Graft(imageFilter->GetOutput());
 }
-

--- a/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/Code.cxx
+++ b/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/Code.cxx
@@ -30,17 +30,18 @@
 #include "itkSubtractImageFilter.h"
 
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
+  if (argc != 6)
+  {
     std::cerr << "Missing Parameters " << std::endl;
     std::cerr << "Usage: " << argv[0];
     std::cerr << " fixedImageFile  movingImageFile ";
     std::cerr << "outputImagefile [differenceImageAfter]";
     std::cerr << "[differenceImageBefore]" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * fixedImageFile = argv[1];
   const char * movingImageFile = argv[2];
@@ -51,82 +52,76 @@ int main( int argc, char *argv[] )
   constexpr unsigned int Dimension = 2;
   using PixelType = float;
 
-  using FixedImageType = itk::Image< PixelType, Dimension >;
-  using MovingImageType = itk::Image< PixelType, Dimension >;
+  using FixedImageType = itk::Image<PixelType, Dimension>;
+  using MovingImageType = itk::Image<PixelType, Dimension>;
 
 
-  using FixedImageReaderType = itk::ImageFileReader< FixedImageType  >;
+  using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
   auto fixedImageReader = FixedImageReaderType::New();
-  fixedImageReader->SetFileName( fixedImageFile );
+  fixedImageReader->SetFileName(fixedImageFile);
 
-  using MovingImageReaderType = itk::ImageFileReader< MovingImageType >;
+  using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
   auto movingImageReader = MovingImageReaderType::New();
-  movingImageReader->SetFileName( movingImageFile );
+  movingImageReader->SetFileName(movingImageFile);
 
 
-  using TransformType = itk::TranslationTransform< double, Dimension >;
+  using TransformType = itk::TranslationTransform<double, Dimension>;
   auto initialTransform = TransformType::New();
 
   using OptimizerType = itk::RegularStepGradientDescentOptimizerv4<double>;
   auto optimizer = OptimizerType::New();
-  optimizer->SetLearningRate( 4 );
-  optimizer->SetMinimumStepLength( 0.001 );
-  optimizer->SetRelaxationFactor( 0.5 );
-  optimizer->SetNumberOfIterations( 200 );
+  optimizer->SetLearningRate(4);
+  optimizer->SetMinimumStepLength(0.001);
+  optimizer->SetRelaxationFactor(0.5);
+  optimizer->SetNumberOfIterations(200);
 
-  using MetricType = itk::MeanSquaresImageToImageMetricv4<
-                                          FixedImageType,
-                                          MovingImageType >;
+  using MetricType = itk::MeanSquaresImageToImageMetricv4<FixedImageType, MovingImageType>;
   auto metric = MetricType::New();
 
-  using RegistrationType = itk::ImageRegistrationMethodv4<
-                                    FixedImageType,
-                                    MovingImageType >;
+  using RegistrationType = itk::ImageRegistrationMethodv4<FixedImageType, MovingImageType>;
   auto registration = RegistrationType::New();
-  registration->SetInitialTransform( initialTransform );
-  registration->SetMetric( metric );
-  registration->SetOptimizer( optimizer );
-  registration->SetFixedImage( fixedImageReader->GetOutput() );
-  registration->SetMovingImage( movingImageReader->GetOutput() );
+  registration->SetInitialTransform(initialTransform);
+  registration->SetMetric(metric);
+  registration->SetOptimizer(optimizer);
+  registration->SetFixedImage(fixedImageReader->GetOutput());
+  registration->SetMovingImage(movingImageReader->GetOutput());
 
-  auto movingInitialTransform = TransformType::New();
-  TransformType::ParametersType initialParameters(
-    movingInitialTransform->GetNumberOfParameters() );
+  auto                          movingInitialTransform = TransformType::New();
+  TransformType::ParametersType initialParameters(movingInitialTransform->GetNumberOfParameters());
   initialParameters[0] = 0.0;
   initialParameters[1] = 0.0;
-  movingInitialTransform->SetParameters( initialParameters );
-  registration->SetMovingInitialTransform( movingInitialTransform );
+  movingInitialTransform->SetParameters(initialParameters);
+  registration->SetMovingInitialTransform(movingInitialTransform);
 
   auto identityTransform = TransformType::New();
   identityTransform->SetIdentity();
-  registration->SetFixedInitialTransform( identityTransform );
+  registration->SetFixedInitialTransform(identityTransform);
 
   constexpr unsigned int numberOfLevels = 1;
-  registration->SetNumberOfLevels( numberOfLevels );
+  registration->SetNumberOfLevels(numberOfLevels);
 
   RegistrationType::ShrinkFactorsArrayType shrinkFactorsPerLevel;
-  shrinkFactorsPerLevel.SetSize( 1 );
+  shrinkFactorsPerLevel.SetSize(1);
   shrinkFactorsPerLevel[0] = 1;
-  registration->SetShrinkFactorsPerLevel( shrinkFactorsPerLevel );
+  registration->SetShrinkFactorsPerLevel(shrinkFactorsPerLevel);
 
   RegistrationType::SmoothingSigmasArrayType smoothingSigmasPerLevel;
-  smoothingSigmasPerLevel.SetSize( 1 );
+  smoothingSigmasPerLevel.SetSize(1);
   smoothingSigmasPerLevel[0] = 0;
-  registration->SetSmoothingSigmasPerLevel( smoothingSigmasPerLevel );
+  registration->SetSmoothingSigmasPerLevel(smoothingSigmasPerLevel);
 
   try
-    {
+  {
     registration->Update();
-    std::cout << "Optimizer stop condition: "
-      << registration->GetOptimizer()->GetStopConditionDescription()
-      << std::endl;
-    }
-  catch( itk::ExceptionObject & err )
-    {
+    std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
+              << std::endl;
+  }
+  catch (itk::ExceptionObject & err)
+  {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   auto transform = registration->GetTransform();
   auto finalParameters = transform->GetParameters();
@@ -138,69 +133,57 @@ int main( int argc, char *argv[] )
   auto bestValue = optimizer->GetValue();
 
   std::cout << "Result = " << std::endl;
-  std::cout << " Translation X = " << translationAlongX  << std::endl;
-  std::cout << " Translation Y = " << translationAlongY  << std::endl;
+  std::cout << " Translation X = " << translationAlongX << std::endl;
+  std::cout << " Translation Y = " << translationAlongY << std::endl;
   std::cout << " Iterations    = " << numberOfIterations << std::endl;
-  std::cout << " Metric value  = " << bestValue          << std::endl;
+  std::cout << " Metric value  = " << bestValue << std::endl;
 
-  using CompositeTransformType = itk::CompositeTransform<
-                                 double,
-                                 Dimension >;
+  using CompositeTransformType = itk::CompositeTransform<double, Dimension>;
   auto outputCompositeTransform = CompositeTransformType::New();
-  outputCompositeTransform->AddTransform( movingInitialTransform );
-  outputCompositeTransform->AddTransform(
-    registration->GetModifiableTransform() );
+  outputCompositeTransform->AddTransform(movingInitialTransform);
+  outputCompositeTransform->AddTransform(registration->GetModifiableTransform());
 
-  using ResampleFilterType = itk::ResampleImageFilter<
-                            MovingImageType,
-                            FixedImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<MovingImageType, FixedImageType>;
   auto resampler = ResampleFilterType::New();
-  resampler->SetInput( movingImageReader->GetOutput() );
-  resampler->SetTransform( outputCompositeTransform );
+  resampler->SetInput(movingImageReader->GetOutput());
+  resampler->SetTransform(outputCompositeTransform);
   auto fixedImage = fixedImageReader->GetOutput();
-  resampler->SetUseReferenceImage( true );
-  resampler->SetReferenceImage( fixedImage );
-  resampler->SetDefaultPixelValue( 100 );
+  resampler->SetUseReferenceImage(true);
+  resampler->SetReferenceImage(fixedImage);
+  resampler->SetDefaultPixelValue(100);
 
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using CastFilterType = itk::CastImageFilter<
-                        FixedImageType,
-                        OutputImageType >;
+  using CastFilterType = itk::CastImageFilter<FixedImageType, OutputImageType>;
   auto caster = CastFilterType::New();
-  caster->SetInput( resampler->GetOutput() );
+  caster->SetInput(resampler->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
   auto writer = WriterType::New();
-  writer->SetFileName( outputImageFile );
-  writer->SetInput( caster->GetOutput()   );
+  writer->SetFileName(outputImageFile);
+  writer->SetInput(caster->GetOutput());
   writer->Update();
 
-  using DifferenceFilterType = itk::SubtractImageFilter<
-                                  FixedImageType,
-                                  FixedImageType,
-                                  FixedImageType >;
+  using DifferenceFilterType = itk::SubtractImageFilter<FixedImageType, FixedImageType, FixedImageType>;
   auto difference = DifferenceFilterType::New();
-  difference->SetInput1( fixedImageReader->GetOutput() );
-  difference->SetInput2( resampler->GetOutput() );
+  difference->SetInput1(fixedImageReader->GetOutput());
+  difference->SetInput2(resampler->GetOutput());
 
-  using RescalerType = itk::RescaleIntensityImageFilter<
-                                  FixedImageType,
-                                  OutputImageType >;
+  using RescalerType = itk::RescaleIntensityImageFilter<FixedImageType, OutputImageType>;
   auto intensityRescaler = RescalerType::New();
-  intensityRescaler->SetInput( difference->GetOutput() );
-  intensityRescaler->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  intensityRescaler->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  intensityRescaler->SetInput(difference->GetOutput());
+  intensityRescaler->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  intensityRescaler->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
 
-  resampler->SetDefaultPixelValue( 1 );
+  resampler->SetDefaultPixelValue(1);
 
-  writer->SetInput( intensityRescaler->GetOutput() );
-  writer->SetFileName( differenceImageAfterFile );
+  writer->SetInput(intensityRescaler->GetOutput());
+  writer->SetFileName(differenceImageAfterFile);
   writer->Update();
 
-  resampler->SetTransform( identityTransform );
-  writer->SetFileName( differenceImageBeforeFile );
+  resampler->SetTransform(identityTransform);
+  writer->SetFileName(differenceImageBeforeFile);
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/Code.cxx
+++ b/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/Code.cxx
@@ -63,38 +63,42 @@ public:
   using Self = CommandIterationUpdate;
   using Superclass = itk::Command;
   using Pointer = itk::SmartPointer<Self>;
-  itkNewMacro( Self );
+  itkNewMacro(Self);
 
 protected:
-  CommandIterationUpdate() = default;;
+  CommandIterationUpdate() = default;
+  ;
 
 public:
   using OptimizerType = itk::GradientDescentOptimizer;
-  using OptimizerPointer = const OptimizerType   *;
+  using OptimizerPointer = const OptimizerType *;
 
-  void Execute(itk::Object *caller, const itk::EventObject & event) override
-    {
-    Execute( (const itk::Object *)caller, event);
-    }
+  void
+  Execute(itk::Object * caller, const itk::EventObject & event) override
+  {
+    Execute((const itk::Object *)caller, event);
+  }
 
-  void Execute(const itk::Object * object, const itk::EventObject & event) override
+  void
+  Execute(const itk::Object * object, const itk::EventObject & event) override
+  {
+    auto optimizer = dynamic_cast<OptimizerPointer>(object);
+    if (!itk::IterationEvent().CheckEvent(&event))
     {
-    auto optimizer = dynamic_cast< OptimizerPointer >( object );
-    if( ! itk::IterationEvent().CheckEvent( &event ) )
-      {
       return;
-      }
+    }
     std::cout << optimizer->GetCurrentIteration() << "   ";
     std::cout << optimizer->GetValue() << "   ";
     std::cout << optimizer->GetCurrentPosition() << std::endl;
-    }
+  }
 };
 
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 4 )
-    {
+  if (argc < 4)
+  {
     std::cerr << "Missing Parameters " << std::endl;
     std::cerr << "Usage: " << argv[0];
     std::cerr << " fixedImageFile";
@@ -103,7 +107,7 @@ int main( int argc, char *argv[] )
     std::cerr << " [checkerBoardBefore]";
     std::cerr << " [checkerBoardAfter]" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   const char * fixedImageFile = argv[1];
   const char * movingImageFile = argv[2];
   const char * outputImageFile = argv[3];
@@ -113,40 +117,34 @@ int main( int argc, char *argv[] )
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned short;
 
-  using FixedImageType = itk::Image< PixelType, Dimension >;
-  using MovingImageType = itk::Image< PixelType, Dimension >;
+  using FixedImageType = itk::Image<PixelType, Dimension>;
+  using MovingImageType = itk::Image<PixelType, Dimension>;
 
   //  It is convenient to work with an internal image type because mutual
   //  information will perform better on images with a normalized statistical
   //  distribution. The fixed and moving images will be normalized and
   //  converted to this internal type.
   using InternalPixelType = float;
-  using InternalImageType = itk::Image< InternalPixelType, Dimension >;
+  using InternalImageType = itk::Image<InternalPixelType, Dimension>;
 
-  using TransformType = itk::TranslationTransform< double, Dimension >;
+  using TransformType = itk::TranslationTransform<double, Dimension>;
   using OptimizerType = itk::GradientDescentOptimizer;
-  using InterpolatorType = itk::LinearInterpolateImageFunction<
-                                    InternalImageType,
-                                    double             >;
-  using RegistrationType = itk::ImageRegistrationMethod<
-                                    InternalImageType,
-                                    InternalImageType >;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<InternalImageType, double>;
+  using RegistrationType = itk::ImageRegistrationMethod<InternalImageType, InternalImageType>;
 
-  using MetricType = itk::MutualInformationImageToImageMetric<
-                                          InternalImageType,
-                                          InternalImageType >;
+  using MetricType = itk::MutualInformationImageToImageMetric<InternalImageType, InternalImageType>;
 
 
-  TransformType::Pointer      transform     = TransformType::New();
-  OptimizerType::Pointer      optimizer     = OptimizerType::New();
-  InterpolatorType::Pointer   interpolator  = InterpolatorType::New();
-  RegistrationType::Pointer   registration  = RegistrationType::New();
-  MetricType::Pointer         metric        = MetricType::New();
+  TransformType::Pointer    transform = TransformType::New();
+  OptimizerType::Pointer    optimizer = OptimizerType::New();
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  RegistrationType::Pointer registration = RegistrationType::New();
+  MetricType::Pointer       metric = MetricType::New();
 
-  registration->SetOptimizer(     optimizer     );
-  registration->SetTransform(     transform     );
-  registration->SetInterpolator(  interpolator  );
-  registration->SetMetric( metric  );
+  registration->SetOptimizer(optimizer);
+  registration->SetTransform(transform);
+  registration->SetInterpolator(interpolator);
+  registration->SetMetric(metric);
 
   //  The metric requires a number of parameters to be selected, including
   //  the standard deviation of the Gaussian kernel for the fixed image
@@ -156,60 +154,55 @@ int main( int argc, char *argv[] )
   //  shown that a kernel standard deviation of 0.4 works well for images
   //  which have been normalized to a mean of zero and unit variance.  We
   //  will follow this empirical rule in this example.
-  metric->SetFixedImageStandardDeviation(  0.4 );
-  metric->SetMovingImageStandardDeviation( 0.4 );
+  metric->SetFixedImageStandardDeviation(0.4);
+  metric->SetMovingImageStandardDeviation(0.4);
 
-  using FixedImageReaderType = itk::ImageFileReader< FixedImageType  >;
-  using MovingImageReaderType = itk::ImageFileReader< MovingImageType >;
+  using FixedImageReaderType = itk::ImageFileReader<FixedImageType>;
+  using MovingImageReaderType = itk::ImageFileReader<MovingImageType>;
 
-  FixedImageReaderType::Pointer  fixedImageReader  =
-    FixedImageReaderType::New();
-  MovingImageReaderType::Pointer movingImageReader =
-    MovingImageReaderType::New();
+  FixedImageReaderType::Pointer  fixedImageReader = FixedImageReaderType::New();
+  MovingImageReaderType::Pointer movingImageReader = MovingImageReaderType::New();
 
-  fixedImageReader->SetFileName(  fixedImageFile );
-  movingImageReader->SetFileName( movingImageFile );
+  fixedImageReader->SetFileName(fixedImageFile);
+  movingImageReader->SetFileName(movingImageFile);
 
-  using FixedNormalizeFilterType = itk::NormalizeImageFilter< FixedImageType, InternalImageType >;
+  using FixedNormalizeFilterType = itk::NormalizeImageFilter<FixedImageType, InternalImageType>;
 
-  using MovingNormalizeFilterType = itk::NormalizeImageFilter< MovingImageType, InternalImageType >;
+  using MovingNormalizeFilterType = itk::NormalizeImageFilter<MovingImageType, InternalImageType>;
 
-  FixedNormalizeFilterType::Pointer fixedNormalizer =
-                                            FixedNormalizeFilterType::New();
+  FixedNormalizeFilterType::Pointer fixedNormalizer = FixedNormalizeFilterType::New();
 
-  MovingNormalizeFilterType::Pointer movingNormalizer =
-                                            MovingNormalizeFilterType::New();
+  MovingNormalizeFilterType::Pointer movingNormalizer = MovingNormalizeFilterType::New();
 
-  using GaussianFilterType = itk::DiscreteGaussianImageFilter< InternalImageType, InternalImageType >;
+  using GaussianFilterType = itk::DiscreteGaussianImageFilter<InternalImageType, InternalImageType>;
 
-  GaussianFilterType::Pointer fixedSmoother  = GaussianFilterType::New();
+  GaussianFilterType::Pointer fixedSmoother = GaussianFilterType::New();
   GaussianFilterType::Pointer movingSmoother = GaussianFilterType::New();
 
-  fixedSmoother->SetVariance( 2.0 );
-  movingSmoother->SetVariance( 2.0 );
+  fixedSmoother->SetVariance(2.0);
+  movingSmoother->SetVariance(2.0);
 
-  fixedNormalizer->SetInput(  fixedImageReader->GetOutput() );
-  movingNormalizer->SetInput( movingImageReader->GetOutput() );
+  fixedNormalizer->SetInput(fixedImageReader->GetOutput());
+  movingNormalizer->SetInput(movingImageReader->GetOutput());
 
-  fixedSmoother->SetInput( fixedNormalizer->GetOutput() );
-  movingSmoother->SetInput( movingNormalizer->GetOutput() );
+  fixedSmoother->SetInput(fixedNormalizer->GetOutput());
+  movingSmoother->SetInput(movingNormalizer->GetOutput());
 
-  registration->SetFixedImage(    fixedSmoother->GetOutput()    );
-  registration->SetMovingImage(   movingSmoother->GetOutput()   );
+  registration->SetFixedImage(fixedSmoother->GetOutput());
+  registration->SetMovingImage(movingSmoother->GetOutput());
 
 
   fixedNormalizer->Update();
-  FixedImageType::RegionType fixedImageRegion =
-       fixedNormalizer->GetOutput()->GetBufferedRegion();
-  registration->SetFixedImageRegion( fixedImageRegion );
+  FixedImageType::RegionType fixedImageRegion = fixedNormalizer->GetOutput()->GetBufferedRegion();
+  registration->SetFixedImageRegion(fixedImageRegion);
 
   using ParametersType = RegistrationType::ParametersType;
-  ParametersType initialParameters( transform->GetNumberOfParameters() );
+  ParametersType initialParameters(transform->GetNumberOfParameters());
 
-  initialParameters[0] = 0.0;  // Initial offset in mm along X
-  initialParameters[1] = 0.0;  // Initial offset in mm along Y
+  initialParameters[0] = 0.0; // Initial offset in mm along X
+  initialParameters[1] = 0.0; // Initial offset in mm along Y
 
-  registration->SetInitialTransformParameters( initialParameters );
+  registration->SetInitialTransformParameters(initialParameters);
 
   //  We should now define the number of spatial samples to be considered in
   //  the metric computation. Note that we were forced to postpone this setting
@@ -238,12 +231,12 @@ int main( int argc, char *argv[] )
   //  behavior of the metric values as the iterations progress.
   const unsigned int numberOfPixels = fixedImageRegion.GetNumberOfPixels();
 
-  const auto numberOfSamples = static_cast< unsigned int >( numberOfPixels * 0.01 );
+  const auto numberOfSamples = static_cast<unsigned int>(numberOfPixels * 0.01);
 
-  metric->SetNumberOfSpatialSamples( numberOfSamples );
+  metric->SetNumberOfSpatialSamples(numberOfSamples);
 
   // For consistent results when regression testing.
-  metric->ReinitializeSeed( 121212 );
+  metric->ReinitializeSeed(121212);
 
 
   //  Since larger values of mutual information indicate better matches than
@@ -253,7 +246,7 @@ int main( int argc, char *argv[] )
   //  default behavior by invoking the MaximizeOn() method.
   //  Additionally, we need to define the optimizer's step size using the
   //  SetLearningRate() method.
-  optimizer->SetNumberOfIterations( 200 );
+  optimizer->SetNumberOfIterations(200);
   optimizer->MaximizeOn();
 
   // Note that large values of the learning rate will make the optimizer
@@ -271,24 +264,23 @@ int main( int argc, char *argv[] )
   // optimizer step length is proportional to the Metric values themselves.
   // Metrics with large values will require you to use smaller values for the
   // learning rate in order to maintain a similar optimizer behavior.
-  optimizer->SetLearningRate( 15.0 );
+  optimizer->SetLearningRate(15.0);
 
   CommandIterationUpdate::Pointer observer = CommandIterationUpdate::New();
-  optimizer->AddObserver( itk::IterationEvent(), observer );
+  optimizer->AddObserver(itk::IterationEvent(), observer);
 
   try
-    {
+  {
     registration->Update();
-    std::cout << "Optimizer stop condition: "
-              << registration->GetOptimizer()->GetStopConditionDescription()
+    std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
               << std::endl;
-    }
-  catch( itk::ExceptionObject & err )
-    {
+  }
+  catch (itk::ExceptionObject & err)
+  {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   ParametersType finalParameters = registration->GetLastTransformParameters();
 
@@ -302,92 +294,88 @@ int main( int argc, char *argv[] )
   // Print out results
   std::cout << std::endl;
   std::cout << "Result = " << std::endl;
-  std::cout << " Translation X = " << TranslationAlongX  << std::endl;
-  std::cout << " Translation Y = " << TranslationAlongY  << std::endl;
+  std::cout << " Translation X = " << TranslationAlongX << std::endl;
+  std::cout << " Translation Y = " << TranslationAlongY << std::endl;
   std::cout << " Iterations    = " << numberOfIterations << std::endl;
-  std::cout << " Metric value  = " << bestValue          << std::endl;
-  std::cout << " Numb. Samples = " << numberOfSamples    << std::endl;
+  std::cout << " Metric value  = " << bestValue << std::endl;
+  std::cout << " Numb. Samples = " << numberOfSamples << std::endl;
 
 
-  using ResampleFilterType = itk::ResampleImageFilter<
-                            MovingImageType,
-                            FixedImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<MovingImageType, FixedImageType>;
 
   TransformType::Pointer finalTransform = TransformType::New();
 
-  finalTransform->SetParameters( finalParameters );
-  finalTransform->SetFixedParameters( transform->GetFixedParameters() );
+  finalTransform->SetParameters(finalParameters);
+  finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
   ResampleFilterType::Pointer resample = ResampleFilterType::New();
 
-  resample->SetTransform( finalTransform );
-  resample->SetInput( movingImageReader->GetOutput() );
+  resample->SetTransform(finalTransform);
+  resample->SetInput(movingImageReader->GetOutput());
 
   FixedImageType::Pointer fixedImage = fixedImageReader->GetOutput();
 
-  resample->SetSize(    fixedImage->GetLargestPossibleRegion().GetSize() );
-  resample->SetOutputOrigin(  fixedImage->GetOrigin() );
-  resample->SetOutputSpacing( fixedImage->GetSpacing() );
-  resample->SetOutputDirection( fixedImage->GetDirection() );
-  resample->SetDefaultPixelValue( 100 );
+  resample->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
+  resample->SetOutputOrigin(fixedImage->GetOrigin());
+  resample->SetOutputSpacing(fixedImage->GetSpacing());
+  resample->SetOutputDirection(fixedImage->GetDirection());
+  resample->SetDefaultPixelValue(100);
 
 
   using OutputPixelType = unsigned char;
 
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using CastFilterType = itk::CastImageFilter<
-                        FixedImageType,
-                        OutputImageType >;
+  using CastFilterType = itk::CastImageFilter<FixedImageType, OutputImageType>;
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
 
-  WriterType::Pointer      writer =  WriterType::New();
-  CastFilterType::Pointer  caster =  CastFilterType::New();
+  WriterType::Pointer     writer = WriterType::New();
+  CastFilterType::Pointer caster = CastFilterType::New();
 
-  writer->SetFileName( outputImageFile );
-  caster->SetInput( resample->GetOutput() );
-  writer->SetInput( caster->GetOutput()   );
+  writer->SetFileName(outputImageFile);
+  caster->SetInput(resample->GetOutput());
+  writer->SetInput(caster->GetOutput());
   writer->Update();
 
 
   // Generate checkerboards before and after registration
-  using CheckerBoardFilterType = itk::CheckerBoardImageFilter< FixedImageType >;
+  using CheckerBoardFilterType = itk::CheckerBoardImageFilter<FixedImageType>;
 
   CheckerBoardFilterType::Pointer checker = CheckerBoardFilterType::New();
 
-  checker->SetInput1( fixedImage );
-  checker->SetInput2( resample->GetOutput() );
+  checker->SetInput1(fixedImage);
+  checker->SetInput2(resample->GetOutput());
 
-  caster->SetInput( checker->GetOutput() );
-  writer->SetInput( caster->GetOutput()   );
+  caster->SetInput(checker->GetOutput());
+  writer->SetInput(caster->GetOutput());
 
   // Before registration
   TransformType::Pointer identityTransform = TransformType::New();
   identityTransform->SetIdentity();
-  resample->SetTransform( identityTransform );
+  resample->SetTransform(identityTransform);
 
-  if( argc > 4 )
-    {
-    writer->SetFileName( checkerBoardBefore );
-    }
+  if (argc > 4)
+  {
+    writer->SetFileName(checkerBoardBefore);
+  }
 
   // After registration
-  resample->SetTransform( finalTransform );
-  if( argc > 5 )
-    {
-    writer->SetFileName( checkerBoardAfter );
-    }
+  resample->SetTransform(finalTransform);
+  if (argc > 5)
+  {
+    writer->SetFileName(checkerBoardAfter);
+  }
 
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/Code.cxx
+++ b/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/Code.cxx
@@ -24,164 +24,169 @@
 
 constexpr unsigned int Dimension = 2;
 using PixelType = unsigned char;
-using ImageType = itk::Image< PixelType, Dimension >;
+using ImageType = itk::Image<PixelType, Dimension>;
 
-static void CreateFixedImage(ImageType::Pointer image);
-static void CreateMovingImage(ImageType::Pointer image);
+static void
+CreateFixedImage(ImageType::Pointer image);
+static void
+CreateMovingImage(ImageType::Pointer image);
 
-int main( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )
+int
+main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 {
-    ImageType::Pointer fixedImage = ImageType::New();
-    CreateFixedImage(fixedImage);
+  ImageType::Pointer fixedImage = ImageType::New();
+  CreateFixedImage(fixedImage);
 
-    ImageType::Pointer movingImage = ImageType::New();
-    CreateMovingImage(movingImage);
+  ImageType::Pointer movingImage = ImageType::New();
+  CreateMovingImage(movingImage);
 
-    using Rigid2DTransformType = itk::Rigid2DTransform< double >;
-    using LandmarkBasedTransformInitializerType = itk::LandmarkBasedTransformInitializer< Rigid2DTransformType, ImageType, ImageType >;
+  using Rigid2DTransformType = itk::Rigid2DTransform<double>;
+  using LandmarkBasedTransformInitializerType =
+    itk::LandmarkBasedTransformInitializer<Rigid2DTransformType, ImageType, ImageType>;
 
-    LandmarkBasedTransformInitializerType::Pointer landmarkBasedTransformInitializer =
-            LandmarkBasedTransformInitializerType::New();
-    //  Create source and target landmarks.
-    using LandmarkContainerType = LandmarkBasedTransformInitializerType::LandmarkPointContainer;
-    using LandmarkPointType = LandmarkBasedTransformInitializerType::LandmarkPointType;
+  LandmarkBasedTransformInitializerType::Pointer landmarkBasedTransformInitializer =
+    LandmarkBasedTransformInitializerType::New();
+  //  Create source and target landmarks.
+  using LandmarkContainerType = LandmarkBasedTransformInitializerType::LandmarkPointContainer;
+  using LandmarkPointType = LandmarkBasedTransformInitializerType::LandmarkPointType;
 
-    LandmarkContainerType fixedLandmarks;
-    LandmarkContainerType movingLandmarks;
+  LandmarkContainerType fixedLandmarks;
+  LandmarkContainerType movingLandmarks;
 
-    LandmarkPointType fixedPoint;
-    LandmarkPointType movingPoint;
+  LandmarkPointType fixedPoint;
+  LandmarkPointType movingPoint;
 
-    fixedPoint[0] = 10;
-    fixedPoint[1] = 10;
-    movingPoint[0] = 50;
-    movingPoint[1] = 50;
-    fixedLandmarks.push_back( fixedPoint );
-    movingLandmarks.push_back( movingPoint );
+  fixedPoint[0] = 10;
+  fixedPoint[1] = 10;
+  movingPoint[0] = 50;
+  movingPoint[1] = 50;
+  fixedLandmarks.push_back(fixedPoint);
+  movingLandmarks.push_back(movingPoint);
 
-    fixedPoint[0] = 10;
-    fixedPoint[1] = 20;
-    movingPoint[0] = 50;
-    movingPoint[1] = 60;
-    fixedLandmarks.push_back( fixedPoint );
-    movingLandmarks.push_back( movingPoint );
+  fixedPoint[0] = 10;
+  fixedPoint[1] = 20;
+  movingPoint[0] = 50;
+  movingPoint[1] = 60;
+  fixedLandmarks.push_back(fixedPoint);
+  movingLandmarks.push_back(movingPoint);
 
-    fixedPoint[0] = 20;
-    fixedPoint[1] = 10;
-    movingPoint[0] = 60;
-    movingPoint[1] = 50;
-    fixedLandmarks.push_back( fixedPoint );
-    movingLandmarks.push_back( movingPoint );
+  fixedPoint[0] = 20;
+  fixedPoint[1] = 10;
+  movingPoint[0] = 60;
+  movingPoint[1] = 50;
+  fixedLandmarks.push_back(fixedPoint);
+  movingLandmarks.push_back(movingPoint);
 
-    fixedPoint[0] = 20;
-    fixedPoint[1] = 20;
-    movingPoint[0] = 60;
-    movingPoint[1] = 60;
-    fixedLandmarks.push_back( fixedPoint );
-    movingLandmarks.push_back( movingPoint );
+  fixedPoint[0] = 20;
+  fixedPoint[1] = 20;
+  movingPoint[0] = 60;
+  movingPoint[1] = 60;
+  fixedLandmarks.push_back(fixedPoint);
+  movingLandmarks.push_back(movingPoint);
 
-    landmarkBasedTransformInitializer->SetFixedLandmarks( fixedLandmarks );
-    landmarkBasedTransformInitializer->SetMovingLandmarks( movingLandmarks );
+  landmarkBasedTransformInitializer->SetFixedLandmarks(fixedLandmarks);
+  landmarkBasedTransformInitializer->SetMovingLandmarks(movingLandmarks);
 
-    Rigid2DTransformType::Pointer transform = Rigid2DTransformType::New();
+  Rigid2DTransformType::Pointer transform = Rigid2DTransformType::New();
 
-    transform->SetIdentity();
-    landmarkBasedTransformInitializer->SetTransform(transform);
-    landmarkBasedTransformInitializer->InitializeTransform();
+  transform->SetIdentity();
+  landmarkBasedTransformInitializer->SetTransform(transform);
+  landmarkBasedTransformInitializer->InitializeTransform();
 
-    using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType, double >;
-    ResampleFilterType::Pointer resampleFilter = ResampleFilterType::New();
-    resampleFilter->SetInput( movingImage );
-    resampleFilter->SetTransform( transform );
-    resampleFilter->SetSize( fixedImage->GetLargestPossibleRegion().GetSize() );
-    resampleFilter->SetOutputOrigin(  fixedImage->GetOrigin() );
-    resampleFilter->SetOutputSpacing( fixedImage->GetSpacing() );
-    resampleFilter->SetOutputDirection( fixedImage->GetDirection() );
-    resampleFilter->SetDefaultPixelValue( 200 );
-    resampleFilter->GetOutput();
+  using ResampleFilterType = itk::ResampleImageFilter<ImageType, ImageType, double>;
+  ResampleFilterType::Pointer resampleFilter = ResampleFilterType::New();
+  resampleFilter->SetInput(movingImage);
+  resampleFilter->SetTransform(transform);
+  resampleFilter->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
+  resampleFilter->SetOutputOrigin(fixedImage->GetOrigin());
+  resampleFilter->SetOutputSpacing(fixedImage->GetSpacing());
+  resampleFilter->SetOutputDirection(fixedImage->GetDirection());
+  resampleFilter->SetDefaultPixelValue(200);
+  resampleFilter->GetOutput();
 
-    // Write the output
-    using WriterType = itk::ImageFileWriter<  ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput (  resampleFilter->GetOutput() );
-    writer->SetFileName( "output.png" );
-    writer->Update();
+  // Write the output
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(resampleFilter->GetOutput());
+  writer->SetFileName("output.png");
+  writer->Update();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateFixedImage(ImageType::Pointer image)
+void
+CreateFixedImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 10 && imageIterator.GetIndex()[0] < 20 && imageIterator.GetIndex()[1] > 10 &&
+        imageIterator.GetIndex()[1] < 20)
     {
-        if(imageIterator.GetIndex()[0] > 10 && imageIterator.GetIndex()[0] < 20 &&
-           imageIterator.GetIndex()[1] > 10 && imageIterator.GetIndex()[1] < 20)
-        {
-            imageIterator.Set(255);
-        }
-        ++imageIterator;
+      imageIterator.Set(255);
     }
+    ++imageIterator;
+  }
 
-    // Write the deformation field
-    using WriterType = itk::ImageFileWriter<  ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput (  image );
-    writer->SetFileName( "fixed.png" );
-    writer->Update();
+  // Write the deformation field
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(image);
+  writer->SetFileName("fixed.png");
+  writer->Update();
 }
 
 
-void CreateMovingImage(ImageType::Pointer image)
+void
+CreateMovingImage(ImageType::Pointer image)
 {
-    // Create a black image with a white square
-    ImageType::IndexType start;
-    start.Fill(0);
+  // Create a black image with a white square
+  ImageType::IndexType start;
+  start.Fill(0);
 
-    ImageType::SizeType size;
-    size.Fill(100);
+  ImageType::SizeType size;
+  size.Fill(100);
 
-    ImageType::RegionType region;
-    region.SetSize(size);
-    region.SetIndex(start);
+  ImageType::RegionType region;
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(0);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(0);
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 60 && imageIterator.GetIndex()[1] > 50 &&
+        imageIterator.GetIndex()[1] < 60)
     {
-        if(imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 60 &&
-           imageIterator.GetIndex()[1] > 50 && imageIterator.GetIndex()[1] < 60)
-        {
-            imageIterator.Set(100);
-        }
-        ++imageIterator;
+      imageIterator.Set(100);
     }
+    ++imageIterator;
+  }
 
-    // Write the deformation field
-    using WriterType = itk::ImageFileWriter<  ImageType  >;
-    WriterType::Pointer writer = WriterType::New();
-    writer->SetInput (  image );
-    writer->SetFileName( "moving.png" );
-    writer->Update();
+  // Write the deformation field
+  using WriterType = itk::ImageFileWriter<ImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetInput(image);
+  writer->SetFileName("moving.png");
+  writer->Update();
 }
-

--- a/src/Registration/Common/WatchRegistration/Code.cxx
+++ b/src/Registration/Common/WatchRegistration/Code.cxx
@@ -41,331 +41,312 @@
 constexpr unsigned int Dimension = 2;
 using PixelType = unsigned char;
 
-using InputImageType = itk::Image< PixelType, Dimension >;
-using OutputImageType = itk::Image< unsigned char, Dimension >;
+using InputImageType = itk::Image<PixelType, Dimension>;
+using OutputImageType = itk::Image<unsigned char, Dimension>;
 
 //  Command observer to visualize the evolution of the registration process.
 //
 #include "itkCommand.h"
-template< typename TImage >
+template <typename TImage>
 class IterationUpdate : public itk::Command
 {
 public:
-    using Self = IterationUpdate;
-    using Superclass = itk::Command;
-    using Pointer = itk::SmartPointer<Self>;
-    itkNewMacro( Self );
+  using Self = IterationUpdate;
+  using Superclass = itk::Command;
+  using Pointer = itk::SmartPointer<Self>;
+  itkNewMacro(Self);
 
 protected:
-    IterationUpdate() = default;;
+  IterationUpdate() = default;
+  ;
 
 public:
-    using InternalImageType = itk::Image< float, 2>;
-    using OptimizerType = itk::RegularStepGradientDescentOptimizer;
-    using OptimizerPointer = const OptimizerType *;
-    using ResampleFilterType = itk::ResampleImageFilter<
-            TImage,
-            TImage >;
-    using TransformType = itk::AffineTransform< double, 2 >;
-    using ConnectorType = itk::ImageToVTKImageFilter<TImage >;
-    using FilterType = itk::FlipImageFilter<TImage>;
-    void Execute(itk::Object *caller, const itk::EventObject & event) override
+  using InternalImageType = itk::Image<float, 2>;
+  using OptimizerType = itk::RegularStepGradientDescentOptimizer;
+  using OptimizerPointer = const OptimizerType *;
+  using ResampleFilterType = itk::ResampleImageFilter<TImage, TImage>;
+  using TransformType = itk::AffineTransform<double, 2>;
+  using ConnectorType = itk::ImageToVTKImageFilter<TImage>;
+  using FilterType = itk::FlipImageFilter<TImage>;
+  void
+  Execute(itk::Object * caller, const itk::EventObject & event) override
+  {
+    Execute((const itk::Object *)caller, event);
+  }
+
+  void
+  Execute(const itk::Object * object, const itk::EventObject & event) override
+  {
+    auto optimizer = static_cast<OptimizerPointer>(object);
+    if (!(itk::IterationEvent().CheckEvent(&event)))
     {
-        Execute( (const itk::Object *) caller, event);
+      return;
     }
 
-    void Execute(const itk::Object * object, const itk::EventObject & event) override
-    {
-        auto optimizer = static_cast< OptimizerPointer >( object );
-        if( !(itk::IterationEvent().CheckEvent( &event )) )
-        {
-            return;
-        }
-
-        m_Transform->SetParameters(optimizer->GetCurrentPosition());
-        m_Filter->Update();
-        m_Connector->SetInput(m_Filter->GetOutput());
-        m_Connector->Update();
+    m_Transform->SetParameters(optimizer->GetCurrentPosition());
+    m_Filter->Update();
+    m_Connector->SetInput(m_Filter->GetOutput());
+    m_Connector->Update();
 
 #if VTK_MAJOR_VERSION <= 5
-        m_ImageActor->SetInput(m_Connector->GetOutput());
+    m_ImageActor->SetInput(m_Connector->GetOutput());
 #else
-        m_Connector->Update();
+    m_Connector->Update();
     m_ImageActor->GetMapper()->SetInputData(m_Connector->GetOutput());
 #endif
-        m_RenderWindow->Render();
-    }
-    void SetTransform(TransformType::Pointer &transform)
-    {
-        m_Transform = transform;
-    }
-    void SetFilter(typename FilterType::Pointer &filter)
-    {
-        m_Filter = filter;
-    }
-    void SetConnector(typename ConnectorType::Pointer &connector)
-    {
-        m_Connector = connector;
-    }
-    void SetImageActor(vtkImageActor *actor)
-    {
-        m_ImageActor = actor;
-    }
-    void SetRenderWindow(vtkRenderWindow *renderWindow)
-    {
-        m_RenderWindow = renderWindow;
-    }
-    TransformType::Pointer               m_Transform;
-    typename FilterType::Pointer         m_Filter;
-    typename ConnectorType::Pointer      m_Connector;
-    vtkImageActor *                      m_ImageActor;
-    vtkRenderWindow *                    m_RenderWindow;
+    m_RenderWindow->Render();
+  }
+  void
+  SetTransform(TransformType::Pointer & transform)
+  {
+    m_Transform = transform;
+  }
+  void
+  SetFilter(typename FilterType::Pointer & filter)
+  {
+    m_Filter = filter;
+  }
+  void
+  SetConnector(typename ConnectorType::Pointer & connector)
+  {
+    m_Connector = connector;
+  }
+  void
+  SetImageActor(vtkImageActor * actor)
+  {
+    m_ImageActor = actor;
+  }
+  void
+  SetRenderWindow(vtkRenderWindow * renderWindow)
+  {
+    m_RenderWindow = renderWindow;
+  }
+  TransformType::Pointer          m_Transform;
+  typename FilterType::Pointer    m_Filter;
+  typename ConnectorType::Pointer m_Connector;
+  vtkImageActor *                 m_ImageActor;
+  vtkRenderWindow *               m_RenderWindow;
 };
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-    InputImageType::Pointer  fixedImage = InputImageType::New();
-    InputImageType::Pointer movingImage = InputImageType::New();
+  InputImageType::Pointer fixedImage = InputImageType::New();
+  InputImageType::Pointer movingImage = InputImageType::New();
 
-    if (argc > 2)
-    {
-        using ReaderType = itk::ImageFileReader<InputImageType>;
-        ReaderType::Pointer fixedReader = ReaderType::New();
-        fixedReader->SetFileName( argv[1] );
-        fixedReader->Update();
-        fixedImage = fixedReader->GetOutput();
+  if (argc > 2)
+  {
+    using ReaderType = itk::ImageFileReader<InputImageType>;
+    ReaderType::Pointer fixedReader = ReaderType::New();
+    fixedReader->SetFileName(argv[1]);
+    fixedReader->Update();
+    fixedImage = fixedReader->GetOutput();
 
-        ReaderType::Pointer movingReader = ReaderType::New();
-        movingReader->SetFileName( argv[2] );
-        movingReader->Update();
-        movingImage = movingReader->GetOutput();
-    }
-    else
-    {
-        std::cout << "Usage: " << argv[0] << " fixedImage movingImage" << std::endl;
-        return EXIT_FAILURE;
-    }
+    ReaderType::Pointer movingReader = ReaderType::New();
+    movingReader->SetFileName(argv[2]);
+    movingReader->Update();
+    movingImage = movingReader->GetOutput();
+  }
+  else
+  {
+    std::cout << "Usage: " << argv[0] << " fixedImage movingImage" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    // Use floats internally
-    using InternalImageType = itk::Image< float, Dimension>;
+  // Use floats internally
+  using InternalImageType = itk::Image<float, Dimension>;
 
-    // Normalize the images
-    using NormalizeFilterType = itk::NormalizeImageFilter<InputImageType, InternalImageType>;
-    NormalizeFilterType::Pointer fixedNormalizer =
-            NormalizeFilterType::New();
-    NormalizeFilterType::Pointer movingNormalizer =
-            NormalizeFilterType::New();
+  // Normalize the images
+  using NormalizeFilterType = itk::NormalizeImageFilter<InputImageType, InternalImageType>;
+  NormalizeFilterType::Pointer fixedNormalizer = NormalizeFilterType::New();
+  NormalizeFilterType::Pointer movingNormalizer = NormalizeFilterType::New();
 
-    fixedNormalizer->SetInput(  fixedImage);
-    movingNormalizer->SetInput( movingImage);
+  fixedNormalizer->SetInput(fixedImage);
+  movingNormalizer->SetInput(movingImage);
 
-    // Smooth the normalized images
-    using GaussianFilterType = itk::DiscreteGaussianImageFilter<InternalImageType,InternalImageType>;
-    GaussianFilterType::Pointer fixedSmoother  =
-            GaussianFilterType::New();
-    GaussianFilterType::Pointer movingSmoother =
-            GaussianFilterType::New();
+  // Smooth the normalized images
+  using GaussianFilterType = itk::DiscreteGaussianImageFilter<InternalImageType, InternalImageType>;
+  GaussianFilterType::Pointer fixedSmoother = GaussianFilterType::New();
+  GaussianFilterType::Pointer movingSmoother = GaussianFilterType::New();
 
-    fixedSmoother->SetVariance( 3.0 );
-    fixedSmoother->SetInput( fixedNormalizer->GetOutput() );
-    movingSmoother->SetVariance( 3.0 );
-    movingSmoother->SetInput( movingNormalizer->GetOutput() );
+  fixedSmoother->SetVariance(3.0);
+  fixedSmoother->SetInput(fixedNormalizer->GetOutput());
+  movingSmoother->SetVariance(3.0);
+  movingSmoother->SetInput(movingNormalizer->GetOutput());
 
-    // Set up registration
-    using TransformType = itk::AffineTransform< double, Dimension >;
-    using OptimizerType = itk::RegularStepGradientDescentOptimizer;
-    using InterpolatorType = itk::LinearInterpolateImageFunction<
-            InternalImageType,
-            double             >;
-    using MetricType = itk::MattesMutualInformationImageToImageMetric<
-            InternalImageType,
-            InternalImageType >;
-    using RegistrationType = itk::ImageRegistrationMethod<
-            InternalImageType,
-            InternalImageType >;
-    using InitializerType = itk::CenteredTransformInitializer<
-            TransformType,
-            InputImageType,
-            InputImageType >;
+  // Set up registration
+  using TransformType = itk::AffineTransform<double, Dimension>;
+  using OptimizerType = itk::RegularStepGradientDescentOptimizer;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<InternalImageType, double>;
+  using MetricType = itk::MattesMutualInformationImageToImageMetric<InternalImageType, InternalImageType>;
+  using RegistrationType = itk::ImageRegistrationMethod<InternalImageType, InternalImageType>;
+  using InitializerType = itk::CenteredTransformInitializer<TransformType, InputImageType, InputImageType>;
 
-    InitializerType::Pointer    initializer = InitializerType::New();
-    TransformType::Pointer      transform     = TransformType::New();
-    OptimizerType::Pointer      optimizer     = OptimizerType::New();
-    InterpolatorType::Pointer   interpolator  = InterpolatorType::New();
-    RegistrationType::Pointer   registration  = RegistrationType::New();
+  InitializerType::Pointer  initializer = InitializerType::New();
+  TransformType::Pointer    transform = TransformType::New();
+  OptimizerType::Pointer    optimizer = OptimizerType::New();
+  InterpolatorType::Pointer interpolator = InterpolatorType::New();
+  RegistrationType::Pointer registration = RegistrationType::New();
 
-    // Set up the registration framework
-    initializer->SetFixedImage( fixedImage );
-    initializer->SetMovingImage( movingImage );
-    initializer->SetTransform( transform );
+  // Set up the registration framework
+  initializer->SetFixedImage(fixedImage);
+  initializer->SetMovingImage(movingImage);
+  initializer->SetTransform(transform);
 
-    transform->SetIdentity();
-    initializer->GeometryOn();
-    initializer->InitializeTransform();
+  transform->SetIdentity();
+  initializer->GeometryOn();
+  initializer->InitializeTransform();
 
-    registration->SetOptimizer(     optimizer     );
-    registration->SetTransform(     transform     );
-    registration->SetInterpolator(  interpolator  );
+  registration->SetOptimizer(optimizer);
+  registration->SetTransform(transform);
+  registration->SetInterpolator(interpolator);
 
-    MetricType::Pointer         metric        = MetricType::New();
+  MetricType::Pointer metric = MetricType::New();
 
-    registration->SetMetric( metric );
-    registration->SetFixedImage( fixedSmoother->GetOutput() );
-    registration->SetMovingImage(movingSmoother->GetOutput() );
+  registration->SetMetric(metric);
+  registration->SetFixedImage(fixedSmoother->GetOutput());
+  registration->SetMovingImage(movingSmoother->GetOutput());
 
-    // Update to get the size of the region
-    fixedNormalizer->Update();
-    InputImageType::RegionType fixedImageRegion =
-            fixedNormalizer->GetOutput()->GetBufferedRegion();
-    registration->SetFixedImageRegion( fixedImageRegion );
+  // Update to get the size of the region
+  fixedNormalizer->Update();
+  InputImageType::RegionType fixedImageRegion = fixedNormalizer->GetOutput()->GetBufferedRegion();
+  registration->SetFixedImageRegion(fixedImageRegion);
 
-    using ParametersType = RegistrationType::ParametersType;
-    ParametersType initialParameters( transform->GetNumberOfParameters() );
+  using ParametersType = RegistrationType::ParametersType;
+  ParametersType initialParameters(transform->GetNumberOfParameters());
 
-    // rotation matrix (identity)
-    initialParameters[0] = 1.0;  // R(0,0)
-    initialParameters[1] = 0.0;  // R(0,1)
-    initialParameters[2] = 0.0;  // R(1,0)
-    initialParameters[3] = 1.0;  // R(1,1)
+  // rotation matrix (identity)
+  initialParameters[0] = 1.0; // R(0,0)
+  initialParameters[1] = 0.0; // R(0,1)
+  initialParameters[2] = 0.0; // R(1,0)
+  initialParameters[3] = 1.0; // R(1,1)
 
-    // translation vector
-    initialParameters[4] = 0.0;
-    initialParameters[5] = 0.0;
+  // translation vector
+  initialParameters[4] = 0.0;
+  initialParameters[5] = 0.0;
 
-    registration->SetInitialTransformParameters( initialParameters );
+  registration->SetInitialTransformParameters(initialParameters);
 
-    const unsigned int numberOfPixels = fixedImageRegion.GetNumberOfPixels();
-    const auto numberOfSamples = static_cast< unsigned int >( numberOfPixels * 0.05 );
+  const unsigned int numberOfPixels = fixedImageRegion.GetNumberOfPixels();
+  const auto         numberOfSamples = static_cast<unsigned int>(numberOfPixels * 0.05);
 
-    metric->SetNumberOfHistogramBins( 26 );
-    metric->SetNumberOfSpatialSamples( numberOfSamples );
+  metric->SetNumberOfHistogramBins(26);
+  metric->SetNumberOfSpatialSamples(numberOfSamples);
 
-    optimizer->MinimizeOn();
-    optimizer->SetMaximumStepLength( 0.500 );
-    optimizer->SetMinimumStepLength( 0.001 );
-    optimizer->SetNumberOfIterations( 1000 );
+  optimizer->MinimizeOn();
+  optimizer->SetMaximumStepLength(0.500);
+  optimizer->SetMinimumStepLength(0.001);
+  optimizer->SetNumberOfIterations(1000);
 
-    const unsigned int numberOfParameters =  transform->GetNumberOfParameters();
-    using OptimizerScalesType = OptimizerType::ScalesType;
-    OptimizerScalesType optimizerScales( numberOfParameters );
-    double translationScale = 1.0 / 1000.0;
-    optimizerScales[0] =  1.0;
-    optimizerScales[1] =  1.0;
-    optimizerScales[2] =  1.0;
-    optimizerScales[3] =  1.0;
-    optimizerScales[4] =  translationScale;
-    optimizerScales[5] =  translationScale;
+  const unsigned int numberOfParameters = transform->GetNumberOfParameters();
+  using OptimizerScalesType = OptimizerType::ScalesType;
+  OptimizerScalesType optimizerScales(numberOfParameters);
+  double              translationScale = 1.0 / 1000.0;
+  optimizerScales[0] = 1.0;
+  optimizerScales[1] = 1.0;
+  optimizerScales[2] = 1.0;
+  optimizerScales[3] = 1.0;
+  optimizerScales[4] = translationScale;
+  optimizerScales[5] = translationScale;
 
-    optimizer->SetScales( optimizerScales );
+  optimizer->SetScales(optimizerScales);
 
-    TransformType::Pointer finalTransform =
-            TransformType::New();
-    finalTransform->SetParameters( initialParameters );
-    finalTransform->SetFixedParameters( transform->GetFixedParameters() );
+  TransformType::Pointer finalTransform = TransformType::New();
+  finalTransform->SetParameters(initialParameters);
+  finalTransform->SetFixedParameters(transform->GetFixedParameters());
 
-    using ResampleFilterType = itk::ResampleImageFilter< InputImageType, InputImageType >;
-    ResampleFilterType::Pointer resample =
-            ResampleFilterType::New();
-    resample->SetTransform( finalTransform );
-    resample->SetInput( movingImage);
-    resample->SetSize( fixedImage->GetLargestPossibleRegion().GetSize() );
-    resample->SetOutputOrigin( fixedImage->GetOrigin() );
-    resample->SetOutputSpacing( fixedImage->GetSpacing() );
-    resample->SetOutputDirection( fixedImage->GetDirection() );
-    resample->SetDefaultPixelValue( 100 );
-    resample->Update();
+  using ResampleFilterType = itk::ResampleImageFilter<InputImageType, InputImageType>;
+  ResampleFilterType::Pointer resample = ResampleFilterType::New();
+  resample->SetTransform(finalTransform);
+  resample->SetInput(movingImage);
+  resample->SetSize(fixedImage->GetLargestPossibleRegion().GetSize());
+  resample->SetOutputOrigin(fixedImage->GetOrigin());
+  resample->SetOutputSpacing(fixedImage->GetSpacing());
+  resample->SetOutputDirection(fixedImage->GetDirection());
+  resample->SetDefaultPixelValue(100);
+  resample->Update();
 
-    // Set up the visualization pipeline
-    using CheckerBoardFilterType = itk::CheckerBoardImageFilter< InputImageType >;
-    CheckerBoardFilterType::Pointer checkerboard =
-            CheckerBoardFilterType::New();
-    CheckerBoardFilterType::PatternArrayType pattern;
-    pattern[0] = 4;
-    pattern[1] = 4;
+  // Set up the visualization pipeline
+  using CheckerBoardFilterType = itk::CheckerBoardImageFilter<InputImageType>;
+  CheckerBoardFilterType::Pointer          checkerboard = CheckerBoardFilterType::New();
+  CheckerBoardFilterType::PatternArrayType pattern;
+  pattern[0] = 4;
+  pattern[1] = 4;
 
-    checkerboard->SetCheckerPattern( pattern );
-    checkerboard->SetInput1( fixedImage);
-    checkerboard->SetInput2( resample->GetOutput());
+  checkerboard->SetCheckerPattern(pattern);
+  checkerboard->SetInput1(fixedImage);
+  checkerboard->SetInput2(resample->GetOutput());
 
-    using FlipFilterType = itk::FlipImageFilter< InputImageType>;
-    FlipFilterType::Pointer flip =
-            FlipFilterType::New();
-    bool flipAxes[3] = { false, true, false };
-    flip->SetFlipAxes(flipAxes);
-    flip->SetInput(checkerboard->GetOutput());
-    flip->Update();
+  using FlipFilterType = itk::FlipImageFilter<InputImageType>;
+  FlipFilterType::Pointer flip = FlipFilterType::New();
+  bool                    flipAxes[3] = { false, true, false };
+  flip->SetFlipAxes(flipAxes);
+  flip->SetInput(checkerboard->GetOutput());
+  flip->Update();
 
-    // VTK visualization pipeline
-    using ConnectorType = itk::ImageToVTKImageFilter<InputImageType >;
-    ConnectorType::Pointer connector =
-            ConnectorType::New();
-    connector->SetInput(flip->GetOutput());
+  // VTK visualization pipeline
+  using ConnectorType = itk::ImageToVTKImageFilter<InputImageType>;
+  ConnectorType::Pointer connector = ConnectorType::New();
+  connector->SetInput(flip->GetOutput());
 
-    vtkSmartPointer<vtkImageActor> actor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor->SetInput(connector->GetOutput());
+  actor->SetInput(connector->GetOutput());
 #else
-    connector->Update();
+  connector->Update();
   actor->GetMapper()->SetInputData(connector->GetOutput());
 #endif
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
-    vtkSmartPointer<vtkRenderer> renderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderer->SetBackground(.4, .5, .6);
-    renderer->AddActor(actor);
-    renderWindow->SetSize(640, 480);;
-    renderWindow->AddRenderer(renderer);
-    renderWindow->Render();
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+  vtkSmartPointer<vtkRenderer>     renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderer->SetBackground(.4, .5, .6);
+  renderer->AddActor(actor);
+  renderWindow->SetSize(640, 480);
+  ;
+  renderWindow->AddRenderer(renderer);
+  renderWindow->Render();
 
-    // Set up the iteration event observer
-    IterationUpdate<InputImageType>::Pointer observer =
-            IterationUpdate<InputImageType>::New();
-    optimizer->AddObserver( itk::IterationEvent(), observer );
+  // Set up the iteration event observer
+  IterationUpdate<InputImageType>::Pointer observer = IterationUpdate<InputImageType>::New();
+  optimizer->AddObserver(itk::IterationEvent(), observer);
 
-    observer->SetTransform(finalTransform);
-    observer->SetFilter(flip);
-    observer->SetConnector(connector);
-    observer->SetImageActor(actor);
-    observer->SetRenderWindow(renderWindow);
-    try
-    {
-        registration->Update();
-        std::cout << "Optimizer stop condition: "
-                  << registration->GetOptimizer()->GetStopConditionDescription()
-                  << std::endl;
-    }
-    catch( itk::ExceptionObject & err )
-    {
-        std::cout << "ExceptionObject caught !" << std::endl;
-        std::cout << err << std::endl;
-        return EXIT_FAILURE;
-    }
-    std::cout << "Final Transform: " << finalTransform << std::endl;
+  observer->SetTransform(finalTransform);
+  observer->SetFilter(flip);
+  observer->SetConnector(connector);
+  observer->SetImageActor(actor);
+  observer->SetRenderWindow(renderWindow);
+  try
+  {
+    registration->Update();
+    std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
+              << std::endl;
+  }
+  catch (itk::ExceptionObject & err)
+  {
+    std::cout << "ExceptionObject caught !" << std::endl;
+    std::cout << err << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::cout << "Final Transform: " << finalTransform << std::endl;
 
-    ParametersType finalParameters = registration->GetLastTransformParameters();
-    std::cout << "Final Parameters: " << finalParameters << std::endl;
+  ParametersType finalParameters = registration->GetLastTransformParameters();
+  std::cout << "Final Parameters: " << finalParameters << std::endl;
 
-    unsigned int numberOfIterations = optimizer->GetCurrentIteration();
-    double bestValue = optimizer->GetValue();
+  unsigned int numberOfIterations = optimizer->GetCurrentIteration();
+  double       bestValue = optimizer->GetValue();
 
-    // Print out results
-    std::cout << std::endl;
-    std::cout << "Result = " << std::endl;
-    std::cout << " Iterations    = " << numberOfIterations << std::endl;
-    std::cout << " Metric value  = " << bestValue          << std::endl;
-    std::cout << " Numb. Samples = " << numberOfSamples    << std::endl;
+  // Print out results
+  std::cout << std::endl;
+  std::cout << "Result = " << std::endl;
+  std::cout << " Iterations    = " << numberOfIterations << std::endl;
+  std::cout << " Metric value  = " << bestValue << std::endl;
+  std::cout << " Numb. Samples = " << numberOfSamples << std::endl;
 
-    // Interact with the image
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
-    interactor->SetInteractorStyle(style);
-    interactor->SetRenderWindow(renderWindow);
-    interactor->Start();
+  // Interact with the image
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  vtkSmartPointer<vtkInteractorStyleImage>   style = vtkSmartPointer<vtkInteractorStyleImage>::New();
+  interactor->SetInteractorStyle(style);
+  interactor->SetRenderWindow(renderWindow);
+  interactor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/Code.cxx
+++ b/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/Code.cxx
@@ -1,20 +1,20 @@
 /*=========================================================================
-*
-*  Copyright Insight Software Consortium
-*
-*  Licensed under the Apache License, Version 2.0 (the "License");
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*         http://www.apache.org/licenses/LICENSE-2.0.txt
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an "AS IS" BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*
-*=========================================================================*/
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
 
 #include "itkMeanSquaresImageToImageMetricv4.h"
 #include "itkGradientDescentOptimizerv4.h"
@@ -31,11 +31,12 @@
 
 #include <iomanip>
 
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
 
-  if( argc < 4 )
-    {
+  if (argc < 4)
+  {
     std::cerr << "Missing Parameters " << std::endl;
     std::cerr << "Usage: " << argv[0];
     std::cerr << " fixedImageFile movingImageFile ";
@@ -43,133 +44,128 @@ int main(int argc, char *argv[])
     std::cerr << " [numberOfAffineIterations numberOfDisplacementIterations] ";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   const char * fixedImageFile = argv[1];
   const char * movingImageFile = argv[2];
   const char * resampledMovingImageFile = argv[3];
 
   unsigned int numberOfAffineIterations = 2;
   unsigned int numberOfDisplacementIterations = 2;
-  if( argc >= 5 )
-    {
-    numberOfAffineIterations = std::stoi( argv[4] );
-    }
-  if( argc >= 6 )
-    {
-    numberOfDisplacementIterations = std::stoi( argv[5] );
-    }
+  if (argc >= 5)
+  {
+    numberOfAffineIterations = std::stoi(argv[4]);
+  }
+  if (argc >= 6)
+  {
+    numberOfDisplacementIterations = std::stoi(argv[5]);
+  }
 
   constexpr unsigned int Dimension = 2;
 
   // The input images have red, blue, and green pixel components.
   constexpr unsigned int NumberOfPixelComponents = 3;
   using PixelComponentType = float;
-  using InputPixelType = itk::Vector< PixelComponentType, NumberOfPixelComponents >;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputPixelType = itk::Vector<PixelComponentType, NumberOfPixelComponents>;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   using ParametersValueType = double;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer fixedImageReader = ReaderType::New();
-  fixedImageReader->SetFileName( fixedImageFile );
+  fixedImageReader->SetFileName(fixedImageFile);
   ReaderType::Pointer movingImageReader = ReaderType::New();
-  movingImageReader->SetFileName( movingImageFile );
+  movingImageReader->SetFileName(movingImageFile);
 
   // Get the input images
   try
-    {
+  {
     fixedImageReader->Update();
     movingImageReader->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error while reading images: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
   InputImageType::Pointer fixedImage = fixedImageReader->GetOutput();
   InputImageType::Pointer movingImage = movingImageReader->GetOutput();
 
-  using AffineTransformType = itk::AffineTransform< ParametersValueType, Dimension >;
+  using AffineTransformType = itk::AffineTransform<ParametersValueType, Dimension>;
   AffineTransformType::Pointer affineTransform = AffineTransformType::New();
 
-  using DisplacementTransformType = itk::GaussianSmoothingOnUpdateDisplacementFieldTransform<
-    ParametersValueType, Dimension >;
-  DisplacementTransformType::Pointer displacementTransform =
-    DisplacementTransformType::New();
+  using DisplacementTransformType =
+    itk::GaussianSmoothingOnUpdateDisplacementFieldTransform<ParametersValueType, Dimension>;
+  DisplacementTransformType::Pointer displacementTransform = DisplacementTransformType::New();
 
   using DisplacementFieldType = DisplacementTransformType::DisplacementFieldType;
-  DisplacementFieldType::Pointer displacementField =
-    DisplacementFieldType::New();
+  DisplacementFieldType::Pointer displacementField = DisplacementFieldType::New();
 
   // Set the displacement field to be the same as the fixed image region, which will
   // act by default as the virtual domain in this example.
-  displacementField->SetRegions( fixedImage->GetLargestPossibleRegion() );
+  displacementField->SetRegions(fixedImage->GetLargestPossibleRegion());
   // make sure the displacement field has the same spatial information as the image
-  displacementField->CopyInformation( fixedImage );
-  std::cout << "fixedImage->GetLargestPossibleRegion(): "
-    << fixedImage->GetLargestPossibleRegion() << std::endl;
+  displacementField->CopyInformation(fixedImage);
+  std::cout << "fixedImage->GetLargestPossibleRegion(): " << fixedImage->GetLargestPossibleRegion() << std::endl;
   displacementField->Allocate();
   // Fill it with 0's
   DisplacementTransformType::OutputVectorType zeroVector;
-  zeroVector.Fill( 0.0 );
-  displacementField->FillBuffer( zeroVector );
+  zeroVector.Fill(0.0);
+  displacementField->FillBuffer(zeroVector);
   // Assign to transform
-  displacementTransform->SetDisplacementField( displacementField );
-  displacementTransform->SetGaussianSmoothingVarianceForTheUpdateField( 5.0 );
-  displacementTransform->SetGaussianSmoothingVarianceForTheTotalField( 6.0 );
+  displacementTransform->SetDisplacementField(displacementField);
+  displacementTransform->SetGaussianSmoothingVarianceForTheUpdateField(5.0);
+  displacementTransform->SetGaussianSmoothingVarianceForTheTotalField(6.0);
 
   // Identity transform for fixed image
-  using IdentityTransformType = itk::IdentityTransform< ParametersValueType, Dimension >;
-  IdentityTransformType::Pointer identityTransform =
-    IdentityTransformType::New();
+  using IdentityTransformType = itk::IdentityTransform<ParametersValueType, Dimension>;
+  IdentityTransformType::Pointer identityTransform = IdentityTransformType::New();
 
   // The metric
-  using VirtualImageType = itk::Image< double, Dimension>;
-  using MetricTraitsType = itk::VectorImageToImageMetricTraitsv4<
-    InputImageType, InputImageType, VirtualImageType, InputPixelType::Length >;
-  using MetricType = itk::MeanSquaresImageToImageMetricv4<
-    InputImageType, InputImageType, VirtualImageType, double, MetricTraitsType >;
+  using VirtualImageType = itk::Image<double, Dimension>;
+  using MetricTraitsType =
+    itk::VectorImageToImageMetricTraitsv4<InputImageType, InputImageType, VirtualImageType, InputPixelType::Length>;
+  using MetricType =
+    itk::MeanSquaresImageToImageMetricv4<InputImageType, InputImageType, VirtualImageType, double, MetricTraitsType>;
   using PointSetType = MetricType::FixedSampledPointSetType;
   MetricType::Pointer metric = MetricType::New();
 
   using PointType = PointSetType::PointType;
-  PointSetType::Pointer pointSet = PointSetType::New();
-  itk::ImageRegionIteratorWithIndex< InputImageType > fixedImageIt( fixedImage,
-    fixedImage->GetLargestPossibleRegion() );
-  itk::SizeValueType index = 0;
-  itk::SizeValueType count = 0;
-  for( fixedImageIt.GoToBegin(); !fixedImageIt.IsAtEnd(); ++fixedImageIt )
-    {
+  PointSetType::Pointer                             pointSet = PointSetType::New();
+  itk::ImageRegionIteratorWithIndex<InputImageType> fixedImageIt(fixedImage, fixedImage->GetLargestPossibleRegion());
+  itk::SizeValueType                                index = 0;
+  itk::SizeValueType                                count = 0;
+  for (fixedImageIt.GoToBegin(); !fixedImageIt.IsAtEnd(); ++fixedImageIt)
+  {
     // take every N^th point
-    if ( count % 2 == 0  )
-      {
+    if (count % 2 == 0)
+    {
       PointType point;
-      fixedImage->TransformIndexToPhysicalPoint( fixedImageIt.GetIndex(), point );
-      pointSet->SetPoint( index, point );
+      fixedImage->TransformIndexToPhysicalPoint(fixedImageIt.GetIndex(), point);
+      pointSet->SetPoint(index, point);
       ++index;
-      }
-      ++count;
     }
-  metric->SetFixedSampledPointSet( pointSet );
-  metric->SetUseSampledPointSet( true );
+    ++count;
+  }
+  metric->SetFixedSampledPointSet(pointSet);
+  metric->SetUseSampledPointSet(true);
 
 
   // Assign images and transforms.
   // By not setting a virtual domain image or virtual domain settings,
   // the metric will use the fixed image for the virtual domain.
-  metric->SetFixedImage( fixedImage );
-  metric->SetMovingImage( movingImage );
-  metric->SetFixedTransform( identityTransform );
-  metric->SetMovingTransform( affineTransform );
+  metric->SetFixedImage(fixedImage);
+  metric->SetMovingImage(movingImage);
+  metric->SetFixedTransform(identityTransform);
+  metric->SetMovingTransform(affineTransform);
   const bool gaussian = false;
-  metric->SetUseMovingImageGradientFilter( gaussian );
-  metric->SetUseFixedImageGradientFilter( gaussian );
+  metric->SetUseMovingImageGradientFilter(gaussian);
+  metric->SetUseFixedImageGradientFilter(gaussian);
   metric->Initialize();
 
-  using RegistrationParameterScalesFromShiftType = itk::RegistrationParameterScalesFromPhysicalShift< MetricType >;
+  using RegistrationParameterScalesFromShiftType = itk::RegistrationParameterScalesFromPhysicalShift<MetricType>;
   RegistrationParameterScalesFromShiftType::Pointer shiftScaleEstimator =
     RegistrationParameterScalesFromShiftType::New();
-  shiftScaleEstimator->SetMetric( metric );
+  shiftScaleEstimator->SetMetric(metric);
 
 
   //
@@ -177,79 +173,77 @@ int main(int argc, char *argv[])
   //
   std::cout << "First do an affine registration..." << std::endl;
   using OptimizerType = itk::GradientDescentOptimizerv4;
-  OptimizerType::Pointer  optimizer = OptimizerType::New();
-  optimizer->SetMetric( metric );
-  optimizer->SetNumberOfIterations( numberOfAffineIterations );
-  optimizer->SetScalesEstimator( shiftScaleEstimator );
+  OptimizerType::Pointer optimizer = OptimizerType::New();
+  optimizer->SetMetric(metric);
+  optimizer->SetNumberOfIterations(numberOfAffineIterations);
+  optimizer->SetScalesEstimator(shiftScaleEstimator);
   optimizer->StartOptimization();
-  std::cout << "After optimization affine parameters are: "
-    << affineTransform->GetParameters() << std::endl;
+  std::cout << "After optimization affine parameters are: " << affineTransform->GetParameters() << std::endl;
 
   //
   // Deformable registration
   //
-  std::cout << "Now, add the displacement field to the composite transform..."
-    << std::endl;
-  using CompositeType = itk::CompositeTransform< ParametersValueType, Dimension>;
+  std::cout << "Now, add the displacement field to the composite transform..." << std::endl;
+  using CompositeType = itk::CompositeTransform<ParametersValueType, Dimension>;
   CompositeType::Pointer compositeTransform = CompositeType::New();
-  compositeTransform->AddTransform( affineTransform );
-  compositeTransform->AddTransform( displacementTransform );
+  compositeTransform->AddTransform(affineTransform);
+  compositeTransform->AddTransform(displacementTransform);
   // Optimize only the displacement field, but still using the
   // previously computed affine transformation.
   compositeTransform->SetOnlyMostRecentTransformToOptimizeOn();
-  metric->SetMovingTransform( compositeTransform );
-  metric->SetUseSampledPointSet( false );
+  metric->SetMovingTransform(compositeTransform);
+  metric->SetUseSampledPointSet(false);
   metric->Initialize();
 
   // Optimizer
-  optimizer->SetScalesEstimator( shiftScaleEstimator );
-  optimizer->SetMetric( metric );
-  optimizer->SetNumberOfIterations( numberOfDisplacementIterations );
+  optimizer->SetScalesEstimator(shiftScaleEstimator);
+  optimizer->SetMetric(metric);
+  optimizer->SetNumberOfIterations(numberOfDisplacementIterations);
   try
+  {
+    if (numberOfDisplacementIterations > 0)
     {
-    if( numberOfDisplacementIterations > 0 )
-      {
       optimizer->StartOptimization();
-      }
-    else
-      {
-      std::cout << "*** Skipping displacement field optimization.\n";
-      }
     }
-  catch( itk::ExceptionObject & error )
+    else
     {
+      std::cout << "*** Skipping displacement field optimization.\n";
+    }
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Warp the image with the displacement field
-  using ResampleFilterType = itk::ResampleImageFilter< InputImageType, InputImageType >;
+  using ResampleFilterType = itk::ResampleImageFilter<InputImageType, InputImageType>;
   ResampleFilterType::Pointer resampler = ResampleFilterType::New();
-  resampler->SetTransform( compositeTransform );
-  resampler->SetInput( movingImageReader->GetOutput() );
-  resampler->SetReferenceImage( fixedImage );
-  resampler->SetUseReferenceImage( true );
+  resampler->SetTransform(compositeTransform);
+  resampler->SetInput(movingImageReader->GetOutput());
+  resampler->SetReferenceImage(fixedImage);
+  resampler->SetUseReferenceImage(true);
 
   // Write the warped image into a file
-  using OutputPixelType = itk::Vector< unsigned char, NumberOfPixelComponents >;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
-  using CastFilterType = itk::CastImageFilter< InputImageType, OutputImageType >;
+  using OutputPixelType = itk::Vector<unsigned char, NumberOfPixelComponents>;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
+  using CastFilterType = itk::CastImageFilter<InputImageType, OutputImageType>;
   CastFilterType::Pointer caster = CastFilterType::New();
-  caster->SetInput( resampler->GetOutput() );
+  caster->SetInput(resampler->GetOutput());
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
-  WriterType::Pointer writer =  WriterType::New();
-  writer->SetFileName( resampledMovingImageFile );
-  writer->SetInput( caster->GetOutput() );
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName(resampledMovingImageFile);
+  writer->SetInput(caster->GetOutput());
   try
-    {
+  {
     writer->UpdateLargestPossibleRegion();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Remote/WikiExamples/DisplayITKImage/Code.cxx
+++ b/src/Remote/WikiExamples/DisplayITKImage/Code.cxx
@@ -29,54 +29,49 @@
 #include "vtkInteractorStyleImage.h"
 #include "vtkRenderer.h"
 #include "itkRGBPixel.h"
-int main(int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if( argc < 2 )
-    {
-        std::cerr << "Usage: " << std::endl;
-        std::cerr << argv[0] << " inputImageFile" << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cerr << "Usage: " << std::endl;
+    std::cerr << argv[0] << " inputImageFile" << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using ImageType = itk::Image<itk::RGBPixel<unsigned char>, 2>;
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  using ImageType = itk::Image<itk::RGBPixel<unsigned char>, 2>;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
 
-    ReaderType::Pointer reader = ReaderType::New();
-    ConnectorType::Pointer connector = ConnectorType::New();
+  ReaderType::Pointer    reader = ReaderType::New();
+  ConnectorType::Pointer connector = ConnectorType::New();
 
-    reader->SetFileName(argv[1]);
-    connector->SetInput(reader->GetOutput());
+  reader->SetFileName(argv[1]);
+  connector->SetInput(reader->GetOutput());
 
-    vtkSmartPointer<vtkImageActor> actor =
-            vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
-    actor->SetInput(connector->GetOutput());
+  actor->SetInput(connector->GetOutput());
 #else
-    connector->Update();
+  connector->Update();
   actor->GetMapper()->SetInputData(connector->GetOutput());
 #endif
-    vtkSmartPointer<vtkRenderer> renderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderer->AddActor(actor);
-    renderer->ResetCamera();
+  vtkSmartPointer<vtkRenderer> renderer = vtkSmartPointer<vtkRenderer>::New();
+  renderer->AddActor(actor);
+  renderer->ResetCamera();
 
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
-    renderWindow->AddRenderer(renderer);
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+  renderWindow->AddRenderer(renderer);
 
-    vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
+  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  vtkSmartPointer<vtkInteractorStyleImage>   style = vtkSmartPointer<vtkInteractorStyleImage>::New();
 
-    renderWindowInteractor->SetInteractorStyle(style);
+  renderWindowInteractor->SetInteractorStyle(style);
 
-    renderWindowInteractor->SetRenderWindow(renderWindow);
-    renderWindowInteractor->Initialize();
+  renderWindowInteractor->SetRenderWindow(renderWindow);
+  renderWindowInteractor->Initialize();
 
-    renderWindowInteractor->Start();
+  renderWindowInteractor->Start();
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Segmentation/Classifiers/KMeansClustering/Code.cxx
+++ b/src/Segmentation/Classifiers/KMeansClustering/Code.cxx
@@ -20,45 +20,45 @@
 #include <itkImageFileWriter.h>
 #include <itkScalarImageKmeansImageFilter.h>
 
-int main( int argc, char * argv [] )
+int
+main(int argc, char * argv[])
 {
-  //sample usage
+  // sample usage
   //./kMeansClustering input.jpg output.jpg 1 3 0 100 200
 
-  //verify command line arguments
-  if( argc < 5 )
-    {
+  // verify command line arguments
+  if (argc < 5)
+  {
     std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " inputScalarImage outputLabeledImage contiguousLabels";
     std::cerr << " numberOfClasses mean1 mean2... meanN " << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  //parse command line arguments
-  const char * inputImageFileName = argv[1];
-  const char * outputImageFileName = argv[2];
-  const unsigned int useNonContiguousLabels = std::stoi( argv[3] );
-  const unsigned int numberOfInitialClasses = std::stoi( argv[4] );
+  // parse command line arguments
+  const char *       inputImageFileName = argv[1];
+  const char *       outputImageFileName = argv[2];
+  const unsigned int useNonContiguousLabels = std::stoi(argv[3]);
+  const unsigned int numberOfInitialClasses = std::stoi(argv[4]);
 
   constexpr unsigned int argoffset = 5;
 
-  if( static_cast<unsigned int>(argc) <
-      numberOfInitialClasses + argoffset )
-    {
+  if (static_cast<unsigned int>(argc) < numberOfInitialClasses + argoffset)
+  {
     std::cerr << "Error: " << std::endl;
     std::cerr << numberOfInitialClasses << " classes has been specified ";
     std::cerr << "but no enough means have been provided in the command ";
     std::cerr << "line arguments " << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   std::vector<double> userMeans;
-  for( unsigned k = 0; k < numberOfInitialClasses; k++ )
-    {
-    const double userProvidedInitialMean = std::stod( argv[k+argoffset] );
+  for (unsigned k = 0; k < numberOfInitialClasses; k++)
+  {
+    const double userProvidedInitialMean = std::stod(argv[k + argoffset]);
     userMeans.push_back(userProvidedInitialMean);
-    }
+  }
 
   // Define the pixel type and dimension of the image that we intend to
   // classify.
@@ -66,69 +66,66 @@ int main( int argc, char * argv [] )
   using PixelType = signed short;
   constexpr unsigned int Dimension = 2;
 
-  using ImageType = itk::Image<PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
   // create a reader
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputImageFileName );
+  reader->SetFileName(inputImageFileName);
 
   // Instantiate the ScalarImageKmeansImageFilter
-  using KMeansFilterType = itk::ScalarImageKmeansImageFilter< ImageType >;
+  using KMeansFilterType = itk::ScalarImageKmeansImageFilter<ImageType>;
 
   KMeansFilterType::Pointer kmeansFilter = KMeansFilterType::New();
 
-  kmeansFilter->SetInput( reader->GetOutput() );
+  kmeansFilter->SetInput(reader->GetOutput());
 
   // Make the output image intellegable by expanding the range of output image values, if desired
 
-  kmeansFilter->SetUseNonContiguousLabels( useNonContiguousLabels );
+  kmeansFilter->SetUseNonContiguousLabels(useNonContiguousLabels);
 
   // initialize using the user input means
 
-    for( unsigned k = 0; k < numberOfInitialClasses; k++ )
-    {
-    kmeansFilter->AddClassWithInitialMean( userMeans[k] );
-    }
+  for (unsigned k = 0; k < numberOfInitialClasses; k++)
+  {
+    kmeansFilter->AddClassWithInitialMean(userMeans[k]);
+  }
 
   // Create and setup a writer
 
   using OutputImageType = KMeansFilterType::OutputImageType;
 
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
 
   WriterType::Pointer writer = WriterType::New();
 
-  writer->SetInput( kmeansFilter->GetOutput() );
+  writer->SetInput(kmeansFilter->GetOutput());
 
-  writer->SetFileName( outputImageFileName );
+  writer->SetFileName(outputImageFileName);
 
   // execut the pipeline
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & excp )
-    {
+  }
+  catch (itk::ExceptionObject & excp)
+  {
     std::cerr << "Problem encountered while writing ";
     std::cerr << " image file : " << outputImageFileName << std::endl;
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // inspect the means
-  KMeansFilterType::ParametersType estimatedMeans =
-                                            kmeansFilter->GetFinalMeans();
+  KMeansFilterType::ParametersType estimatedMeans = kmeansFilter->GetFinalMeans();
 
   const unsigned int numberOfClasses = estimatedMeans.Size();
 
-  for ( unsigned int i = 0; i < numberOfClasses; ++i )
-    {
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
+  {
     std::cout << "cluster[" << i << "] ";
     std::cout << "    estimated mean : " << estimatedMeans[i] << std::endl;
-    }
+  }
 
   return EXIT_SUCCESS;
-
 }
-

--- a/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/Code.cxx
+++ b/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/Code.cxx
@@ -25,130 +25,114 @@
 #include "itkRelabelComponentImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 using RGBPixelType = itk::RGBPixel<unsigned char>;
 using RGBImageType = itk::Image<RGBPixelType, 2>;
 using ImageType = itk::Image<unsigned char, 2>;
-using ColormapType = itk::Function::CustomColormapFunction<
-        ImageType::PixelType, RGBImageType::PixelType>;
+using ColormapType = itk::Function::CustomColormapFunction<ImageType::PixelType, RGBImageType::PixelType>;
 
-static void CreateImage(
-        ImageType::Pointer image);
-static void CreateRandomColormap(\
-  unsigned int size, ColormapType::Pointer colormap);
+static void
+CreateImage(ImageType::Pointer image);
+static void
+CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap);
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-    ImageType::Pointer image = ImageType::New();
+  ImageType::Pointer image = ImageType::New();
 
-    CreateImage(image);
+  CreateImage(image);
 
-    using FilterType = itk::RelabelComponentImageFilter<ImageType, ImageType>;
-    FilterType::Pointer relabelFilter =
-            FilterType::New();
-    relabelFilter->SetInput(image);
+  using FilterType = itk::RelabelComponentImageFilter<ImageType, ImageType>;
+  FilterType::Pointer relabelFilter = FilterType::New();
+  relabelFilter->SetInput(image);
 
-    using ColormapFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
-    ColormapFilterType::Pointer colormapFilter1 =
-            ColormapFilterType::New();
+  using ColormapFilterType = itk::ScalarToRGBColormapImageFilter<ImageType, RGBImageType>;
+  ColormapFilterType::Pointer colormapFilter1 = ColormapFilterType::New();
 
-    ColormapType::Pointer largeColormap
-            = ColormapType::New();
-    CreateRandomColormap(255, largeColormap);
+  ColormapType::Pointer largeColormap = ColormapType::New();
+  CreateRandomColormap(255, largeColormap);
 
-    colormapFilter1->SetInput (image);
-    colormapFilter1->SetColormap(largeColormap);
+  colormapFilter1->SetInput(image);
+  colormapFilter1->SetColormap(largeColormap);
 
-    ColormapFilterType::Pointer colormapFilter2 =
-            ColormapFilterType::New();
-    colormapFilter2->SetInput (relabelFilter->GetOutput());
-    colormapFilter2->SetColormap(largeColormap);
+  ColormapFilterType::Pointer colormapFilter2 = ColormapFilterType::New();
+  colormapFilter2->SetInput(relabelFilter->GetOutput());
+  colormapFilter2->SetColormap(largeColormap);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddRGBImage(
-            colormapFilter1->GetOutput(),
-            true,
-            "Original");
+  QuickView viewer;
+  viewer.AddRGBImage(colormapFilter1->GetOutput(), true, "Original");
 
-    viewer.AddRGBImage(
-            colormapFilter2->GetOutput(),
-            true,
-            "Relabeled");
+  viewer.AddRGBImage(colormapFilter2->GetOutput(), true, "Relabeled");
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    size[0] = 200;
-    size[1] = 300;
+  ImageType::SizeType size;
+  size[0] = 200;
+  size[1] = 300;
 
-    region.SetSize(size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    itk::ImageRegionIterator<ImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<ImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 100 && imageIterator.GetIndex()[0] < 150 && imageIterator.GetIndex()[1] > 100 &&
+        imageIterator.GetIndex()[1] < 150)
     {
-        if(imageIterator.GetIndex()[0] > 100 &&
-           imageIterator.GetIndex()[0] < 150 &&
-           imageIterator.GetIndex()[1] > 100 &&
-           imageIterator.GetIndex()[1] < 150)
-        {
-            imageIterator.Set(200);
-        }
-        else if(imageIterator.GetIndex()[0] > 50 &&
-                imageIterator.GetIndex()[0] < 70 &&
-                imageIterator.GetIndex()[1] > 50 &&
-                imageIterator.GetIndex()[1] < 70)
-        {
-            imageIterator.Set(100);
-        }
-        else
-        {
-            imageIterator.Set(0);
-        }
-
-        ++imageIterator;
+      imageIterator.Set(200);
     }
+    else if (imageIterator.GetIndex()[0] > 50 && imageIterator.GetIndex()[0] < 70 && imageIterator.GetIndex()[1] > 50 &&
+             imageIterator.GetIndex()[1] < 70)
+    {
+      imageIterator.Set(100);
+    }
+    else
+    {
+      imageIterator.Set(0);
+    }
+
+    ++imageIterator;
+  }
 }
 
-void CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap)
+void
+CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap)
 {
-    ColormapType::ChannelType redChannel;
-    ColormapType::ChannelType greenChannel;
-    ColormapType::ChannelType blueChannel;
-    itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer random =
-            itk::Statistics::MersenneTwisterRandomVariateGenerator::New();
+  ColormapType::ChannelType                                       redChannel;
+  ColormapType::ChannelType                                       greenChannel;
+  ColormapType::ChannelType                                       blueChannel;
+  itk::Statistics::MersenneTwisterRandomVariateGenerator::Pointer random =
+    itk::Statistics::MersenneTwisterRandomVariateGenerator::New();
 
-    random->SetSeed ( 8775070 );
-    for (unsigned int i = 0; i < size; ++i)
-    {
-        redChannel.push_back(static_cast<ColormapType::RealType>
-                             (random->GetUniformVariate(.3, 1.0)));
-        greenChannel.push_back(static_cast<ColormapType::RealType>
-                               (random->GetUniformVariate(.3, 1.0)));
-        blueChannel.push_back(static_cast<ColormapType::RealType>
-                              (random->GetUniformVariate(.3, 1.0)));
-    }
-    colormap->SetRedChannel(redChannel);
-    colormap->SetGreenChannel(greenChannel);
-    colormap->SetBlueChannel(blueChannel);
+  random->SetSeed(8775070);
+  for (unsigned int i = 0; i < size; ++i)
+  {
+    redChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(.3, 1.0)));
+    greenChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(.3, 1.0)));
+    blueChannel.push_back(static_cast<ColormapType::RealType>(random->GetUniformVariate(.3, 1.0)));
+  }
+  colormap->SetRedChannel(redChannel);
+  colormap->SetGreenChannel(greenChannel);
+  colormap->SetBlueChannel(blueChannel);
 }
-

--- a/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/Code.cxx
+++ b/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/Code.cxx
@@ -25,62 +25,60 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if( argc < 2 )
-    {
-        std::cout << "Usage:" << std::endl;
-        std::cout << argv[0] << " InputFileName" << std::endl;
-    }
-    constexpr unsigned int Dimension = 2;
-    using PixelType = unsigned char;
-    using ImageType = itk::Image< PixelType, Dimension >;
+  if (argc < 2)
+  {
+    std::cout << "Usage:" << std::endl;
+    std::cout << argv[0] << " InputFileName" << std::endl;
+  }
+  constexpr unsigned int Dimension = 2;
+  using PixelType = unsigned char;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    using ReaderType = itk::ImageFileReader< ImageType >;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( argv[1] );
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
-    using OutputImageType = itk::Image< unsigned short, Dimension >;
+  using OutputImageType = itk::Image<unsigned short, Dimension>;
 
-    using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter <ImageType, OutputImageType >;
+  using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter<ImageType, OutputImageType>;
 
-    ConnectedComponentImageFilterType::Pointer connected = ConnectedComponentImageFilterType::New ();
-    connected->SetInput(reader->GetOutput());
-    connected->Update();
+  ConnectedComponentImageFilterType::Pointer connected = ConnectedComponentImageFilterType::New();
+  connected->SetInput(reader->GetOutput());
+  connected->Update();
 
-    std::cout << "Number of objects: " << connected->GetObjectCount() << std::endl;
+  std::cout << "Number of objects: " << connected->GetObjectCount() << std::endl;
 
-    using LabelShapeKeepNObjectsImageFilterType = itk::LabelShapeKeepNObjectsImageFilter< OutputImageType >;
-    LabelShapeKeepNObjectsImageFilterType::Pointer labelShapeKeepNObjectsImageFilter = LabelShapeKeepNObjectsImageFilterType::New();
-    labelShapeKeepNObjectsImageFilter->SetInput( connected->GetOutput() );
-    labelShapeKeepNObjectsImageFilter->SetBackgroundValue( 0 );
-    labelShapeKeepNObjectsImageFilter->SetNumberOfObjects( 1 );
-    labelShapeKeepNObjectsImageFilter->SetAttribute( LabelShapeKeepNObjectsImageFilterType::LabelObjectType::NUMBER_OF_PIXELS);
+  using LabelShapeKeepNObjectsImageFilterType = itk::LabelShapeKeepNObjectsImageFilter<OutputImageType>;
+  LabelShapeKeepNObjectsImageFilterType::Pointer labelShapeKeepNObjectsImageFilter =
+    LabelShapeKeepNObjectsImageFilterType::New();
+  labelShapeKeepNObjectsImageFilter->SetInput(connected->GetOutput());
+  labelShapeKeepNObjectsImageFilter->SetBackgroundValue(0);
+  labelShapeKeepNObjectsImageFilter->SetNumberOfObjects(1);
+  labelShapeKeepNObjectsImageFilter->SetAttribute(
+    LabelShapeKeepNObjectsImageFilterType::LabelObjectType::NUMBER_OF_PIXELS);
 
-    using RescaleFilterType = itk::RescaleIntensityImageFilter< OutputImageType, ImageType >;
-    RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
-    rescaleFilter->SetOutputMinimum(0);
-    rescaleFilter->SetOutputMaximum(itk::NumericTraits<PixelType>::max());
-    rescaleFilter->SetInput(labelShapeKeepNObjectsImageFilter->GetOutput());
+  using RescaleFilterType = itk::RescaleIntensityImageFilter<OutputImageType, ImageType>;
+  RescaleFilterType::Pointer rescaleFilter = RescaleFilterType::New();
+  rescaleFilter->SetOutputMinimum(0);
+  rescaleFilter->SetOutputMaximum(itk::NumericTraits<PixelType>::max());
+  rescaleFilter->SetInput(labelShapeKeepNObjectsImageFilter->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    std::stringstream desc;
-    desc << "Largest object of " << connected->GetObjectCount() << " objects";
-    viewer.AddImage(
-            rescaleFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Largest object of " << connected->GetObjectCount() << " objects";
+  viewer.AddImage(rescaleFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/Code.cxx
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/Code.cxx
@@ -37,104 +37,99 @@
 #include <sstream>
 #include <map>
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-int main(int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-    if( argc < 2 )
-    {
-        std::cout << "Usage: " << argv[0];
-        std::cout << " inputImageFile";
-        std::cerr << std::endl;
-        return EXIT_FAILURE;
-    }
+  if (argc < 2)
+  {
+    std::cout << "Usage: " << argv[0];
+    std::cout << " inputImageFile";
+    std::cerr << std::endl;
+    return EXIT_FAILURE;
+  }
 
-    using InputPixelType = short;
-    using OutputPixelType = int;
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using InputPixelType = short;
+  using OutputPixelType = int;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
 
-    using InputImageType = itk::Image< InputPixelType,  2 >;
-    using OutputImageType = itk::Image< OutputPixelType, 2 >;
-    using RGBImageType = itk::Image<RGBPixelType, 2>;
+  using InputImageType = itk::Image<InputPixelType, 2>;
+  using OutputImageType = itk::Image<OutputPixelType, 2>;
+  using RGBImageType = itk::Image<RGBPixelType, 2>;
 
-    using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType >;
-    using HuangFilterType = itk::HuangThresholdImageFilter<InputImageType, OutputImageType >;
-    using IntermodesFilterType = itk::IntermodesThresholdImageFilter<InputImageType, OutputImageType >;
-    using IsoDataFilterType = itk::IsoDataThresholdImageFilter<InputImageType, OutputImageType >;
-    using KittlerIllingworthFilterType = itk::KittlerIllingworthThresholdImageFilter<InputImageType, OutputImageType >;
-    using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType >;
-    using MaximumEntropyFilterType = itk::MaximumEntropyThresholdImageFilter<InputImageType, OutputImageType >;
-    using MomentsFilterType = itk::MomentsThresholdImageFilter<InputImageType, OutputImageType >;
-    using OtsuFilterType = itk::OtsuThresholdImageFilter<InputImageType, OutputImageType >;
-    using RenyiEntropyFilterType = itk::RenyiEntropyThresholdImageFilter<InputImageType, OutputImageType >;
-    using ShanbhagFilterType = itk::ShanbhagThresholdImageFilter<InputImageType, OutputImageType >;
-    using TriangleFilterType = itk::TriangleThresholdImageFilter<InputImageType, OutputImageType >;
-    using YenFilterType = itk::YenThresholdImageFilter<InputImageType, OutputImageType >;
+  using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType>;
+  using HuangFilterType = itk::HuangThresholdImageFilter<InputImageType, OutputImageType>;
+  using IntermodesFilterType = itk::IntermodesThresholdImageFilter<InputImageType, OutputImageType>;
+  using IsoDataFilterType = itk::IsoDataThresholdImageFilter<InputImageType, OutputImageType>;
+  using KittlerIllingworthFilterType = itk::KittlerIllingworthThresholdImageFilter<InputImageType, OutputImageType>;
+  using LiFilterType = itk::LiThresholdImageFilter<InputImageType, OutputImageType>;
+  using MaximumEntropyFilterType = itk::MaximumEntropyThresholdImageFilter<InputImageType, OutputImageType>;
+  using MomentsFilterType = itk::MomentsThresholdImageFilter<InputImageType, OutputImageType>;
+  using OtsuFilterType = itk::OtsuThresholdImageFilter<InputImageType, OutputImageType>;
+  using RenyiEntropyFilterType = itk::RenyiEntropyThresholdImageFilter<InputImageType, OutputImageType>;
+  using ShanbhagFilterType = itk::ShanbhagThresholdImageFilter<InputImageType, OutputImageType>;
+  using TriangleFilterType = itk::TriangleThresholdImageFilter<InputImageType, OutputImageType>;
+  using YenFilterType = itk::YenThresholdImageFilter<InputImageType, OutputImageType>;
 
-    using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter <OutputImageType, OutputImageType >;
-    using RGBFilterType = itk::LabelToRGBImageFilter<OutputImageType, RGBImageType>;
+  using ConnectedComponentImageFilterType = itk::ConnectedComponentImageFilter<OutputImageType, OutputImageType>;
+  using RGBFilterType = itk::LabelToRGBImageFilter<OutputImageType, RGBImageType>;
 
-    using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
 
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName( argv[1] );
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[1]);
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(argv[1]));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 
-    using FilterContainerType = std::map<std::string, itk::HistogramThresholdImageFilter<InputImageType, OutputImageType>::Pointer>;
-    FilterContainerType filterContainer;
+  using FilterContainerType =
+    std::map<std::string, itk::HistogramThresholdImageFilter<InputImageType, OutputImageType>::Pointer>;
+  FilterContainerType filterContainer;
 
-    filterContainer["Huang"] = HuangFilterType::New();
-    filterContainer["Intermodes"] = IntermodesFilterType::New();
-    filterContainer["IsoData"] = IsoDataFilterType::New();
-    filterContainer["KittlerIllingworth"] = KittlerIllingworthFilterType::New();
-    filterContainer["Li"] = LiFilterType::New();
-    filterContainer["MaximumEntropy"] = MaximumEntropyFilterType::New();
-    filterContainer["Moments"] = MomentsFilterType::New();
-    filterContainer["Otsu"] = OtsuFilterType::New();
-    filterContainer["RenyiEntropy"] = RenyiEntropyFilterType::New();
-    filterContainer["Shanbhag"] = ShanbhagFilterType::New();
-    filterContainer["Triangle"] = TriangleFilterType::New();
-    filterContainer["Yen"] = YenFilterType::New();
+  filterContainer["Huang"] = HuangFilterType::New();
+  filterContainer["Intermodes"] = IntermodesFilterType::New();
+  filterContainer["IsoData"] = IsoDataFilterType::New();
+  filterContainer["KittlerIllingworth"] = KittlerIllingworthFilterType::New();
+  filterContainer["Li"] = LiFilterType::New();
+  filterContainer["MaximumEntropy"] = MaximumEntropyFilterType::New();
+  filterContainer["Moments"] = MomentsFilterType::New();
+  filterContainer["Otsu"] = OtsuFilterType::New();
+  filterContainer["RenyiEntropy"] = RenyiEntropyFilterType::New();
+  filterContainer["Shanbhag"] = ShanbhagFilterType::New();
+  filterContainer["Triangle"] = TriangleFilterType::New();
+  filterContainer["Yen"] = YenFilterType::New();
 
-    auto it = filterContainer.begin();
-    for (it = filterContainer.begin(); it != filterContainer.end(); ++it)
+  auto it = filterContainer.begin();
+  for (it = filterContainer.begin(); it != filterContainer.end(); ++it)
+  {
+    (*it).second->SetInsideValue(255);
+    (*it).second->SetOutsideValue(0);
+    (*it).second->SetNumberOfHistogramBins(25);
+    (*it).second->SetInput(reader->GetOutput());
+    try
     {
-        (*it).second->SetInsideValue( 255 );
-        (*it).second->SetOutsideValue( 0 );
-        (*it).second->SetNumberOfHistogramBins( 25 );
-        (*it).second->SetInput( reader->GetOutput() );
-        try
-        {
-            (*it).second->Update();
-        }
-        catch( itk::ExceptionObject & err )
-        {
-            std::cout << "Caught exception" << std::endl;
-            std::cout << err << std::endl;
-            continue;
-        }
-        ConnectedComponentImageFilterType::Pointer connected =
-                ConnectedComponentImageFilterType::New ();
-        connected->SetInput((*it).second->GetOutput());
-
-        RGBFilterType::Pointer rgbFilter = RGBFilterType::New();
-        rgbFilter->SetInput( connected->GetOutput() );
-        std::stringstream desc;
-        desc << (*it).first << " threshold = "
-             << (*it).second->GetThreshold();
-        viewer.AddRGBImage(
-                rgbFilter->GetOutput(),
-                true,
-                desc.str());
+      (*it).second->Update();
     }
+    catch (itk::ExceptionObject & err)
+    {
+      std::cout << "Caught exception" << std::endl;
+      std::cout << err << std::endl;
+      continue;
+    }
+    ConnectedComponentImageFilterType::Pointer connected = ConnectedComponentImageFilterType::New();
+    connected->SetInput((*it).second->GetOutput());
 
-    viewer.Visualize();
+    RGBFilterType::Pointer rgbFilter = RGBFilterType::New();
+    rgbFilter->SetInput(connected->GetOutput());
+    std::stringstream desc;
+    desc << (*it).first << " threshold = " << (*it).second->GetThreshold();
+    viewer.AddRGBImage(rgbFilter->GetOutput(), true, desc.str());
+  }
+
+  viewer.Visualize();
 #endif
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/Code.cxx
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/Code.cxx
@@ -27,196 +27,169 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
 template <typename TImage>
-static void CreateImage(TImage* const image);
+static void
+CreateImage(TImage * const image);
 
-template<typename TImage, typename TLabelImage>
-static void SummarizeLabelStatistics (TImage* image,
-                                      TLabelImage* labelImage);
+template <typename TImage, typename TLabelImage>
+static void
+SummarizeLabelStatistics(TImage * image, TLabelImage * labelImage);
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    constexpr unsigned int Dimension = 2;
-    using PixelType = short;
-    using ImageType = itk::Image<PixelType, Dimension>;
+  constexpr unsigned int Dimension = 2;
+  using PixelType = short;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-    using RGBPixelType = itk::RGBPixel<unsigned char>;
-    using RGBImageType = itk::Image<RGBPixelType, Dimension>;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType, Dimension>;
 
-    using LabelPixelType = unsigned int;
-    using LabelImageType = itk::Image<LabelPixelType, Dimension >;
+  using LabelPixelType = unsigned int;
+  using LabelImageType = itk::Image<LabelPixelType, Dimension>;
 
-    ImageType::Pointer image;
-    PixelType distanceThreshold = 4;
-    if( argc < 2 )
+  ImageType::Pointer image;
+  PixelType          distanceThreshold = 4;
+  if (argc < 2)
+  {
+    image = ImageType::New();
+    CreateImage(image.GetPointer());
+  }
+  else
+  {
+    using ReaderType = itk::ImageFileReader<ImageType>;
+    ReaderType::Pointer reader = ReaderType::New();
+    reader->SetFileName(argv[1]);
+    reader->Update();
+
+    if (argc > 2)
     {
-        image = ImageType::New();
-        CreateImage(image.GetPointer());
+      distanceThreshold = static_cast<PixelType>(atoi(argv[2]));
     }
-    else
-    {
-        using ReaderType = itk::ImageFileReader<ImageType>;
-        ReaderType::Pointer reader = ReaderType::New();
-        reader->SetFileName(argv[1]);
-        reader->Update();
-
-        if (argc > 2)
-        {
-            distanceThreshold = static_cast<PixelType> (atoi(argv[2]));
-        }
-        image = reader->GetOutput();
-    }
+    image = reader->GetOutput();
+  }
 
 
-    using ConnectedComponentImageFilterType = itk::ScalarConnectedComponentImageFilter <ImageType, LabelImageType >;
+  using ConnectedComponentImageFilterType = itk::ScalarConnectedComponentImageFilter<ImageType, LabelImageType>;
 
-    ConnectedComponentImageFilterType::Pointer connected =
-            ConnectedComponentImageFilterType::New ();
-    connected->SetInput(image);
-    connected->SetDistanceThreshold(distanceThreshold);
+  ConnectedComponentImageFilterType::Pointer connected = ConnectedComponentImageFilterType::New();
+  connected->SetInput(image);
+  connected->SetDistanceThreshold(distanceThreshold);
 
-    using RelabelFilterType = itk::RelabelComponentImageFilter <LabelImageType, LabelImageType >;
-    RelabelFilterType::Pointer relabel =
-            RelabelFilterType::New();
-    RelabelFilterType::ObjectSizeType minSize = 20;
-    if (argc > 3)
-    {
-        minSize = std::stoi(argv[3]);
-    }
-    relabel->SetInput(connected->GetOutput());
-    relabel->SetMinimumObjectSize(minSize);
-    relabel->Update();
+  using RelabelFilterType = itk::RelabelComponentImageFilter<LabelImageType, LabelImageType>;
+  RelabelFilterType::Pointer        relabel = RelabelFilterType::New();
+  RelabelFilterType::ObjectSizeType minSize = 20;
+  if (argc > 3)
+  {
+    minSize = std::stoi(argv[3]);
+  }
+  relabel->SetInput(connected->GetOutput());
+  relabel->SetMinimumObjectSize(minSize);
+  relabel->Update();
 
-    SummarizeLabelStatistics (image.GetPointer(), relabel->GetOutput());
+  SummarizeLabelStatistics(image.GetPointer(), relabel->GetOutput());
 
-    using RGBFilterType = itk::LabelToRGBImageFilter<LabelImageType, RGBImageType>;
-    RGBFilterType::Pointer rgbFilter =
-            RGBFilterType::New();
-    rgbFilter->SetInput( relabel->GetOutput() );
+  using RGBFilterType = itk::LabelToRGBImageFilter<LabelImageType, RGBImageType>;
+  RGBFilterType::Pointer rgbFilter = RGBFilterType::New();
+  rgbFilter->SetInput(relabel->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            image.GetPointer(),true,
-            argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
+  QuickView viewer;
+  viewer.AddImage(
+    image.GetPointer(), true, argc > 1 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated image");
 
-    std::stringstream desc;
-    desc << "Scalar Connected Components:\n# of Objects: "
-         << relabel->GetNumberOfObjects()
-         << " Threshold: "
-         << itk::NumericTraits<ConnectedComponentImageFilterType::OutputPixelType>::PrintType(connected->GetDistanceThreshold())
-         << " Min Size: " << relabel->GetMinimumObjectSize();
-    viewer.AddRGBImage(
-            rgbFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "Scalar Connected Components:\n# of Objects: " << relabel->GetNumberOfObjects() << " Threshold: "
+       << itk::NumericTraits<ConnectedComponentImageFilterType::OutputPixelType>::PrintType(
+            connected->GetDistanceThreshold())
+       << " Min Size: " << relabel->GetMinimumObjectSize();
+  viewer.AddRGBImage(rgbFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 template <typename TImage>
-void CreateImage(TImage* const image)
+void
+CreateImage(TImage * const image)
 {
-    // Create an image with 2 connected components
-    typename TImage::IndexType start = {{0,0}};
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  typename TImage::IndexType start = { { 0, 0 } };
+  start[0] = 0;
+  start[1] = 0;
 
-    typename TImage::SizeType size;
-    unsigned int NumRows = 200;
-    unsigned int NumCols = 300;
-    size[0] = NumRows;
-    size[1] = NumCols;
+  typename TImage::SizeType size;
+  unsigned int              NumRows = 200;
+  unsigned int              NumCols = 300;
+  size[0] = NumRows;
+  size[1] = NumCols;
 
-    typename TImage::RegionType region(start, size);
+  typename TImage::RegionType region(start, size);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(typename TImage::IndexValueType r = 20; r < 80; r++)
+  // Make a square
+  for (typename TImage::IndexValueType r = 20; r < 80; r++)
+  {
+    for (typename TImage::IndexValueType c = 30; c < 100; c++)
     {
-        for(typename TImage::IndexValueType c = 30; c < 100; c++)
-        {
-            typename TImage::IndexType pixelIndex = {{r,c}};
+      typename TImage::IndexType pixelIndex = { { r, c } };
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 
-    // Make another square
-    for(typename TImage::IndexValueType r = 100; r < 130; r++)
+  // Make another square
+  for (typename TImage::IndexValueType r = 100; r < 130; r++)
+  {
+    for (typename TImage::IndexValueType c = 115; c < 160; c++)
     {
-        for(typename TImage::IndexValueType c = 115; c < 160; c++)
-        {
-            typename TImage::IndexType pixelIndex = {{r,c}};
+      typename TImage::IndexType pixelIndex = { { r, c } };
 
-            image->SetPixel(pixelIndex, 255);
-        }
+      image->SetPixel(pixelIndex, 255);
     }
+  }
 }
 
-template<typename TImage, typename TLabelImage>
-void SummarizeLabelStatistics (TImage* image,
-                               TLabelImage* labelImage)
+template <typename TImage, typename TLabelImage>
+void
+SummarizeLabelStatistics(TImage * image, TLabelImage * labelImage)
 {
-    using LabelStatisticsImageFilterType = itk::LabelStatisticsImageFilter< TImage, TLabelImage >;
-    typename LabelStatisticsImageFilterType::Pointer labelStatisticsImageFilter =
-            LabelStatisticsImageFilterType::New();
-    labelStatisticsImageFilter->SetLabelInput( labelImage );
-    labelStatisticsImageFilter->SetInput(image);
-    labelStatisticsImageFilter->UseHistogramsOn(); // needed to compute median
-    labelStatisticsImageFilter->Update();
+  using LabelStatisticsImageFilterType = itk::LabelStatisticsImageFilter<TImage, TLabelImage>;
+  typename LabelStatisticsImageFilterType::Pointer labelStatisticsImageFilter = LabelStatisticsImageFilterType::New();
+  labelStatisticsImageFilter->SetLabelInput(labelImage);
+  labelStatisticsImageFilter->SetInput(image);
+  labelStatisticsImageFilter->UseHistogramsOn(); // needed to compute median
+  labelStatisticsImageFilter->Update();
 
-    std::cout << "Number of labels: "
-              << labelStatisticsImageFilter->GetNumberOfLabels() << std::endl;
-    std::cout << std::endl;
+  std::cout << "Number of labels: " << labelStatisticsImageFilter->GetNumberOfLabels() << std::endl;
+  std::cout << std::endl;
 
-    using LabelPixelType = typename LabelStatisticsImageFilterType::LabelPixelType;
+  using LabelPixelType = typename LabelStatisticsImageFilterType::LabelPixelType;
 
-    for(auto vIt = labelStatisticsImageFilter->GetValidLabelValues().begin();
-        vIt != labelStatisticsImageFilter->GetValidLabelValues().end();
-        ++vIt)
+  for (auto vIt = labelStatisticsImageFilter->GetValidLabelValues().begin();
+       vIt != labelStatisticsImageFilter->GetValidLabelValues().end();
+       ++vIt)
+  {
+    if (labelStatisticsImageFilter->HasLabel(*vIt))
     {
-        if ( labelStatisticsImageFilter->HasLabel(*vIt) )
-        {
-            LabelPixelType labelValue = *vIt;
-            std::cout << "Label: " << *vIt << std::endl;
-            std::cout << "\tmin: "
-                      << labelStatisticsImageFilter->GetMinimum( labelValue )
-                      << std::endl;
-            std::cout << "\tmax: "
-                      << labelStatisticsImageFilter->GetMaximum( labelValue )
-                      << std::endl;
-            std::cout << "\tmedian: "
-                      << labelStatisticsImageFilter->GetMedian( labelValue )
-                      << std::endl;
-            std::cout << "\tmean: "
-                      << labelStatisticsImageFilter->GetMean( labelValue )
-                      << std::endl;
-            std::cout << "\tsigma: "
-                      << labelStatisticsImageFilter->GetSigma( labelValue )
-                      << std::endl;
-            std::cout << "\tvariance: "
-                      << labelStatisticsImageFilter->GetVariance( labelValue )
-                      << std::endl;
-            std::cout << "\tsum: "
-                      << labelStatisticsImageFilter->GetSum( labelValue )
-                      << std::endl;
-            std::cout << "\tcount: "
-                      << labelStatisticsImageFilter->GetCount( labelValue )
-                      << std::endl;
-            std::cout << "\tregion: "
-                      << labelStatisticsImageFilter->GetRegion( labelValue )
-                      << std::endl;
-        }
+      LabelPixelType labelValue = *vIt;
+      std::cout << "Label: " << *vIt << std::endl;
+      std::cout << "\tmin: " << labelStatisticsImageFilter->GetMinimum(labelValue) << std::endl;
+      std::cout << "\tmax: " << labelStatisticsImageFilter->GetMaximum(labelValue) << std::endl;
+      std::cout << "\tmedian: " << labelStatisticsImageFilter->GetMedian(labelValue) << std::endl;
+      std::cout << "\tmean: " << labelStatisticsImageFilter->GetMean(labelValue) << std::endl;
+      std::cout << "\tsigma: " << labelStatisticsImageFilter->GetSigma(labelValue) << std::endl;
+      std::cout << "\tvariance: " << labelStatisticsImageFilter->GetVariance(labelValue) << std::endl;
+      std::cout << "\tsum: " << labelStatisticsImageFilter->GetSum(labelValue) << std::endl;
+      std::cout << "\tcount: " << labelStatisticsImageFilter->GetCount(labelValue) << std::endl;
+      std::cout << "\tregion: " << labelStatisticsImageFilter->GetRegion(labelValue) << std::endl;
     }
-
+  }
 }
-

--- a/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/Code.cxx
+++ b/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/Code.cxx
@@ -31,153 +31,148 @@
 
 using PixelType = int;
 constexpr size_t Dimension = 3;
-using ImageType = itk::Image< PixelType, Dimension >;
+using ImageType = itk::Image<PixelType, Dimension>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    ImageType::Pointer image = ImageType::New();
-    CreateImage(image);
+  ImageType::Pointer image = ImageType::New();
+  CreateImage(image);
 
-    using RegionGrowImageFilterType = itk::RegionGrowImageFilter<ImageType, ImageType>;
-    RegionGrowImageFilterType::Pointer regionGrow = RegionGrowImageFilterType::New();
-    float lower = 95.0;
-    float upper = 105.0;
-    regionGrow->SetLower(lower);
-    regionGrow->SetUpper(upper);
+  using RegionGrowImageFilterType = itk::RegionGrowImageFilter<ImageType, ImageType>;
+  RegionGrowImageFilterType::Pointer regionGrow = RegionGrowImageFilterType::New();
+  float                              lower = 95.0;
+  float                              upper = 105.0;
+  regionGrow->SetLower(lower);
+  regionGrow->SetUpper(upper);
 
-    regionGrow->SetReplaceValue(255);
+  regionGrow->SetReplaceValue(255);
 
-    // Seed 1: (25, 35)
-    ImageType::IndexType seed1;
-    seed1[0] = 25;
-    seed1[1] = 35;
-    regionGrow->SetSeed(seed1);
-    regionGrow->SetInput(image);
+  // Seed 1: (25, 35)
+  ImageType::IndexType seed1;
+  seed1[0] = 25;
+  seed1[1] = 35;
+  regionGrow->SetSeed(seed1);
+  regionGrow->SetInput(image);
 
-    // Seed 2: (110, 120)
-    ImageType::IndexType seed2;
-    seed2[0] = 110;
-    seed2[1] = 120;
-    regionGrow->SetSeed(seed2);
-    regionGrow->SetReplaceValue(150);
+  // Seed 2: (110, 120)
+  ImageType::IndexType seed2;
+  seed2[0] = 110;
+  seed2[1] = 120;
+  regionGrow->SetSeed(seed2);
+  regionGrow->SetReplaceValue(150);
 
-    regionGrow->SetInput(image);
+  regionGrow->SetInput(image);
 
-    // Visualize
-    using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
-    ConnectorType::Pointer connector2 = ConnectorType::New();
-    connector2->SetInput(image2);
+  // Visualize
+  using ConnectorType = itk::ImageToVTKImageFilter<ImageType>;
+  ConnectorType::Pointer connector2 = ConnectorType::New();
+  connector2->SetInput(image2);
 
-    vtkSmartPointer<vtkImageActor> actor2 =
-            vtkSmartPointer<vtkImageActor>::New();
-    actor2->SetInput(connector2->GetOutput());
+  vtkSmartPointer<vtkImageActor> actor2 = vtkSmartPointer<vtkImageActor>::New();
+  actor2->SetInput(connector2->GetOutput());
 
-    // Visualize joined image
-    ConnectorType::Pointer addConnector = ConnectorType::New();
-    addConnector->SetInput(addFilter->GetOutput());
+  // Visualize joined image
+  ConnectorType::Pointer addConnector = ConnectorType::New();
+  addConnector->SetInput(addFilter->GetOutput());
 
-    vtkSmartPointer<vtkImageActor> addActor =
-            vtkSmartPointer<vtkImageActor>::New();
-    addActor->SetInput(addConnector->GetOutput());
+  vtkSmartPointer<vtkImageActor> addActor = vtkSmartPointer<vtkImageActor>::New();
+  addActor->SetInput(addConnector->GetOutput());
 
-    // There will be one render window
-    vtkSmartPointer<vtkRenderWindow> renderWindow =
-            vtkSmartPointer<vtkRenderWindow>::New();
-    renderWindow->SetSize(900, 300);
+  // There will be one render window
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
+  renderWindow->SetSize(900, 300);
 
-    vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-            vtkSmartPointer<vtkRenderWindowInteractor>::New();
-    interactor->SetRenderWindow(renderWindow);
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  interactor->SetRenderWindow(renderWindow);
 
-    // Define viewport ranges
-    // (xmin, ymin, xmax, ymax)
-    double leftViewport[4] = {0.0, 0.0, 0.33, 1.0};
-    double centerViewport[4] = {0.33, 0.0, 0.66, 1.0};
-    double rightViewport[4] = {0.66, 0.0, 1.0, 1.0};
+  // Define viewport ranges
+  // (xmin, ymin, xmax, ymax)
+  double leftViewport[4] = { 0.0, 0.0, 0.33, 1.0 };
+  double centerViewport[4] = { 0.33, 0.0, 0.66, 1.0 };
+  double rightViewport[4] = { 0.66, 0.0, 1.0, 1.0 };
 
-    // Setup both renderers
-    vtkSmartPointer<vtkRenderer> leftRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(leftRenderer);
-    leftRenderer->SetViewport(leftViewport);
-    leftRenderer->SetBackground(.6, .5, .4);
+  // Setup both renderers
+  vtkSmartPointer<vtkRenderer> leftRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(leftRenderer);
+  leftRenderer->SetViewport(leftViewport);
+  leftRenderer->SetBackground(.6, .5, .4);
 
-    vtkSmartPointer<vtkRenderer> centerRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(centerRenderer);
-    centerRenderer->SetViewport(centerViewport);
-    centerRenderer->SetBackground(.4, .5, .6);
+  vtkSmartPointer<vtkRenderer> centerRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(centerRenderer);
+  centerRenderer->SetViewport(centerViewport);
+  centerRenderer->SetBackground(.4, .5, .6);
 
-    vtkSmartPointer<vtkRenderer> rightRenderer =
-            vtkSmartPointer<vtkRenderer>::New();
-    renderWindow->AddRenderer(rightRenderer);
-    rightRenderer->SetViewport(rightViewport);
-    rightRenderer->SetBackground(.4, .5, .6);
+  vtkSmartPointer<vtkRenderer> rightRenderer = vtkSmartPointer<vtkRenderer>::New();
+  renderWindow->AddRenderer(rightRenderer);
+  rightRenderer->SetViewport(rightViewport);
+  rightRenderer->SetBackground(.4, .5, .6);
 
-    // Add the sphere to the left and the cube to the right
-    leftRenderer->AddActor(actor1);
-    centerRenderer->AddActor(actor2);
-    rightRenderer->AddActor(addActor);
+  // Add the sphere to the left and the cube to the right
+  leftRenderer->AddActor(actor1);
+  centerRenderer->AddActor(actor2);
+  rightRenderer->AddActor(addActor);
 
-    leftRenderer->ResetCamera();
-    centerRenderer->ResetCamera();
-    rightRenderer->ResetCamera();
+  leftRenderer->ResetCamera();
+  centerRenderer->ResetCamera();
+  rightRenderer->ResetCamera();
 
-    renderWindow->Render();
+  renderWindow->Render();
 
-    vtkSmartPointer<vtkInteractorStyleImage> style =
-            vtkSmartPointer<vtkInteractorStyleImage>::New();
-    interactor->SetInteractorStyle(style);
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
+  interactor->SetInteractorStyle(style);
 
-    interactor->Start();
+  interactor->Start();
 
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
-    // Create an image with 2 connected components
-    ImageType::RegionType region;
-    ImageType::IndexType start;
-    start[0] = 0;
-    start[1] = 0;
+  // Create an image with 2 connected components
+  ImageType::RegionType region;
+  ImageType::IndexType  start;
+  start[0] = 0;
+  start[1] = 0;
 
-    ImageType::SizeType size;
-    size[0] = 200;
-    size[1] = 300;
+  ImageType::SizeType size;
+  size[0] = 200;
+  size[1] = 300;
 
-    region.SetSize( size);
-    region.SetIndex(start);
+  region.SetSize(size);
+  region.SetIndex(start);
 
-    image->SetRegions(region);
-    image->Allocate();
+  image->SetRegions(region);
+  image->Allocate();
 
-    // Make a square
-    for(unsigned int r = 20; r < 80; r++)
+  // Make a square
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-        for(unsigned int c = 30; c < 100; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 100.0);
-        }
+      image->SetPixel(pixelIndex, 100.0);
     }
+  }
 
-    // Make another square
-    for(unsigned int r = 100; r < 130; r++)
+  // Make another square
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-        for(unsigned int c = 115; c < 160; c++)
-        {
-            ImageType::IndexType pixelIndex;
-            pixelIndex[0] = r;
-            pixelIndex[1] = c;
+      ImageType::IndexType pixelIndex;
+      pixelIndex[0] = r;
+      pixelIndex[1] = c;
 
-            image->SetPixel(pixelIndex, 100.0);
-        }
+      image->SetPixel(pixelIndex, 100.0);
     }
+  }
 }

--- a/src/Segmentation/LabelVoting/IterativeHoleFilling/Code.cxx
+++ b/src/Segmentation/LabelVoting/IterativeHoleFilling/Code.cxx
@@ -20,58 +20,59 @@
 #include "itkImageFileWriter.h"
 #include "itkVotingBinaryIterativeHoleFillingImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 6 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << " <InputFileName> <OutputFileName> <radius> <majority threshold> <number of iterations>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   const char * inputFileName = argv[1];
   const char * outputFileName = argv[2];
 
-  int r = std::stoi( argv[3] );
-  int majorityThreshold = std::stoi( argv[4] );
-  unsigned int numberOfIterations = std::stoi( argv[5] );
+  int          r = std::stoi(argv[3]);
+  int          majorityThreshold = std::stoi(argv[4]);
+  unsigned int numberOfIterations = std::stoi(argv[5]);
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using FilterType = itk::VotingBinaryIterativeHoleFillingImageFilter< ImageType >;
+  using FilterType = itk::VotingBinaryIterativeHoleFillingImageFilter<ImageType>;
   FilterType::InputSizeType radius;
-  radius.Fill( r );
+  radius.Fill(r);
 
   FilterType::Pointer filter = FilterType::New();
-  filter->SetInput( reader->GetOutput() );
-  filter->SetRadius( radius );
-  filter->SetMajorityThreshold( majorityThreshold );
-  filter->SetBackgroundValue( itk::NumericTraits< PixelType >::Zero );
-  filter->SetForegroundValue( itk::NumericTraits< PixelType >::max() );
-  filter->SetMaximumNumberOfIterations( numberOfIterations );
+  filter->SetInput(reader->GetOutput());
+  filter->SetRadius(radius);
+  filter->SetMajorityThreshold(majorityThreshold);
+  filter->SetBackgroundValue(itk::NumericTraits<PixelType>::Zero);
+  filter->SetForegroundValue(itk::NumericTraits<PixelType>::max());
+  filter->SetMaximumNumberOfIterations(numberOfIterations);
 
-  using WriterType = itk::ImageFileWriter< ImageType >;
+  using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( filter->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(filter->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.cxx
+++ b/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.cxx
@@ -26,104 +26,105 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "itkBinaryThresholdImageFilter.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 11 )
-    {
+  if (argc != 11)
+  {
     std::cerr << "Usage: " << argv[0];
     std::cerr << " <InputFileName>  <OutputFileName>";
     std::cerr << " <seedX> <seedY> <InitialDistance>";
     std::cerr << " <Sigma> <SigmoidAlpha> <SigmoidBeta>";
-    std::cerr << " <PropagationScaling> <NumberOfIterations>"  << std::endl;
+    std::cerr << " <PropagationScaling> <NumberOfIterations>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  const char * inputFileName =      argv[1];
-  const char * outputFileName =     argv[2];
-  const int seedPosX =              std::stoi( argv[3] );
-  const int seedPosY =              std::stoi( argv[4] );
+  const char * inputFileName = argv[1];
+  const char * outputFileName = argv[2];
+  const int    seedPosX = std::stoi(argv[3]);
+  const int    seedPosY = std::stoi(argv[4]);
 
-  const double initialDistance =    std::stod( argv[5] );
-  const double sigma =              std::stod( argv[6] );
-  const double alpha =              std::stod( argv[7] );
-  const double beta  =              std::stod( argv[8] );
-  const double propagationScaling = std::stod( argv[9] );
-  const double numberOfIterations = std::stoi( argv[10] );
-  const double seedValue =          - initialDistance;
+  const double initialDistance = std::stod(argv[5]);
+  const double sigma = std::stod(argv[6]);
+  const double alpha = std::stod(argv[7]);
+  const double beta = std::stod(argv[8]);
+  const double propagationScaling = std::stod(argv[9]);
+  const double numberOfIterations = std::stoi(argv[10]);
+  const double seedValue = -initialDistance;
 
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = float;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
   using OutputPixelType = unsigned char;
-  using OutputImageType = itk::Image< OutputPixelType, Dimension >;
+  using OutputImageType = itk::Image<OutputPixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< InputImageType >;
-  using WriterType = itk::ImageFileWriter< OutputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
+  using WriterType = itk::ImageFileWriter<OutputImageType>;
 
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( inputFileName );
+  reader->SetFileName(inputFileName);
 
-  using SmoothingFilterType = itk::CurvatureAnisotropicDiffusionImageFilter< InputImageType, InputImageType >;
+  using SmoothingFilterType = itk::CurvatureAnisotropicDiffusionImageFilter<InputImageType, InputImageType>;
   SmoothingFilterType::Pointer smoothing = SmoothingFilterType::New();
-  smoothing->SetTimeStep( 0.125 );
-  smoothing->SetNumberOfIterations( 5 );
-  smoothing->SetConductanceParameter( 9.0 );
-  smoothing->SetInput( reader->GetOutput() );
+  smoothing->SetTimeStep(0.125);
+  smoothing->SetNumberOfIterations(5);
+  smoothing->SetConductanceParameter(9.0);
+  smoothing->SetInput(reader->GetOutput());
 
-  using GradientFilterType = itk::GradientMagnitudeRecursiveGaussianImageFilter< InputImageType, InputImageType >;
-  GradientFilterType::Pointer  gradientMagnitude = GradientFilterType::New();
-  gradientMagnitude->SetSigma( sigma );
-  gradientMagnitude->SetInput( smoothing->GetOutput() );
+  using GradientFilterType = itk::GradientMagnitudeRecursiveGaussianImageFilter<InputImageType, InputImageType>;
+  GradientFilterType::Pointer gradientMagnitude = GradientFilterType::New();
+  gradientMagnitude->SetSigma(sigma);
+  gradientMagnitude->SetInput(smoothing->GetOutput());
 
-  using SigmoidFilterType = itk::SigmoidImageFilter< InputImageType, InputImageType >;
+  using SigmoidFilterType = itk::SigmoidImageFilter<InputImageType, InputImageType>;
   SigmoidFilterType::Pointer sigmoid = SigmoidFilterType::New();
-  sigmoid->SetOutputMinimum( 0.0 );
-  sigmoid->SetOutputMaximum( 1.0 );
-  sigmoid->SetAlpha( alpha );
-  sigmoid->SetBeta( beta );
-  sigmoid->SetInput( gradientMagnitude->GetOutput() );
+  sigmoid->SetOutputMinimum(0.0);
+  sigmoid->SetOutputMaximum(1.0);
+  sigmoid->SetAlpha(alpha);
+  sigmoid->SetBeta(beta);
+  sigmoid->SetInput(gradientMagnitude->GetOutput());
 
-  using FastMarchingFilterType = itk::FastMarchingImageFilter< InputImageType, InputImageType >;
-  FastMarchingFilterType::Pointer  fastMarching = FastMarchingFilterType::New();
+  using FastMarchingFilterType = itk::FastMarchingImageFilter<InputImageType, InputImageType>;
+  FastMarchingFilterType::Pointer fastMarching = FastMarchingFilterType::New();
 
-  using GeodesicActiveContourFilterType = itk::GeodesicActiveContourLevelSetImageFilter< InputImageType, InputImageType >;
+  using GeodesicActiveContourFilterType = itk::GeodesicActiveContourLevelSetImageFilter<InputImageType, InputImageType>;
   GeodesicActiveContourFilterType::Pointer geodesicActiveContour = GeodesicActiveContourFilterType::New();
-  geodesicActiveContour->SetPropagationScaling( propagationScaling );
-  geodesicActiveContour->SetCurvatureScaling( 1.0 );
-  geodesicActiveContour->SetAdvectionScaling( 1.0 );
-  geodesicActiveContour->SetMaximumRMSError( 0.02 );
-  geodesicActiveContour->SetNumberOfIterations( numberOfIterations );
-  geodesicActiveContour->SetInput( fastMarching->GetOutput() );
-  geodesicActiveContour->SetFeatureImage( sigmoid->GetOutput() );
+  geodesicActiveContour->SetPropagationScaling(propagationScaling);
+  geodesicActiveContour->SetCurvatureScaling(1.0);
+  geodesicActiveContour->SetAdvectionScaling(1.0);
+  geodesicActiveContour->SetMaximumRMSError(0.02);
+  geodesicActiveContour->SetNumberOfIterations(numberOfIterations);
+  geodesicActiveContour->SetInput(fastMarching->GetOutput());
+  geodesicActiveContour->SetFeatureImage(sigmoid->GetOutput());
 
-  using ThresholdingFilterType = itk::BinaryThresholdImageFilter< InputImageType, OutputImageType >;
+  using ThresholdingFilterType = itk::BinaryThresholdImageFilter<InputImageType, OutputImageType>;
   ThresholdingFilterType::Pointer thresholder = ThresholdingFilterType::New();
-  thresholder->SetLowerThreshold( -1000.0 );
-  thresholder->SetUpperThreshold( 0.0 );
-  thresholder->SetOutsideValue( itk::NumericTraits< OutputPixelType >::min() );
-  thresholder->SetInsideValue( itk::NumericTraits< OutputPixelType >::max() );
-  thresholder->SetInput( geodesicActiveContour->GetOutput() );
+  thresholder->SetLowerThreshold(-1000.0);
+  thresholder->SetUpperThreshold(0.0);
+  thresholder->SetOutsideValue(itk::NumericTraits<OutputPixelType>::min());
+  thresholder->SetInsideValue(itk::NumericTraits<OutputPixelType>::max());
+  thresholder->SetInput(geodesicActiveContour->GetOutput());
 
   using NodeContainer = FastMarchingFilterType::NodeContainer;
   using NodeType = FastMarchingFilterType::NodeType;
 
-  InputImageType::IndexType  seedPosition;
+  InputImageType::IndexType seedPosition;
   seedPosition[0] = seedPosX;
   seedPosition[1] = seedPosY;
 
   NodeContainer::Pointer seeds = NodeContainer::New();
-  NodeType node;
-  node.SetValue( seedValue );
-  node.SetIndex( seedPosition );
+  NodeType               node;
+  node.SetValue(seedValue);
+  node.SetIndex(seedPosition);
 
   seeds->Initialize();
-  seeds->InsertElement( 0, node );
+  seeds->InsertElement(0, node);
 
-  fastMarching->SetTrialPoints( seeds );
-  fastMarching->SetSpeedConstant( 1.0 );
+  fastMarching->SetTrialPoints(seeds);
+  fastMarching->SetSpeedConstant(1.0);
 
-  using CastFilterType = itk::RescaleIntensityImageFilter< InputImageType, OutputImageType >;
+  using CastFilterType = itk::RescaleIntensityImageFilter<InputImageType, OutputImageType>;
 
   CastFilterType::Pointer caster1 = CastFilterType::New();
   CastFilterType::Pointer caster2 = CastFilterType::New();
@@ -135,32 +136,32 @@ int main( int argc, char* argv[] )
   WriterType::Pointer writer3 = WriterType::New();
   WriterType::Pointer writer4 = WriterType::New();
 
-  caster1->SetInput( smoothing->GetOutput() );
-  writer1->SetInput( caster1->GetOutput() );
+  caster1->SetInput(smoothing->GetOutput());
+  writer1->SetInput(caster1->GetOutput());
   writer1->SetFileName("GeodesicActiveContourImageFilterOutput1.png");
-  caster1->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  caster1->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  caster1->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  caster1->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
   writer1->Update();
 
-  caster2->SetInput( gradientMagnitude->GetOutput() );
-  writer2->SetInput( caster2->GetOutput() );
+  caster2->SetInput(gradientMagnitude->GetOutput());
+  writer2->SetInput(caster2->GetOutput());
   writer2->SetFileName("GeodesicActiveContourImageFilterOutput2.png");
-  caster2->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  caster2->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  caster2->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  caster2->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
   writer2->Update();
 
-  caster3->SetInput( sigmoid->GetOutput() );
-  writer3->SetInput( caster3->GetOutput() );
+  caster3->SetInput(sigmoid->GetOutput());
+  writer3->SetInput(caster3->GetOutput());
   writer3->SetFileName("GeodesicActiveContourImageFilterOutput3.png");
-  caster3->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  caster3->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  caster3->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  caster3->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
   writer3->Update();
 
-  caster4->SetInput( fastMarching->GetOutput() );
-  writer4->SetInput( caster4->GetOutput() );
+  caster4->SetInput(fastMarching->GetOutput());
+  writer4->SetInput(caster4->GetOutput());
   writer4->SetFileName("GeodesicActiveContourImageFilterOutput4.png");
-  caster4->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
-  caster4->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
+  caster4->SetOutputMinimum(itk::NumericTraits<OutputPixelType>::min());
+  caster4->SetOutputMaximum(itk::NumericTraits<OutputPixelType>::max());
 
   InputImageType::Pointer inImage = reader->GetOutput();
   fastMarching->SetOutputDirection(inImage->GetDirection());
@@ -169,17 +170,17 @@ int main( int argc, char* argv[] )
   fastMarching->SetOutputSpacing(inImage->GetSpacing());
 
   WriterType::Pointer writer = WriterType::New();
-  writer->SetFileName( outputFileName );
-  writer->SetInput( thresholder->GetOutput() );
+  writer->SetFileName(outputFileName);
+  writer->SetInput(thresholder->GetOutput());
   try
-    {
+  {
     writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   std::cout << std::endl;
   std::cout << "Max. no. iterations: " << geodesicActiveContour->GetNumberOfIterations() << std::endl;
@@ -189,55 +190,55 @@ int main( int argc, char* argv[] )
   std::cout << "RMS change: " << geodesicActiveContour->GetRMSChange() << std::endl;
 
   try
-    {
+  {
     writer4->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  using InternalWriterType = itk::ImageFileWriter< InputImageType >;
+  using InternalWriterType = itk::ImageFileWriter<InputImageType>;
 
   InternalWriterType::Pointer mapWriter = InternalWriterType::New();
-  mapWriter->SetInput( fastMarching->GetOutput() );
+  mapWriter->SetInput(fastMarching->GetOutput());
   mapWriter->SetFileName("GeodesicActiveContourImageFilterOutput4.mha");
   try
-    {
+  {
     mapWriter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   InternalWriterType::Pointer speedWriter = InternalWriterType::New();
-  speedWriter->SetInput( sigmoid->GetOutput() );
+  speedWriter->SetInput(sigmoid->GetOutput());
   speedWriter->SetFileName("GeodesicActiveContourImageFilterOutput3.mha");
   try
-    {
+  {
     speedWriter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   InternalWriterType::Pointer gradientWriter = InternalWriterType::New();
-  gradientWriter->SetInput( gradientMagnitude->GetOutput() );
+  gradientWriter->SetInput(gradientMagnitude->GetOutput());
   gradientWriter->SetFileName("GeodesicActiveContourImageFilterOutput2.mha");
   try
-    {
+  {
     gradientWriter->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeEvolvingDense2DLevelSetAsElevationMap/Code.cxx
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeEvolvingDense2DLevelSetAsElevationMap/Code.cxx
@@ -30,140 +30,142 @@
 #include "itkVTKVisualize2DLevelSetAsElevationMap.h"
 #include "itkSinRegularizedHeavisideStepFunction.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3)
-    {
+  if (argc != 3)
+  {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << "1- Input Image" << std::endl;
     std::cerr << "2- Number of Iterations" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Image Dimension
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   // Read input image (to be processed).
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
   InputImageType::Pointer input = reader->GetOutput();
 
-  int numberOfIterations = std::stoi( argv[2] );
+  int numberOfIterations = std::stoi(argv[2]);
 
   using LevelSetPixelType = float;
-  using LevelSetImageType = itk::Image< LevelSetPixelType, Dimension >;
-  using LevelSetType = itk::LevelSetDenseImage< LevelSetImageType >;
+  using LevelSetImageType = itk::Image<LevelSetPixelType, Dimension>;
+  using LevelSetType = itk::LevelSetDenseImage<LevelSetImageType>;
 
   using LevelSetOutputType = LevelSetType::OutputType;
   using LevelSetRealType = LevelSetType::OutputRealType;
 
   // Generate a binary mask that will be used as initialization for the level
   // set evolution.
-  using BinaryImageType = itk::Image< LevelSetOutputType, Dimension >;
+  using BinaryImageType = itk::Image<LevelSetOutputType, Dimension>;
   BinaryImageType::Pointer binary = BinaryImageType::New();
-  binary->SetRegions( input->GetLargestPossibleRegion() );
-  binary->CopyInformation( input );
+  binary->SetRegions(input->GetLargestPossibleRegion());
+  binary->CopyInformation(input);
   binary->Allocate();
-  binary->FillBuffer( itk::NumericTraits< LevelSetOutputType >::Zero );
+  binary->FillBuffer(itk::NumericTraits<LevelSetOutputType>::Zero);
 
   BinaryImageType::RegionType region;
   BinaryImageType::IndexType  index;
   BinaryImageType::SizeType   size;
 
-  index.Fill( 5 );
-  size.Fill( 120 );
+  index.Fill(5);
+  size.Fill(120);
 
-  region.SetIndex( index );
-  region.SetSize( size );
+  region.SetIndex(index);
+  region.SetSize(size);
 
-  using InputIteratorType = itk::ImageRegionIteratorWithIndex< BinaryImageType >;
-  InputIteratorType iIt( binary, region );
+  using InputIteratorType = itk::ImageRegionIteratorWithIndex<BinaryImageType>;
+  InputIteratorType iIt(binary, region);
   iIt.GoToBegin();
-  while( !iIt.IsAtEnd() )
-    {
-    iIt.Set( itk::NumericTraits< LevelSetOutputType >::One );
+  while (!iIt.IsAtEnd())
+  {
+    iIt.Set(itk::NumericTraits<LevelSetOutputType>::One);
     ++iIt;
-    }
+  }
 
   // convert a binary mask to a level-set function
-  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor< BinaryImageType,
-    LevelSetType >;
+  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor<BinaryImageType, LevelSetType>;
 
   BinaryImageToLevelSetType::Pointer adaptor = BinaryImageToLevelSetType::New();
-  adaptor->SetInputImage( binary );
+  adaptor->SetInputImage(binary);
   adaptor->Initialize();
   LevelSetType::Pointer levelSet = adaptor->GetLevelSet();
 
   // The Heaviside function
-  using HeavisideFunctionType = itk::SinRegularizedHeavisideStepFunction< LevelSetRealType, LevelSetRealType >;
+  using HeavisideFunctionType = itk::SinRegularizedHeavisideStepFunction<LevelSetRealType, LevelSetRealType>;
   HeavisideFunctionType::Pointer heaviside = HeavisideFunctionType::New();
-  heaviside->SetEpsilon( 1.5 );
+  heaviside->SetEpsilon(1.5);
 
   // Create the level set container
-  using LevelSetContainerType = itk::LevelSetContainer< itk::IdentifierType, LevelSetType >;
+  using LevelSetContainerType = itk::LevelSetContainer<itk::IdentifierType, LevelSetType>;
   LevelSetContainerType::Pointer levelSetContainer = LevelSetContainerType::New();
-  levelSetContainer->SetHeaviside( heaviside );
-  levelSetContainer->AddLevelSet( 0, levelSet );
+  levelSetContainer->SetHeaviside(heaviside);
+  levelSetContainer->AddLevelSet(0, levelSet);
 
   // Create the terms.
   //
   // // Chan and Vese internal term
-  using ChanAndVeseInternalTermType = itk::LevelSetEquationChanAndVeseInternalTerm< InputImageType, LevelSetContainerType >;
+  using ChanAndVeseInternalTermType =
+    itk::LevelSetEquationChanAndVeseInternalTerm<InputImageType, LevelSetContainerType>;
   ChanAndVeseInternalTermType::Pointer cvInternalTerm = ChanAndVeseInternalTermType::New();
-  cvInternalTerm->SetInput( input );
-  cvInternalTerm->SetCoefficient( 0.5 );
+  cvInternalTerm->SetInput(input);
+  cvInternalTerm->SetCoefficient(0.5);
 
   // // Chan and Vese external term
-  using ChanAndVeseExternalTermType = itk::LevelSetEquationChanAndVeseExternalTerm< InputImageType, LevelSetContainerType >;
+  using ChanAndVeseExternalTermType =
+    itk::LevelSetEquationChanAndVeseExternalTerm<InputImageType, LevelSetContainerType>;
   ChanAndVeseExternalTermType::Pointer cvExternalTerm = ChanAndVeseExternalTermType::New();
-  cvExternalTerm->SetInput( input );
+  cvExternalTerm->SetInput(input);
 
   // Create term container (equation rhs)
-  using TermContainerType = itk::LevelSetEquationTermContainer< InputImageType, LevelSetContainerType >;
+  using TermContainerType = itk::LevelSetEquationTermContainer<InputImageType, LevelSetContainerType>;
   TermContainerType::Pointer termContainer = TermContainerType::New();
-  termContainer->SetLevelSetContainer( levelSetContainer );
-  termContainer->SetInput( input );
-  termContainer->AddTerm( 0, cvInternalTerm );
-  termContainer->AddTerm( 1, cvExternalTerm );
+  termContainer->SetLevelSetContainer(levelSetContainer);
+  termContainer->SetInput(input);
+  termContainer->AddTerm(0, cvInternalTerm);
+  termContainer->AddTerm(1, cvExternalTerm);
 
   // Create equation container
-  using EquationContainerType = itk::LevelSetEquationContainer< TermContainerType >;
+  using EquationContainerType = itk::LevelSetEquationContainer<TermContainerType>;
   EquationContainerType::Pointer equationContainer = EquationContainerType::New();
-  equationContainer->SetLevelSetContainer( levelSetContainer );
-  equationContainer->AddEquation( 0, termContainer );
+  equationContainer->SetLevelSetContainer(levelSetContainer);
+  equationContainer->AddEquation(0, termContainer);
 
   // Create stopping criteria
-  using StoppingCriterionType = itk::LevelSetEvolutionNumberOfIterationsStoppingCriterion< LevelSetContainerType >;
+  using StoppingCriterionType = itk::LevelSetEvolutionNumberOfIterationsStoppingCriterion<LevelSetContainerType>;
   StoppingCriterionType::Pointer criterion = StoppingCriterionType::New();
-  criterion->SetNumberOfIterations( numberOfIterations );
+  criterion->SetNumberOfIterations(numberOfIterations);
 
   // Create the visualizer
-  using VisualizationType = itk::VTKVisualize2DLevelSetAsElevationMap< InputImageType, LevelSetType >;
+  using VisualizationType = itk::VTKVisualize2DLevelSetAsElevationMap<InputImageType, LevelSetType>;
   VisualizationType::Pointer visualizer = VisualizationType::New();
-  visualizer->SetInputImage( input );
-  visualizer->SetLevelSet( levelSet );
-  visualizer->SetScreenCapture( true );
+  visualizer->SetInputImage(input);
+  visualizer->SetLevelSet(levelSet);
+  visualizer->SetScreenCapture(true);
 
   // Create evolution class
-  using LevelSetEvolutionType = itk::LevelSetEvolution< EquationContainerType, LevelSetType >;
+  using LevelSetEvolutionType = itk::LevelSetEvolution<EquationContainerType, LevelSetType>;
   LevelSetEvolutionType::Pointer evolution = LevelSetEvolutionType::New();
-  evolution->SetEquationContainer( equationContainer );
-  evolution->SetStoppingCriterion( criterion );
-  evolution->SetLevelSetContainer( levelSetContainer );
+  evolution->SetEquationContainer(equationContainer);
+  evolution->SetStoppingCriterion(criterion);
+  evolution->SetLevelSetContainer(levelSetContainer);
 
-  using IterationUpdateCommandType = itk::LevelSetIterationUpdateCommand< LevelSetEvolutionType, VisualizationType >;
+  using IterationUpdateCommandType = itk::LevelSetIterationUpdateCommand<LevelSetEvolutionType, VisualizationType>;
   IterationUpdateCommandType::Pointer iterationUpdateCommand = IterationUpdateCommandType::New();
-  iterationUpdateCommand->SetFilterToUpdate( visualizer );
-  iterationUpdateCommand->SetUpdatePeriod( 5 );
+  iterationUpdateCommand->SetFilterToUpdate(visualizer);
+  iterationUpdateCommand->SetUpdatePeriod(5);
 
-  evolution->AddObserver( itk::IterationEvent(), iterationUpdateCommand );
+  evolution->AddObserver(itk::IterationEvent(), iterationUpdateCommand);
 
   evolution->Update();
 

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetAsElevationMap/Code.cxx
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetAsElevationMap/Code.cxx
@@ -34,82 +34,81 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "vtkRenderWindowInteractor.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << "<Input Image> <Interactive (0 or 1)>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Image Dimension
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   // Read input image (to be processed).
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   InputImageType::Pointer input = reader->GetOutput();
 
   using LevelSetPixelType = float;
-  using LevelSetImageType = itk::Image< LevelSetPixelType, Dimension >;
-  using LevelSetType = itk::LevelSetDenseImage< LevelSetImageType >;
+  using LevelSetImageType = itk::Image<LevelSetPixelType, Dimension>;
+  using LevelSetType = itk::LevelSetDenseImage<LevelSetImageType>;
 
   // Generate a binary mask that will be used as initialization for the level
   // set evolution.
-  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter< InputImageType, LevelSetImageType >;
+  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter<InputImageType, LevelSetImageType>;
   OtsuFilterType::Pointer otsu = OtsuFilterType::New();
-  otsu->SetInput( input );
-  otsu->SetNumberOfHistogramBins( 256 );
-  otsu->SetNumberOfThresholds( 1 );
+  otsu->SetInput(input);
+  otsu->SetNumberOfHistogramBins(256);
+  otsu->SetNumberOfThresholds(1);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< LevelSetImageType, LevelSetImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<LevelSetImageType, LevelSetImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( otsu->GetOutput() );
-  rescaler->SetOutputMinimum( 0 );
-  rescaler->SetOutputMaximum( 1 );
+  rescaler->SetInput(otsu->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(1);
 
   // convert a binary mask to a level-set function
-  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor< LevelSetImageType,
-    LevelSetType >;
+  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor<LevelSetImageType, LevelSetType>;
 
   BinaryImageToLevelSetType::Pointer adaptor = BinaryImageToLevelSetType::New();
-  adaptor->SetInputImage( rescaler->GetOutput() );
+  adaptor->SetInputImage(rescaler->GetOutput());
   adaptor->Initialize();
 
   LevelSetType::Pointer levelSet = adaptor->GetModifiableLevelSet();
 
   // Create the visualizer
-  using VisualizationType = itk::VTKVisualize2DLevelSetAsElevationMap< InputImageType, LevelSetType >;
+  using VisualizationType = itk::VTKVisualize2DLevelSetAsElevationMap<InputImageType, LevelSetType>;
   VisualizationType::Pointer visualizer = VisualizationType::New();
-  visualizer->SetInputImage( input );
-  visualizer->SetLevelSet( levelSet );
+  visualizer->SetInputImage(input);
+  visualizer->SetLevelSet(levelSet);
 
-  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor =
-      vtkSmartPointer<vtkRenderWindowInteractor>::New();
-  renderWindowInteractor->SetRenderWindow( visualizer->GetRenderWindow() );
+  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  renderWindowInteractor->SetRenderWindow(visualizer->GetRenderWindow());
 
   try
-    {
+  {
     visualizer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  bool interactive = ( std::stoi( argv[2] ) != 0 );
-  if( interactive )
-    {
+  bool interactive = (std::stoi(argv[2]) != 0);
+  if (interactive)
+  {
     renderWindowInteractor->Start();
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetZeroSet/Code.cxx
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticDense2DLevelSetZeroSet/Code.cxx
@@ -34,82 +34,81 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "vtkRenderWindowInteractor.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << "<Input Image> <Interactive (0 or 1)>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Image Dimension
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   // Read input image (to be processed).
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   InputImageType::Pointer input = reader->GetOutput();
 
   using LevelSetPixelType = float;
-  using LevelSetImageType = itk::Image< LevelSetPixelType, Dimension >;
-  using LevelSetType = itk::LevelSetDenseImage< LevelSetImageType >;
+  using LevelSetImageType = itk::Image<LevelSetPixelType, Dimension>;
+  using LevelSetType = itk::LevelSetDenseImage<LevelSetImageType>;
 
   // Generate a binary mask that will be used as initialization for the level
   // set evolution.
-  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter< InputImageType, LevelSetImageType >;
+  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter<InputImageType, LevelSetImageType>;
   OtsuFilterType::Pointer otsu = OtsuFilterType::New();
-  otsu->SetInput( input );
-  otsu->SetNumberOfHistogramBins( 256 );
-  otsu->SetNumberOfThresholds( 1 );
+  otsu->SetInput(input);
+  otsu->SetNumberOfHistogramBins(256);
+  otsu->SetNumberOfThresholds(1);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< LevelSetImageType, LevelSetImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<LevelSetImageType, LevelSetImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( otsu->GetOutput() );
-  rescaler->SetOutputMinimum( 0 );
-  rescaler->SetOutputMaximum( 1 );
+  rescaler->SetInput(otsu->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(1);
 
   // convert a binary mask to a level-set function
-  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor< LevelSetImageType,
-    LevelSetType >;
+  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor<LevelSetImageType, LevelSetType>;
 
   BinaryImageToLevelSetType::Pointer adaptor = BinaryImageToLevelSetType::New();
-  adaptor->SetInputImage( rescaler->GetOutput() );
+  adaptor->SetInputImage(rescaler->GetOutput());
   adaptor->Initialize();
 
   LevelSetType::Pointer levelSet = adaptor->GetModifiableLevelSet();
 
   // Create the visualizer
-  using VisualizationType = itk::VTKVisualizeImageLevelSetIsoValues< InputImageType, LevelSetType >;
+  using VisualizationType = itk::VTKVisualizeImageLevelSetIsoValues<InputImageType, LevelSetType>;
   VisualizationType::Pointer visualizer = VisualizationType::New();
-  visualizer->SetInputImage( input );
-  visualizer->SetLevelSet( levelSet );
+  visualizer->SetInputImage(input);
+  visualizer->SetLevelSet(levelSet);
 
-  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor =
-      vtkSmartPointer<vtkRenderWindowInteractor>::New();
-  renderWindowInteractor->SetRenderWindow( visualizer->GetRenderWindow() );
+  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  renderWindowInteractor->SetRenderWindow(visualizer->GetRenderWindow());
 
   try
-    {
+  {
     visualizer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  bool interactive = ( std::stoi( argv[2] ) != 0 );
-  if( interactive )
-    {
+  bool interactive = (std::stoi(argv[2]) != 0);
+  if (interactive)
+  {
     renderWindowInteractor->Start();
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticMalcolm2DLevelSetLayers/Code.cxx
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticMalcolm2DLevelSetLayers/Code.cxx
@@ -26,81 +26,80 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "vtkRenderWindowInteractor.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << "<Input Image> <Interactive (0 or 1)>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Image Dimension
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   // Read input image (to be processed).
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   InputImageType::Pointer input = reader->GetOutput();
 
-  using LevelSetType = itk::MalcolmSparseLevelSetImage< Dimension >;
+  using LevelSetType = itk::MalcolmSparseLevelSetImage<Dimension>;
 
   // Generate a binary mask that will be used as initialization for the level
   // set evolution.
-  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter< InputImageType, InputImageType >;
+  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter<InputImageType, InputImageType>;
   OtsuFilterType::Pointer otsu = OtsuFilterType::New();
-  otsu->SetInput( input );
-  otsu->SetNumberOfHistogramBins( 256 );
-  otsu->SetNumberOfThresholds( 1 );
+  otsu->SetInput(input);
+  otsu->SetNumberOfHistogramBins(256);
+  otsu->SetNumberOfThresholds(1);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, InputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, InputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( otsu->GetOutput() );
-  rescaler->SetOutputMinimum( 0 );
-  rescaler->SetOutputMaximum( 1 );
+  rescaler->SetInput(otsu->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(1);
 
   // convert a binary mask to a level-set function
-  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor< InputImageType,
-    LevelSetType >;
+  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor<InputImageType, LevelSetType>;
 
   BinaryImageToLevelSetType::Pointer adaptor = BinaryImageToLevelSetType::New();
-  adaptor->SetInputImage( rescaler->GetOutput() );
+  adaptor->SetInputImage(rescaler->GetOutput());
   adaptor->Initialize();
 
   LevelSetType::Pointer levelSet = adaptor->GetModifiableLevelSet();
 
   // Create the visualizer
-  using VisualizationType = itk::VTKVisualize2DSparseLevelSetLayers< InputImageType, LevelSetType >;
+  using VisualizationType = itk::VTKVisualize2DSparseLevelSetLayers<InputImageType, LevelSetType>;
   VisualizationType::Pointer visualizer = VisualizationType::New();
-  visualizer->SetInputImage( input );
-  visualizer->SetLevelSet( levelSet );
-  visualizer->SetScreenCapture( true );
+  visualizer->SetInputImage(input);
+  visualizer->SetLevelSet(levelSet);
+  visualizer->SetScreenCapture(true);
 
-  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor =
-      vtkSmartPointer<vtkRenderWindowInteractor>::New();
-  renderWindowInteractor->SetRenderWindow( visualizer->GetRenderWindow() );
+  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  renderWindowInteractor->SetRenderWindow(visualizer->GetRenderWindow());
 
   try
-    {
+  {
     visualizer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  bool interactive = ( std::stoi( argv[2] ) != 0 );
-  if( interactive )
-    {
+  bool interactive = (std::stoi(argv[2]) != 0);
+  if (interactive)
+  {
     renderWindowInteractor->Start();
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticShi2DLevelSetLayers/Code.cxx
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticShi2DLevelSetLayers/Code.cxx
@@ -26,82 +26,81 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "vtkRenderWindowInteractor.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << "<Input Image> <Interactive (0 or 1)>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Image Dimension
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   // Read input image (to be processed).
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
   reader->Update();
 
   InputImageType::Pointer input = reader->GetOutput();
 
-  using LevelSetType = itk::ShiSparseLevelSetImage< Dimension >;
+  using LevelSetType = itk::ShiSparseLevelSetImage<Dimension>;
 
   // Generate a binary mask that will be used as initialization for the level
   // set evolution.
-  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter< InputImageType, InputImageType >;
+  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter<InputImageType, InputImageType>;
   OtsuFilterType::Pointer otsu = OtsuFilterType::New();
-  otsu->SetInput( input );
-  otsu->SetNumberOfHistogramBins( 256 );
-  otsu->SetNumberOfThresholds( 1 );
+  otsu->SetInput(input);
+  otsu->SetNumberOfHistogramBins(256);
+  otsu->SetNumberOfThresholds(1);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, InputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, InputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( otsu->GetOutput() );
-  rescaler->SetOutputMinimum( 0 );
-  rescaler->SetOutputMaximum( 1 );
+  rescaler->SetInput(otsu->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(1);
 
   // convert a binary mask to a level-set function
-  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor< InputImageType,
-    LevelSetType >;
+  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor<InputImageType, LevelSetType>;
 
   BinaryImageToLevelSetType::Pointer adaptor = BinaryImageToLevelSetType::New();
-  adaptor->SetInputImage( rescaler->GetOutput() );
+  adaptor->SetInputImage(rescaler->GetOutput());
   adaptor->Initialize();
 
   LevelSetType::Pointer levelSet = adaptor->GetModifiableLevelSet();
 
   // Create the visualizer
-  using VisualizationType = itk::VTKVisualize2DSparseLevelSetLayers< InputImageType, LevelSetType >;
+  using VisualizationType = itk::VTKVisualize2DSparseLevelSetLayers<InputImageType, LevelSetType>;
   VisualizationType::Pointer visualizer = VisualizationType::New();
-  visualizer->SetInputImage( input );
-  visualizer->SetLevelSet( levelSet );
-  visualizer->SetScreenCapture( true );
+  visualizer->SetInputImage(input);
+  visualizer->SetLevelSet(levelSet);
+  visualizer->SetScreenCapture(true);
 
-  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor =
-      vtkSmartPointer<vtkRenderWindowInteractor>::New();
-  renderWindowInteractor->SetRenderWindow( visualizer->GetRenderWindow() );
+  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  renderWindowInteractor->SetRenderWindow(visualizer->GetRenderWindow());
 
   try
-    {
+  {
     visualizer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  bool interactive = ( std::stoi( argv[2] ) != 0 );
-  if( interactive )
-    {
+  bool interactive = (std::stoi(argv[2]) != 0);
+  if (interactive)
+  {
     renderWindowInteractor->Start();
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticWhitaker2DLevelSetLayers/Code.cxx
+++ b/src/Segmentation/LevelSetsv4Visualization/VisualizeStaticWhitaker2DLevelSetLayers/Code.cxx
@@ -26,82 +26,81 @@
 #include "itkRescaleIntensityImageFilter.h"
 #include "vtkRenderWindowInteractor.h"
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
+  if (argc != 3)
+  {
     std::cerr << "Missing Arguments" << std::endl;
     std::cerr << argv[0] << std::endl;
     std::cerr << "<Input Image> <Interactive (0 or 1)>" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   // Image Dimension
   constexpr unsigned int Dimension = 2;
 
   using InputPixelType = unsigned char;
-  using InputImageType = itk::Image< InputPixelType, Dimension >;
+  using InputImageType = itk::Image<InputPixelType, Dimension>;
 
   // Read input image (to be processed).
-  using ReaderType = itk::ImageFileReader< InputImageType >;
+  using ReaderType = itk::ImageFileReader<InputImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   InputImageType::Pointer input = reader->GetOutput();
 
   using LevelSetPixelType = float;
-  using LevelSetType = itk::WhitakerSparseLevelSetImage< LevelSetPixelType, Dimension >;
+  using LevelSetType = itk::WhitakerSparseLevelSetImage<LevelSetPixelType, Dimension>;
 
   // Generate a binary mask that will be used as initialization for the level
   // set evolution.
-  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter< InputImageType, InputImageType >;
+  using OtsuFilterType = itk::OtsuMultipleThresholdsImageFilter<InputImageType, InputImageType>;
   OtsuFilterType::Pointer otsu = OtsuFilterType::New();
-  otsu->SetInput( input );
-  otsu->SetNumberOfHistogramBins( 256 );
-  otsu->SetNumberOfThresholds( 1 );
+  otsu->SetInput(input);
+  otsu->SetNumberOfHistogramBins(256);
+  otsu->SetNumberOfThresholds(1);
 
-  using RescaleType = itk::RescaleIntensityImageFilter< InputImageType, InputImageType >;
+  using RescaleType = itk::RescaleIntensityImageFilter<InputImageType, InputImageType>;
   RescaleType::Pointer rescaler = RescaleType::New();
-  rescaler->SetInput( otsu->GetOutput() );
-  rescaler->SetOutputMinimum( 0 );
-  rescaler->SetOutputMaximum( 1 );
+  rescaler->SetInput(otsu->GetOutput());
+  rescaler->SetOutputMinimum(0);
+  rescaler->SetOutputMaximum(1);
 
   // convert a binary mask to a level-set function
-  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor< InputImageType,
-    LevelSetType >;
+  using BinaryImageToLevelSetType = itk::BinaryImageToLevelSetImageAdaptor<InputImageType, LevelSetType>;
 
   BinaryImageToLevelSetType::Pointer adaptor = BinaryImageToLevelSetType::New();
-  adaptor->SetInputImage( rescaler->GetOutput() );
+  adaptor->SetInputImage(rescaler->GetOutput());
   adaptor->Initialize();
 
   LevelSetType::Pointer levelSet = adaptor->GetModifiableLevelSet();
 
   // Create the visualizer
-  using VisualizationType = itk::VTKVisualize2DSparseLevelSetLayers< InputImageType, LevelSetType >;
+  using VisualizationType = itk::VTKVisualize2DSparseLevelSetLayers<InputImageType, LevelSetType>;
   VisualizationType::Pointer visualizer = VisualizationType::New();
-  visualizer->SetInputImage( input );
-  visualizer->SetLevelSet( levelSet );
-  visualizer->SetScreenCapture( true );
+  visualizer->SetInputImage(input);
+  visualizer->SetLevelSet(levelSet);
+  visualizer->SetScreenCapture(true);
 
-  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor =
-      vtkSmartPointer<vtkRenderWindowInteractor>::New();
-  renderWindowInteractor->SetRenderWindow( visualizer->GetRenderWindow() );
+  vtkSmartPointer<vtkRenderWindowInteractor> renderWindowInteractor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  renderWindowInteractor->SetRenderWindow(visualizer->GetRenderWindow());
 
   try
-    {
+  {
     visualizer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  bool interactive = ( std::stoi( argv[2] ) != 0 );
-  if( interactive )
-    {
+  bool interactive = (std::stoi(argv[2]) != 0);
+  if (interactive)
+  {
     renderWindowInteractor->Start();
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/Code.cxx
+++ b/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/Code.cxx
@@ -31,19 +31,21 @@
 
 using PixelType = unsigned char;
 constexpr size_t Dimension = 3;
-using ImageType = itk::Image< PixelType, Dimension >;
+using ImageType = itk::Image<PixelType, Dimension>;
 
-static void CreateImage(ImageType::Pointer image);
+static void
+CreateImage(ImageType::Pointer image);
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);
 
   using ConnectedFilterType = itk::ConnectedThresholdImageFilter<ImageType, ImageType>;
   ConnectedFilterType::Pointer connectedThreshold = ConnectedFilterType::New();
-  float lower = 95.0;
-  float upper = 105.0;
+  float                        lower = 95.0;
+  float                        upper = 105.0;
   connectedThreshold->SetLower(lower);
   connectedThreshold->SetUpper(upper);
 
@@ -70,8 +72,7 @@ int main( int argc, char *argv[])
   ConnectorType::Pointer connector2 = ConnectorType::New();
   connector2->SetInput(image);
 
-  vtkSmartPointer<vtkImageActor> actor2 =
-    vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> actor2 = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
   actor2->SetInput(connector->GetOutput());
 #else
@@ -83,8 +84,7 @@ int main( int argc, char *argv[])
   ConnectorType::Pointer addConnector = ConnectorType::New();
   addConnector->SetInput(connectedThreshold->GetOutput());
 
-  vtkSmartPointer<vtkImageActor> addActor =
-    vtkSmartPointer<vtkImageActor>::New();
+  vtkSmartPointer<vtkImageActor> addActor = vtkSmartPointer<vtkImageActor>::New();
 #if VTK_MAJOR_VERSION <= 5
   addActor->SetInput(connector->GetOutput());
 #else
@@ -93,35 +93,30 @@ int main( int argc, char *argv[])
 #endif
 
   // There will be one render window
-  vtkSmartPointer<vtkRenderWindow> renderWindow =
-    vtkSmartPointer<vtkRenderWindow>::New();
+  vtkSmartPointer<vtkRenderWindow> renderWindow = vtkSmartPointer<vtkRenderWindow>::New();
   renderWindow->SetSize(900, 300);
 
-  vtkSmartPointer<vtkRenderWindowInteractor> interactor =
-    vtkSmartPointer<vtkRenderWindowInteractor>::New();
+  vtkSmartPointer<vtkRenderWindowInteractor> interactor = vtkSmartPointer<vtkRenderWindowInteractor>::New();
   interactor->SetRenderWindow(renderWindow);
 
   // Define viewport ranges
   // (xmin, ymin, xmax, ymax)
-  double leftViewport[4] = {0.0, 0.0, 0.33, 1.0};
-  double centerViewport[4] = {0.33, 0.0, 0.66, 1.0};
-  double rightViewport[4] = {0.66, 0.0, 1.0, 1.0};
+  double leftViewport[4] = { 0.0, 0.0, 0.33, 1.0 };
+  double centerViewport[4] = { 0.33, 0.0, 0.66, 1.0 };
+  double rightViewport[4] = { 0.66, 0.0, 1.0, 1.0 };
 
   // Setup both renderers
-  vtkSmartPointer<vtkRenderer> leftRenderer =
-    vtkSmartPointer<vtkRenderer>::New();
+  vtkSmartPointer<vtkRenderer> leftRenderer = vtkSmartPointer<vtkRenderer>::New();
   renderWindow->AddRenderer(leftRenderer);
   leftRenderer->SetViewport(leftViewport);
   leftRenderer->SetBackground(.6, .5, .4);
 
-  vtkSmartPointer<vtkRenderer> centerRenderer =
-    vtkSmartPointer<vtkRenderer>::New();
+  vtkSmartPointer<vtkRenderer> centerRenderer = vtkSmartPointer<vtkRenderer>::New();
   renderWindow->AddRenderer(centerRenderer);
   centerRenderer->SetViewport(centerViewport);
   centerRenderer->SetBackground(.4, .5, .6);
 
-  vtkSmartPointer<vtkRenderer> rightRenderer =
-    vtkSmartPointer<vtkRenderer>::New();
+  vtkSmartPointer<vtkRenderer> rightRenderer = vtkSmartPointer<vtkRenderer>::New();
   renderWindow->AddRenderer(rightRenderer);
   rightRenderer->SetViewport(rightViewport);
   rightRenderer->SetBackground(.4, .5, .6);
@@ -137,8 +132,7 @@ int main( int argc, char *argv[])
 
   renderWindow->Render();
 
-  vtkSmartPointer<vtkInteractorStyleImage> style =
-    vtkSmartPointer<vtkInteractorStyleImage>::New();
+  vtkSmartPointer<vtkInteractorStyleImage> style = vtkSmartPointer<vtkInteractorStyleImage>::New();
   interactor->SetInteractorStyle(style);
 
   interactor->Start();
@@ -147,11 +141,12 @@ int main( int argc, char *argv[])
   return EXIT_SUCCESS;
 }
 
-void CreateImage(ImageType::Pointer image)
+void
+CreateImage(ImageType::Pointer image)
 {
   // Create an image with 2 connected components
   ImageType::RegionType region;
-  ImageType::IndexType start;
+  ImageType::IndexType  start;
   start[0] = 0;
   start[1] = 0;
 
@@ -159,36 +154,35 @@ void CreateImage(ImageType::Pointer image)
   size[0] = 200;
   size[1] = 300;
 
-  region.SetSize( size);
+  region.SetSize(size);
   region.SetIndex(start);
 
   image->SetRegions(region);
   image->Allocate();
 
   // Make a square
-  for(unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; r++)
+  {
+    for (unsigned int c = 30; c < 100; c++)
     {
-    for(unsigned int c = 30; c < 100; c++)
-      {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
       pixelIndex[1] = c;
 
       image->SetPixel(pixelIndex, 100.0);
-      }
     }
+  }
 
   // Make another square
-  for(unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; r++)
+  {
+    for (unsigned int c = 115; c < 160; c++)
     {
-    for(unsigned int c = 115; c < 160; c++)
-      {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
       pixelIndex[1] = c;
 
       image->SetPixel(pixelIndex, 100.0);
-      }
     }
+  }
 }
-

--- a/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/Code.cxx
+++ b/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/Code.cxx
@@ -23,56 +23,51 @@
 #include <sstream>
 
 #ifdef ENABLE_QUICKVIEW
-#include "QuickView.h"
+#  include "QuickView.h"
 #endif
 
-using ImageType = itk::Image< unsigned char, 2 >;
+using ImageType = itk::Image<unsigned char, 2>;
 
-int main( int argc, char *argv[])
+int
+main(int argc, char * argv[])
 {
-    if(argc < 4)
-    {
-        std::cerr << "Required: filename.png seedX seedY" << std::endl;
+  if (argc < 4)
+  {
+    std::cerr << "Required: filename.png seedX seedY" << std::endl;
 
-        return EXIT_FAILURE;
-    }
-    std::string inputFileName = argv[1];
+    return EXIT_FAILURE;
+  }
+  std::string inputFileName = argv[1];
 
-    using ReaderType = itk::ImageFileReader<ImageType>;
-    ReaderType::Pointer reader = ReaderType::New();
-    reader->SetFileName(inputFileName.c_str());
-    reader->Update();
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(inputFileName.c_str());
+  reader->Update();
 
-    using ConfidenceConnectedFilterType = itk::ConfidenceConnectedImageFilter<ImageType, ImageType>;
-    ConfidenceConnectedFilterType::Pointer confidenceConnectedFilter = ConfidenceConnectedFilterType::New();
-    confidenceConnectedFilter->SetInitialNeighborhoodRadius(3);
-    confidenceConnectedFilter->SetMultiplier(3);
-    confidenceConnectedFilter->SetNumberOfIterations(25);
-    confidenceConnectedFilter->SetReplaceValue(255);
+  using ConfidenceConnectedFilterType = itk::ConfidenceConnectedImageFilter<ImageType, ImageType>;
+  ConfidenceConnectedFilterType::Pointer confidenceConnectedFilter = ConfidenceConnectedFilterType::New();
+  confidenceConnectedFilter->SetInitialNeighborhoodRadius(3);
+  confidenceConnectedFilter->SetMultiplier(3);
+  confidenceConnectedFilter->SetNumberOfIterations(25);
+  confidenceConnectedFilter->SetReplaceValue(255);
 
-    // Set seed
-    ImageType::IndexType seed;
-    seed[0] = std::stoi(argv[2]);
-    seed[1] = std::stoi(argv[3]);
-    confidenceConnectedFilter->SetSeed(seed);
-    confidenceConnectedFilter->SetInput(reader->GetOutput());
+  // Set seed
+  ImageType::IndexType seed;
+  seed[0] = std::stoi(argv[2]);
+  seed[1] = std::stoi(argv[3]);
+  confidenceConnectedFilter->SetSeed(seed);
+  confidenceConnectedFilter->SetInput(reader->GetOutput());
 
 #ifdef ENABLE_QUICKVIEW
-    QuickView viewer;
-    viewer.AddImage(
-            reader->GetOutput(),true,
-            itksys::SystemTools::GetFilenameName(inputFileName));
+  QuickView viewer;
+  viewer.AddImage(reader->GetOutput(), true, itksys::SystemTools::GetFilenameName(inputFileName));
 
-    std::stringstream desc;
-    desc << "ConfidenceConnected Seed: " << seed[0] << ", " << seed[1];
-    viewer.AddImage(
-            confidenceConnectedFilter->GetOutput(),
-            true,
-            desc.str());
+  std::stringstream desc;
+  desc << "ConfidenceConnected Seed: " << seed[0] << ", " << seed[1];
+  viewer.AddImage(confidenceConnectedFilter->GetOutput(), true, desc.str());
 
-    viewer.Visualize();
+  viewer.Visualize();
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
-

--- a/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
+++ b/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
@@ -19,150 +19,152 @@
 #include "itkImageFileWriter.h"
 #include "itkVTKPolyDataWriter.h"
 
-int main( int, char* [] )
+int
+main(int, char *[])
 {
-    constexpr double height = 100;
-    constexpr double width = 100;
+  constexpr double height = 100;
+  constexpr double width = 100;
 
-    using VoronoiDiagramType = itk::VoronoiDiagram2D<double>;
-    using VoronoiGeneratorType = itk::VoronoiDiagram2DGenerator<double>;
+  using VoronoiDiagramType = itk::VoronoiDiagram2D<double>;
+  using VoronoiGeneratorType = itk::VoronoiDiagram2DGenerator<double>;
 
-    using PointType = VoronoiDiagramType::PointType;
-    using CellType = VoronoiDiagramType::CellType;
-    using CellAutoPointer = VoronoiDiagramType::CellAutoPointer;
-    using PointIdIterator = CellType::PointIdIterator;
-    using NeighborIdIterator = VoronoiDiagramType::NeighborIdIterator;
+  using PointType = VoronoiDiagramType::PointType;
+  using CellType = VoronoiDiagramType::CellType;
+  using CellAutoPointer = VoronoiDiagramType::CellAutoPointer;
+  using PointIdIterator = CellType::PointIdIterator;
+  using NeighborIdIterator = VoronoiDiagramType::NeighborIdIterator;
 
-    VoronoiDiagramType::Pointer voronoiDiagram = VoronoiDiagramType::New();
-    VoronoiGeneratorType::Pointer voronoiGenerator = VoronoiGeneratorType::New();
+  VoronoiDiagramType::Pointer   voronoiDiagram = VoronoiDiagramType::New();
+  VoronoiGeneratorType::Pointer voronoiGenerator = VoronoiGeneratorType::New();
 
-    PointType insize;
-    insize[0] = width;
-    insize[1] = height;
-    voronoiGenerator->SetBoundary(insize);
+  PointType insize;
+  insize[0] = width;
+  insize[1] = height;
+  voronoiGenerator->SetBoundary(insize);
 
-    // Create a list of seeds
-    std::vector<PointType> seeds;
-    PointType seed0;
-    seed0[0] = 50;
-    seed0[1] = 50;
-    seeds.push_back(seed0);
+  // Create a list of seeds
+  std::vector<PointType> seeds;
+  PointType              seed0;
+  seed0[0] = 50;
+  seed0[1] = 50;
+  seeds.push_back(seed0);
 
-    PointType seed1;
-    seed1[0] = 25;
-    seed1[1] = 25;
-    seeds.push_back(seed1);
+  PointType seed1;
+  seed1[0] = 25;
+  seed1[1] = 25;
+  seeds.push_back(seed1);
 
-    PointType seed2;
-    seed2[0] = 75;
-    seed2[1] = 25;
-    seeds.push_back(seed2);
+  PointType seed2;
+  seed2[0] = 75;
+  seed2[1] = 25;
+  seeds.push_back(seed2);
 
-    PointType seed3;
-    seed3[0] = 25;
-    seed3[1] = 75;
-    seeds.push_back(seed3);
+  PointType seed3;
+  seed3[0] = 25;
+  seed3[1] = 75;
+  seeds.push_back(seed3);
 
-    PointType seed4;
-    seed4[0] = 75;
-    seed4[1] = 75;
-    seeds.push_back(seed4);
+  PointType seed4;
+  seed4[0] = 75;
+  seed4[1] = 75;
+  seeds.push_back(seed4);
 
-    for(const auto & seed : seeds)
+  for (const auto & seed : seeds)
+  {
+    voronoiGenerator->AddOneSeed(seed);
+  }
+
+  voronoiGenerator->Update();
+  voronoiDiagram = voronoiGenerator->GetOutput();
+
+  for (unsigned int i = 0; i < seeds.size(); i++)
+  {
+    PointType currP = voronoiDiagram->GetSeed(i);
+    std::cout << "Seed No." << i << ": At (" << currP[0] << "," << currP[1] << ")" << std::endl;
+    std::cout << "  Boundary Vertices List (in order):";
+    CellAutoPointer currCell;
+    voronoiDiagram->GetCellId(i, currCell);
+    PointIdIterator currCellP;
+    for (currCellP = currCell->PointIdsBegin(); currCellP != currCell->PointIdsEnd(); ++currCellP)
     {
-        voronoiGenerator->AddOneSeed(seed);
+      std::cout << (*currCellP) << ",";
     }
-
-    voronoiGenerator->Update();
-    voronoiDiagram = voronoiGenerator->GetOutput();
-
-    for(unsigned int i = 0; i < seeds.size(); i++)
+    std::cout << std::endl;
+    std::cout << "  Neighbors (Seed No.):";
+    NeighborIdIterator currNeibor;
+    for (currNeibor = voronoiDiagram->NeighborIdsBegin(i); currNeibor != voronoiDiagram->NeighborIdsEnd(i);
+         ++currNeibor)
     {
-        PointType currP = voronoiDiagram->GetSeed(i);
-        std::cout << "Seed No." << i << ": At (" << currP[0] << "," << currP[1] << ")" << std::endl;
-        std::cout << "  Boundary Vertices List (in order):";
-        CellAutoPointer currCell;
-        voronoiDiagram->GetCellId(i, currCell);
-        PointIdIterator currCellP;
-        for(currCellP = currCell->PointIdsBegin(); currCellP != currCell->PointIdsEnd(); ++currCellP)
-        {
-            std::cout << (*currCellP) << ",";
-        }
-        std::cout << std::endl;
-        std::cout << "  Neighbors (Seed No.):";
-        NeighborIdIterator currNeibor;
-        for(currNeibor = voronoiDiagram->NeighborIdsBegin(i); currNeibor != voronoiDiagram->NeighborIdsEnd(i); ++currNeibor)
-        {
-            std::cout << (*currNeibor) << ",";
-        }
-        std::cout << std::endl << std::endl;
+      std::cout << (*currNeibor) << ",";
     }
+    std::cout << std::endl << std::endl;
+  }
 
-    std::cout << "Vertices Informations:" << std::endl;
-    VoronoiDiagramType::VertexIterator allVerts;
-    int j = 0;
-    for(allVerts = voronoiDiagram->VertexBegin(); allVerts != voronoiDiagram->VertexEnd(); ++allVerts)
-    {
-        std::cout << "Vertices No." << j;
-        j++;
+  std::cout << "Vertices Informations:" << std::endl;
+  VoronoiDiagramType::VertexIterator allVerts;
+  int                                j = 0;
+  for (allVerts = voronoiDiagram->VertexBegin(); allVerts != voronoiDiagram->VertexEnd(); ++allVerts)
+  {
+    std::cout << "Vertices No." << j;
+    j++;
 #if ITK_VERSION_MAJOR < 4
-        std::cout << ": At (" << (*allVerts)[0] << "," << (*allVerts)[1] << ")" << std::endl;
+    std::cout << ": At (" << (*allVerts)[0] << "," << (*allVerts)[1] << ")" << std::endl;
 #else
-        std::cout << ": At (" << (allVerts.Value())[0] << "," << (allVerts.Value())[1] << ")" << std::endl;
+    std::cout << ": At (" << (allVerts.Value())[0] << "," << (allVerts.Value())[1] << ")" << std::endl;
 #endif
-    }
+  }
 
-    // Write the resulting mesh
-    using WriterType = itk::VTKPolyDataWriter<VoronoiDiagramType::Superclass>;
-    WriterType::Pointer vtkPolyDataWriter = WriterType::New();
-    vtkPolyDataWriter->SetInput(voronoiDiagram);
-    vtkPolyDataWriter->SetFileName("voronoi.vtk");
-    vtkPolyDataWriter->Update();
+  // Write the resulting mesh
+  using WriterType = itk::VTKPolyDataWriter<VoronoiDiagramType::Superclass>;
+  WriterType::Pointer vtkPolyDataWriter = WriterType::New();
+  vtkPolyDataWriter->SetInput(voronoiDiagram);
+  vtkPolyDataWriter->SetFileName("voronoi.vtk");
+  vtkPolyDataWriter->Update();
 
-    // Setup an image to visualize the input
-    {
-        using ImageType = itk::Image< unsigned char, 2>;
+  // Setup an image to visualize the input
+  {
+    using ImageType = itk::Image<unsigned char, 2>;
 
-        ImageType::IndexType start;
-        start.Fill(0);
+    ImageType::IndexType start;
+    start.Fill(0);
 
-        ImageType::SizeType size;
-        size.Fill(100);
+    ImageType::SizeType size;
+    size.Fill(100);
 
-        ImageType::RegionType region(start,size);
+    ImageType::RegionType region(start, size);
 
-        ImageType::Pointer image = ImageType::New();
-        image->SetRegions(region);
-        image->Allocate();
-        image->FillBuffer(0);
+    ImageType::Pointer image = ImageType::New();
+    image->SetRegions(region);
+    image->Allocate();
+    image->FillBuffer(0);
 
-        ImageType::IndexType ind;
-        ind[0] = 50;
-        ind[1] = 50;
-        image->SetPixel(ind, 255);
+    ImageType::IndexType ind;
+    ind[0] = 50;
+    ind[1] = 50;
+    image->SetPixel(ind, 255);
 
-        ind[0] = 25;
-        ind[1] = 25;
-        image->SetPixel(ind, 255);
+    ind[0] = 25;
+    ind[1] = 25;
+    image->SetPixel(ind, 255);
 
-        ind[0] = 75;
-        ind[1] = 25;
-        image->SetPixel(ind, 255);
+    ind[0] = 75;
+    ind[1] = 25;
+    image->SetPixel(ind, 255);
 
-        ind[0] = 25;
-        ind[1] = 75;
-        image->SetPixel(ind, 255);
+    ind[0] = 25;
+    ind[1] = 75;
+    image->SetPixel(ind, 255);
 
-        ind[0] = 75;
-        ind[1] = 75;
-        image->SetPixel(ind, 255);
+    ind[0] = 75;
+    ind[1] = 75;
+    image->SetPixel(ind, 255);
 
-        using ImageWriterType = itk::ImageFileWriter< ImageType  >;
-        ImageWriterType::Pointer imageFileWriter = ImageWriterType::New();
-        imageFileWriter->SetFileName("image.png");
-        imageFileWriter->SetInput(image);
-        imageFileWriter->Update();
-    }
+    using ImageWriterType = itk::ImageFileWriter<ImageType>;
+    ImageWriterType::Pointer imageFileWriter = ImageWriterType::New();
+    imageFileWriter->SetFileName("image.png");
+    imageFileWriter->SetInput(image);
+    imageFileWriter->Update();
+  }
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }

--- a/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/Code.cxx
+++ b/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/Code.cxx
@@ -40,130 +40,132 @@ using RGBPixelType = itk::RGBPixel<unsigned char>;
 using RGBImageType = itk::Image<RGBPixelType, 2>;
 using LabeledImageType = itk::Image<unsigned long, 2>;
 
-static void CreateImage(UnsignedCharImageType::Pointer image);
-static void PerformSegmentation(FloatImageType::Pointer image, const float threshold, const float level);
+static void
+CreateImage(UnsignedCharImageType::Pointer image);
+static void
+PerformSegmentation(FloatImageType::Pointer image, const float threshold, const float level);
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-    // Verify arguments
-    if (argc < 3 )
-    {
-        std::cerr << "Parameters " << std::endl;
-        std::cerr << " threshold level" << std::endl;
-        return 1;
-    }
+  // Verify arguments
+  if (argc < 3)
+  {
+    std::cerr << "Parameters " << std::endl;
+    std::cerr << " threshold level" << std::endl;
+    return 1;
+  }
 
-    // Parse arguments
-    std::string strThreshold = argv[1];
-    float threshold = 0.0;
-    std::stringstream ssThreshold;
-    ssThreshold << strThreshold;
-    ssThreshold >> threshold;
+  // Parse arguments
+  std::string       strThreshold = argv[1];
+  float             threshold = 0.0;
+  std::stringstream ssThreshold;
+  ssThreshold << strThreshold;
+  ssThreshold >> threshold;
 
-    std::string strLevel = argv[2];
-    float level = 0.0;
-    std::stringstream ssLevel;
-    ssLevel << strLevel;
-    ssLevel >> level;
+  std::string       strLevel = argv[2];
+  float             level = 0.0;
+  std::stringstream ssLevel;
+  ssLevel << strLevel;
+  ssLevel >> level;
 
-    // Output arguments
-    std::cout << "Running with:" << std::endl
-              << "Threshold: " << threshold << std::endl
-              << "Level: " << level << std::endl;
+  // Output arguments
+  std::cout << "Running with:" << std::endl
+            << "Threshold: " << threshold << std::endl
+            << "Level: " << level << std::endl;
 
-    UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
-    CreateImage(image);
+  UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
+  CreateImage(image);
 
-    using GradientMagnitudeImageFilterType = itk::GradientMagnitudeImageFilter<
-            UnsignedCharImageType, FloatImageType >;
-    GradientMagnitudeImageFilterType::Pointer gradientMagnitudeImageFilter = GradientMagnitudeImageFilterType::New();
-    gradientMagnitudeImageFilter->SetInput(image);
-    gradientMagnitudeImageFilter->Update();
+  using GradientMagnitudeImageFilterType = itk::GradientMagnitudeImageFilter<UnsignedCharImageType, FloatImageType>;
+  GradientMagnitudeImageFilterType::Pointer gradientMagnitudeImageFilter = GradientMagnitudeImageFilterType::New();
+  gradientMagnitudeImageFilter->SetInput(image);
+  gradientMagnitudeImageFilter->Update();
 
-    // Custom parameters
-    PerformSegmentation(gradientMagnitudeImageFilter->GetOutput(), threshold, level);
+  // Custom parameters
+  PerformSegmentation(gradientMagnitudeImageFilter->GetOutput(), threshold, level);
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }
 
 
-void CreateImage(UnsignedCharImageType::Pointer image)
+void
+CreateImage(UnsignedCharImageType::Pointer image)
 {
-    // Create a white image with 3 dark regions of different values
+  // Create a white image with 3 dark regions of different values
 
-    itk::Index<2> start;
-    start.Fill(0);
+  itk::Index<2> start;
+  start.Fill(0);
 
-    itk::Size<2> size;
-    size.Fill(200);
+  itk::Size<2> size;
+  size.Fill(200);
 
-    itk::ImageRegion<2> region(start,size);
-    image->SetRegions(region);
-    image->Allocate();
-    image->FillBuffer(255);
+  itk::ImageRegion<2> region(start, size);
+  image->SetRegions(region);
+  image->Allocate();
+  image->FillBuffer(255);
 
-    itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image,region);
+  itk::ImageRegionIterator<UnsignedCharImageType> imageIterator(image, region);
 
-    while(!imageIterator.IsAtEnd())
-    {
-        if(imageIterator.GetIndex()[0] > 20 && imageIterator.GetIndex()[0] < 50 &&
-           imageIterator.GetIndex()[1] > 20 && imageIterator.GetIndex()[1] < 50)
-            imageIterator.Set(50);
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 20 && imageIterator.GetIndex()[0] < 50 && imageIterator.GetIndex()[1] > 20 &&
+        imageIterator.GetIndex()[1] < 50)
+      imageIterator.Set(50);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
-    imageIterator.GoToBegin();
+  imageIterator.GoToBegin();
 
-    while(!imageIterator.IsAtEnd())
-    {
-        if(imageIterator.GetIndex()[0] > 60 && imageIterator.GetIndex()[0] < 80 &&
-           imageIterator.GetIndex()[1] > 60 && imageIterator.GetIndex()[1] < 80)
-            imageIterator.Set(100);
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 60 && imageIterator.GetIndex()[0] < 80 && imageIterator.GetIndex()[1] > 60 &&
+        imageIterator.GetIndex()[1] < 80)
+      imageIterator.Set(100);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
-    imageIterator.GoToBegin();
+  imageIterator.GoToBegin();
 
-    while(!imageIterator.IsAtEnd())
-    {
-        if(imageIterator.GetIndex()[0] > 100 && imageIterator.GetIndex()[0] < 130 &&
-           imageIterator.GetIndex()[1] > 100 && imageIterator.GetIndex()[1] < 130)
-            imageIterator.Set(150);
+  while (!imageIterator.IsAtEnd())
+  {
+    if (imageIterator.GetIndex()[0] > 100 && imageIterator.GetIndex()[0] < 130 && imageIterator.GetIndex()[1] > 100 &&
+        imageIterator.GetIndex()[1] < 130)
+      imageIterator.Set(150);
 
-        ++imageIterator;
-    }
+    ++imageIterator;
+  }
 
-    using FileWriterType = itk::ImageFileWriter<UnsignedCharImageType>;
-    FileWriterType::Pointer writer = FileWriterType::New();
-    writer->SetFileName("input.png");
-    writer->SetInput(image);
-    writer->Update();
+  using FileWriterType = itk::ImageFileWriter<UnsignedCharImageType>;
+  FileWriterType::Pointer writer = FileWriterType::New();
+  writer->SetFileName("input.png");
+  writer->SetInput(image);
+  writer->Update();
 }
 
-void PerformSegmentation(FloatImageType::Pointer image, const float threshold, const float level)
+void
+PerformSegmentation(FloatImageType::Pointer image, const float threshold, const float level)
 {
-    using MorphologicalWatershedFilterType = itk::MorphologicalWatershedImageFilter<FloatImageType, LabeledImageType>;
-    MorphologicalWatershedFilterType::Pointer watershedFilter = MorphologicalWatershedFilterType::New();
-    watershedFilter->SetLevel(level);
-    watershedFilter->SetInput(image);
-    watershedFilter->Update();
+  using MorphologicalWatershedFilterType = itk::MorphologicalWatershedImageFilter<FloatImageType, LabeledImageType>;
+  MorphologicalWatershedFilterType::Pointer watershedFilter = MorphologicalWatershedFilterType::New();
+  watershedFilter->SetLevel(level);
+  watershedFilter->SetInput(image);
+  watershedFilter->Update();
 
-    using RGBFilterType = itk::ScalarToRGBColormapImageFilter<LabeledImageType, RGBImageType>;
-    RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
-    colormapImageFilter->SetInput(watershedFilter->GetOutput());
-    colormapImageFilter->SetColormap( itk::RGBColormapFilterEnumType::Jet );
-    colormapImageFilter->Update();
+  using RGBFilterType = itk::ScalarToRGBColormapImageFilter<LabeledImageType, RGBImageType>;
+  RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
+  colormapImageFilter->SetInput(watershedFilter->GetOutput());
+  colormapImageFilter->SetColormap(itk::RGBColormapFilterEnumType::Jet);
+  colormapImageFilter->Update();
 
-    std::stringstream ss;
-    ss << "output_" << threshold << "_" << level << ".png";
+  std::stringstream ss;
+  ss << "output_" << threshold << "_" << level << ".png";
 
-    using FileWriterType = itk::ImageFileWriter<RGBImageType>;
-    FileWriterType::Pointer writer = FileWriterType::New();
-    writer->SetFileName(ss.str());
-    writer->SetInput(colormapImageFilter->GetOutput());
-    writer->Update();
-
+  using FileWriterType = itk::ImageFileWriter<RGBImageType>;
+  FileWriterType::Pointer writer = FileWriterType::New();
+  writer->SetFileName(ss.str());
+  writer->SetInput(colormapImageFilter->GetOutput());
+  writer->Update();
 }
-

--- a/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/Code.cxx
+++ b/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/Code.cxx
@@ -32,57 +32,56 @@
 // ./SegmentWithWatershedImageFilter BrainProtonDensitySlice.png OutBrainWatershed.png 0.005 .5
 // (A rule of thumb is to set the Threshold to be about 1 / 100 of the Level.)
 
-int main( int argc, char *argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc < 5 )
-    {
+  if (argc < 5)
+  {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0]
-      << " inputImageFile outputImageFile threshold level" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " inputImageFile outputImageFile threshold level" << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
-  using InputImageType = itk::Image< unsigned char, Dimension >;
-  using FloatImageType = itk::Image< float, Dimension >;
-  using RGBPixelType = itk::RGBPixel< unsigned char >;
-  using RGBImageType = itk::Image< RGBPixelType, Dimension >;
-  using LabeledImageType = itk::Image< itk::IdentifierType, Dimension >;
+  using InputImageType = itk::Image<unsigned char, Dimension>;
+  using FloatImageType = itk::Image<float, Dimension>;
+  using RGBPixelType = itk::RGBPixel<unsigned char>;
+  using RGBImageType = itk::Image<RGBPixelType, Dimension>;
+  using LabeledImageType = itk::Image<itk::IdentifierType, Dimension>;
 
-  using FileReaderType = itk::ImageFileReader< InputImageType >;
+  using FileReaderType = itk::ImageFileReader<InputImageType>;
   FileReaderType::Pointer reader = FileReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
-  using GradientMagnitudeImageFilterType = itk::GradientMagnitudeImageFilter< InputImageType, FloatImageType >;
-  GradientMagnitudeImageFilterType::Pointer gradientMagnitudeImageFilter =
-    GradientMagnitudeImageFilterType::New();
+  using GradientMagnitudeImageFilterType = itk::GradientMagnitudeImageFilter<InputImageType, FloatImageType>;
+  GradientMagnitudeImageFilterType::Pointer gradientMagnitudeImageFilter = GradientMagnitudeImageFilterType::New();
 
-  gradientMagnitudeImageFilter->SetInput( reader->GetOutput() );
+  gradientMagnitudeImageFilter->SetInput(reader->GetOutput());
   gradientMagnitudeImageFilter->Update();
 
-  using WatershedFilterType = itk::WatershedImageFilter< FloatImageType >;
+  using WatershedFilterType = itk::WatershedImageFilter<FloatImageType>;
   WatershedFilterType::Pointer watershed = WatershedFilterType::New();
 
-  float threshold = std::stod( argv[3] );
-  float level = std::stod( argv[4] );
+  float threshold = std::stod(argv[3]);
+  float level = std::stod(argv[4]);
 
-  watershed->SetThreshold( threshold );
-  watershed->SetLevel( level );
+  watershed->SetThreshold(threshold);
+  watershed->SetLevel(level);
 
-  watershed->SetInput( gradientMagnitudeImageFilter->GetOutput() );
+  watershed->SetInput(gradientMagnitudeImageFilter->GetOutput());
   watershed->Update();
 
-  using RGBFilterType = itk::ScalarToRGBColormapImageFilter< LabeledImageType, RGBImageType>;
+  using RGBFilterType = itk::ScalarToRGBColormapImageFilter<LabeledImageType, RGBImageType>;
   RGBFilterType::Pointer colormapImageFilter = RGBFilterType::New();
-  colormapImageFilter->SetColormap( itk::RGBColormapFilterEnumType::Jet );
-  colormapImageFilter->SetInput( watershed->GetOutput() );
+  colormapImageFilter->SetColormap(itk::RGBColormapFilterEnumType::Jet);
+  colormapImageFilter->SetInput(watershed->GetOutput());
   colormapImageFilter->Update();
 
-  using FileWriterType = itk::ImageFileWriter< RGBImageType >;
+  using FileWriterType = itk::ImageFileWriter<RGBImageType>;
   FileWriterType::Pointer writer = FileWriterType::New();
-  writer->SetFileName( argv[2] );
-  writer->SetInput( colormapImageFilter->GetOutput() );
+  writer->SetFileName(argv[2]);
+  writer->SetInput(colormapImageFilter->GetOutput());
   writer->Update();
 
   return EXIT_SUCCESS;

--- a/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/Code.cxx
+++ b/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/Code.cxx
@@ -23,47 +23,48 @@
 // includes from OpenCV
 #include "cv.h"
 #if CV_VERSION_MAJOR > 2
-#include "opencv2/opencv.hpp" // cv::imwrite
+#  include "opencv2/opencv.hpp" // cv::imwrite
 #endif
 
 
 #if CV_VERSION_MAJOR > 2
-#include "opencv2/opencv.hpp" // cv::imwrite
+#  include "opencv2/opencv.hpp" // cv::imwrite
 #endif
 
-int main( int argc, char* argv[] )
+int
+main(int argc, char * argv[])
 {
-  if( argc != 3 )
-    {
-    std::cerr << "Usage: "<< std::endl;
+  if (argc != 3)
+  {
+    std::cerr << "Usage: " << std::endl;
     std::cerr << argv[0];
     std::cerr << "<InputFileName> <OutputFileName>";
     std::cerr << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
   constexpr unsigned int Dimension = 2;
 
   using PixelType = unsigned char;
-  using ImageType = itk::Image< PixelType, Dimension >;
+  using ImageType = itk::Image<PixelType, Dimension>;
 
-  using ReaderType = itk::ImageFileReader< ImageType >;
+  using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName( argv[1] );
+  reader->SetFileName(argv[1]);
 
   try
-    {
+  {
     reader->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
+  }
+  catch (itk::ExceptionObject & error)
+  {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
-    }
+  }
 
-  cv::Mat img = itk::OpenCVImageBridge::ITKImageToCVMat< ImageType >( reader->GetOutput() );
+  cv::Mat img = itk::OpenCVImageBridge::ITKImageToCVMat<ImageType>(reader->GetOutput());
 
-  cv::imwrite( argv[2], img );
+  cv::imwrite(argv[2], img);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This patch updates the ITK preferred style to one that can be
automatically enforced, integrated with many IDE's, and based
on externally defined documentation and examples.

See: https://discourse.itk.org/t/update-coding-style-for-itk/2055

Most of the changes make inconsistent coding practices consistent
throughout the toolkit.  Community discussions regarding changes
to the current defined coding style are explicitly not included
in this request so that they can be independantly reviewed and
considered.

One large change is changing the {} indentation style from
`Whitesmiths` style https://en.wikipedia.org/wiki/Indentation_style#Whitesmiths_style
to an indentation style consistent with many of the other common
indentation styles.  The primary reason for this change is to
overcome the common deficiency of IDE's and formatters to support
this uncommon style choice.

Many ITK developers provided insightful comments and suggestions that
resulted in this set of style comprimises.