### PR TITLE
DOC: Improve example to provide more complete usage

### DIFF
--- a/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.cxx
@@ -54,6 +54,7 @@ main(int argc, char * argv[])
   BinaryDilateImageFilterType::Pointer dilateFilter = BinaryDilateImageFilterType::New();
   dilateFilter->SetInput(reader->GetOutput());
   dilateFilter->SetKernel(structuringElement);
+  dilateFilter->SetForegroundValue(255); //Value to dilate
 
   using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();

--- a/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.py
+++ b/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import sys
-
 import itk
 
 if len(sys.argv) != 4:
@@ -44,6 +43,7 @@ DilateFilterType = itk.BinaryDilateImageFilter[ImageType,
 dilateFilter = DilateFilterType.New()
 dilateFilter.SetInput(reader.GetOutput())
 dilateFilter.SetKernel(structuringElement)
+dilateFilter.SetForegroundValue(255)
 
 WriterType = itk.ImageFileWriter[ImageType]
 writer = WriterType.New()

--- a/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.cxx
@@ -54,6 +54,8 @@ main(int argc, char * argv[])
   BinaryErodeImageFilterType::Pointer erodeFilter = BinaryErodeImageFilterType::New();
   erodeFilter->SetInput(reader->GetOutput());
   erodeFilter->SetKernel(structuringElement);
+  erodeFilter->SetForegroundValue(255); // Intensity value to erode
+  erodeFilter->SetBackgroundValue(0);   // Replacement value for eroded voxels
 
   using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();

--- a/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.py
+++ b/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.py
@@ -14,9 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 import itk
+import sys
 
 if len(sys.argv) != 4:
     print("Usage: " + sys.argv[0] + " <inputImage> <outputImage> <radius>")
@@ -44,6 +43,8 @@ ErodeFilterType = itk.BinaryErodeImageFilter[ImageType,
 erodeFilter = ErodeFilterType.New()
 erodeFilter.SetInput(reader.GetOutput())
 erodeFilter.SetKernel(structuringElement)
+erodeFilter.SetForegroundValue(255) # Intensity value to erode
+erodeFilter.SetBackgroundValue(0)   # Replacement value for eroded voxels
 
 WriterType = itk.ImageFileWriter[ImageType]
 writer = WriterType.New()

--- a/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/Code.cxx
@@ -54,7 +54,8 @@ main(int argc, char * argv[])
   BinaryErodeImageFilterType::Pointer erodeFilter = BinaryErodeImageFilterType::New();
   erodeFilter->SetInput(reader->GetOutput());
   erodeFilter->SetKernel(structuringElement);
-  erodeFilter->SetErodeValue(255);
+  erodeFilter->SetForegroundValue(255); // Intensity value to erode
+  erodeFilter->SetBackgroundValue(0);   // Replacement value for eroded voxels
 
 #ifdef ENABLE_QUICKVIEW
   QuickView viewer;


### PR DESCRIPTION
The examples used default values that required the image
that was processed to only have values of 0 and 255.

The examples now explicitly set the foreground value of
255 to indicate that this may need to be set by the user
based on the data intensity values used as inputs.