### PR TITLE
ENH: Add Python code for `GetTypeBasicInformation` example

### DIFF
--- a/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
+++ b/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
@@ -21,3 +21,9 @@ install( FILES Code.cxx CMakeLists.txt
 enable_testing()
 add_test( NAME GetTypeBasicInformationTest
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GetTypeBasicInformation )
+
+if( ITK_WRAP_PYTHON )
+  add_test( NAME GetTypeBasicInformationTestPython
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
+    )
+endif()

--- a/src/Core/Common/GetTypeBasicInformation/Code.py
+++ b/src/Core/Common/GetTypeBasicInformation/Code.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itk
+
+MyType = itk.F
+
+print("Min: " + str(itk.NumericTraits[MyType].min()))
+print("Max: " + str(itk.NumericTraits[MyType].max()))
+print("Zero: " + str(itk.NumericTraits[MyType].Zero()))
+print("ZeroValue: " + str(itk.NumericTraits[MyType].ZeroValue()))
+
+print("Is -1 negative? " + str(itk.NumericTraits[MyType].IsNegative(-1)))
+
+print("Is 1 negative? " + str(itk.NumericTraits[MyType].IsNegative(1)))
+
+print("One: " + str(itk.NumericTraits[MyType].One))
+
+print("Epsilon: " + str(itk.NumericTraits[MyType].epsilon()))
+
+print("Infinity: " + str(itk.NumericTraits[MyType].infinity()))
+
+if 0 == itk.NumericTraits[MyType].infinity():
+    print(" 0 == inf!")
+    exit(1)
+else:
+    print("Good")
+    exit(0)

--- a/src/Core/Common/GetTypeBasicInformation/Documentation.rst
+++ b/src/Core/Common/GetTypeBasicInformation/Documentation.rst
@@ -37,6 +37,13 @@ C++
 .. literalinclude:: Code.cxx
    :lines: 18-
 
+Python
+......
+
+.. literalinclude:: Code.py
+   :language: python
+   :lines: 1, 18-
+
 
 Classes demonstrated
 --------------------


### PR DESCRIPTION
Add Python code for `GetTypeBasicInformation` example.