### PR TITLE
BUG: Fix path for GitSetup.git

### DIFF
--- a/Utilities/GitSetup/config
+++ b/Utilities/GitSetup/config
@@ -1,5 +1,5 @@
 [hooks]
-	url = public.kitware.com/GitSetup.git
+	url = https://public.kitware.com/GitSetup.git
 [upstream]
 	url = https://github.com/InsightSoftwareConsortium/ITKExamples.git
 	remote = upstream


### PR DESCRIPTION
Fixing the path for the GitSetup.git, as running SetupForDevelopment.sh failed to find the repository at the link specified. 