### PR TITLE
BUG: Update VTK Git clone URL

### DIFF
--- a/Superbuild/External-VTK.cmake
+++ b/Superbuild/External-VTK.cmake
@@ -8,7 +8,7 @@ endif()
 set(PYTHON_EXECUTABLE "${ITKPYTHON_EXECUTABLE}")
 
 ExternalProject_Add(VTK
-  GIT_REPOSITORY "${git_protocol}://vtk.org/VTK.git"
+  GIT_REPOSITORY "https://gitlab.kitware.com/VTK/VTK.git"
   GIT_TAG "${VTK_TAG}"
   SOURCE_DIR VTK
   BINARY_DIR VTK-build
@@ -23,7 +23,7 @@ ExternalProject_Add(VTK
     -DModule_vtkImagingMath:BOOL=ON
     -DVTK_WRAP_PYTHON:BOOL=ON
     -DExternalData_OBJECT_STORES:STRING=${ExternalData_OBJECT_STORES}
-    "-DPYTHON_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}"
+    "-DPython3_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE}"
     -DVTK_USE_SYSTEM_ZLIB:BOOL=ON
     "-DZLIB_ROOT:PATH=${ZLIB_ROOT}"
     "-DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}"


### PR DESCRIPTION
The old URL, git protocol, is no longer supported.