### PR TITLE
BUG: Use sphinx-build executable from Superbuild

### DIFF
--- a/CMake/FindSphinx.cmake
+++ b/CMake/FindSphinx.cmake
@@ -11,6 +11,7 @@ if(PYTHON_EXECUTABLE)
   get_filename_component(_python_dir "${PYTHON_EXECUTABLE}" DIRECTORY)
   list(APPEND _python_paths
     "${_python_dir}"
+    "${_python_dir}/bin"
     "${_python_dir}/Scripts"
     )
 endif()

--- a/Superbuild/External-Python.cmake
+++ b/Superbuild/External-Python.cmake
@@ -3,8 +3,10 @@ find_package(PythonInterp 3 REQUIRED)
 set(_itk_venv "${CMAKE_CURRENT_BINARY_DIR}/itkpython")
 if(WIN32)
   set(ITKPYTHON_EXECUTABLE "${_itk_venv}/python.exe" CACHE FILEPATH "Python executable with the ITK package installed" FORCE)
+  set(SPHINX_EXECUTABLE "${_itk_venv}/Scripts/sphinx-build.exe" CACHE FILEPATH "Sphinx executable" FORCE)
 else()
   set(ITKPYTHON_EXECUTABLE "${_itk_venv}/bin/python" CACHE FILEPATH "Python executable with the ITK package installed" FORCE)
+  set(SPHINX_EXECUTABLE "${_itk_venv}/bin/sphinx-build" CACHE FILEPATH "Sphinx executable" FORCE)
 endif()
 
 ExternalProject_Add(ITKPython


### PR DESCRIPTION
This ensures we have a new enough version of sphinx. The system version
on Ubuntu 18.04 yields:

  Running Sphinx v1.6.7

  Exception occurred:
    File "/home/kitware/Dashboards/Tests/ITKExamples-doc-build/ITKEx-build/Utilities/SphinxExtensions/breathe/breathe/renderer/sphinxrenderer.py", line 89, in DomainDirectiveFactory
      'union': (cpp.CPPUnionObject, 'union'),
  AttributeError: module 'sphinx.domains.cpp' has no attribute 'CPPUnionObject'

  xref https://github.com/sphinx-doc/sphinx/issues/6285