### PR TITLE
STYLE: Prefer making deleted functions public

### DIFF
--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -9,6 +9,7 @@ template <class TImage>
 class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ImageFilter);
   /** Standard class type alias. */
   using Self = ImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -27,11 +28,6 @@ protected:
   /** Does the real work. */
   void
   GenerateData() override;
-
-private:
-  ImageFilter(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -9,6 +9,7 @@ template <class TImage>
 class ImageFilterMultipleOutputs : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ImageFilterMultipleOutputs);
   /** Standard class type alias. */
   using Self = ImageFilterMultipleOutputs;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -37,10 +38,6 @@ protected:
   DataObject::Pointer
   MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
 
-private:
-  ImageFilterMultipleOutputs(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -9,6 +9,7 @@ template <class TImage>
 class MyInPlaceImageFilter : public InPlaceImageFilter<TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MyInPlaceImageFilter);
   /** Standard class type alias. */
   using Self = MyInPlaceImageFilter;
   using Superclass = InPlaceImageFilter<TImage>;
@@ -27,11 +28,6 @@ protected:
   /** Does the real work. */
   void
   GenerateData() override;
-
-private:
-  MyInPlaceImageFilter(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/itkImageFilterMultipleInputs.h
+++ b/src/Developer/itkImageFilterMultipleInputs.h
@@ -9,6 +9,7 @@ template <class TImage>
 class ImageFilterMultipleInputs : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ImageFilterMultipleInputs);
   /** Standard class type alias. */
   using Self = ImageFilterMultipleInputs;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -35,11 +36,6 @@ protected:
   /** Does the real work. */
   void
   GenerateData() override;
-
-private:
-  ImageFilterMultipleInputs(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/itkOilPaintingImageFilter.h
+++ b/src/Developer/itkOilPaintingImageFilter.h
@@ -18,6 +18,7 @@ template <class TImage>
 class OilPaintingImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(OilPaintingImageFilter);
   /** Standard class type alias. */
   using Self = OilPaintingImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -50,10 +51,6 @@ protected:
   DynamicThreadedGenerateData(const typename TImage::RegionType & outputRegionForThread) override;
 
 private:
-  OilPaintingImageFilter(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
-
   typename TImage::ValueType                        m_Maximum, m_Minimum;
   typename NeighborhoodIterator<TImage>::RadiusType m_Radius;
   unsigned int                                      m_NumberOfBins;

--- a/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
@@ -11,6 +11,7 @@ namespace itk
 class ExampleCostFunction2 : public SingleValuedCostFunction
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ExampleCostFunction2);
   /** Standard class typedefs. */
   typedef ExampleCostFunction2     Self;
   typedef SingleValuedCostFunction Superclass;
@@ -44,11 +45,6 @@ public:
 protected:
   ExampleCostFunction2() = default;
   ~ExampleCostFunction2() override = default;
-
-private:
-  ExampleCostFunction2(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 
 } // end namespace itk


### PR DESCRIPTION
Deleting a function affects fundamental aspects of the client
interface of a class, and hiding them in private as if they
were implementation details is unhelpful.

Unfortunately, this was historically necessary for C++98, but no
longer required with C++11.

Co-authored-by: Hans Johnson  <hans-johnson@uiowa.edu>