### PR TITLE
BUG: Disable AdaptiveHistogramEqualization Python tests

### DIFF
--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
@@ -87,6 +87,8 @@ add_test(NAME AdaptiveHistogramEqualizationImageFilterTest04
     ${radius04}
     )
 
+# Not supported in itk 5.1.0
+if(0)
 if(ITK_WRAP_PYTHON)
   add_test(NAME AdaptiveHistogramEqualizationImageFilterTest01Python
     COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
@@ -136,4 +138,5 @@ if(ITK_WRAP_PYTHON)
       ${beta02}
       ${radius04}
     )
+endif()
 endif()

--- a/src/Filtering/ImageStatistics/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/CMakeLists.txt
@@ -2,14 +2,14 @@
 add_example(AdaptiveHistogramEqualizationImageFilter)
 
 foreach( i RANGE 1 6 )
-  compare_to_baseline(
-    EXAMPLE_NAME AdaptiveHistogramEqualizationImageFilter
-    TEST_NAME AdaptiveHistogramEqualizationImageFilterTest0${i}BaselineComparison
-    TEST_IMAGE AdaptiveHistogramEqualizationImageFilterTest0${i}.png
-    BASELINE_PREFIX AdaptiveHistogramEqualizationImageFilter0${i}Baseline
-    OPTIONS --tolerance-intensity 1
-    DEPENDS AdaptiveHistogramEqualizationImageFilterTest0${i}
-  )
+  #compare_to_baseline(
+    #EXAMPLE_NAME AdaptiveHistogramEqualizationImageFilter
+    #TEST_NAME AdaptiveHistogramEqualizationImageFilterTest0${i}BaselineComparison
+    #TEST_IMAGE AdaptiveHistogramEqualizationImageFilterTest0${i}.png
+    #BASELINE_PREFIX AdaptiveHistogramEqualizationImageFilter0${i}Baseline
+    #OPTIONS --tolerance-intensity 1
+    #DEPENDS AdaptiveHistogramEqualizationImageFilterTest0${i}
+  #)
 
   # compare_to_baseline(
     # EXAMPLE_NAME AdaptiveHistogramEqualizationImageFilter


### PR DESCRIPTION
AdaptiveHistogramEqualization is not availabel with the itk-5.1.0.post1
Python wrapping because an upgrade to Swig 4.0 causes segfault's during
swig execution with the AdaptiveHistogramEqualizationImageFilter module
wrapping.