### PR TITLE
ENH: Add Python code for `DuplicateAnImage` example

### DIFF
--- a/src/Core/Common/DuplicateAnImage/CMakeLists.txt
+++ b/src/Core/Common/DuplicateAnImage/CMakeLists.txt
@@ -21,3 +21,9 @@ install( FILES Code.cxx CMakeLists.txt
 enable_testing()
 add_test( NAME DuplicateAnImageTest
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DuplicateAnImage )
+
+if( ITK_WRAP_PYTHON )
+  add_test( NAME DuplicateAnImageTestPython
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
+    )
+endif()

--- a/src/Core/Common/DuplicateAnImage/Code.py
+++ b/src/Core/Common/DuplicateAnImage/Code.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itk
+
+Dimension = 2
+PixelType = itk.UC
+
+ImageType = itk.Image[PixelType, Dimension]
+
+randomImageSource = itk.RandomImageSource[ImageType]()
+randomImageSource.SetNumberOfWorkUnits(1)  # to produce non-random results
+
+image = randomImageSource.GetOutput()
+
+clonedImage = itk.image_duplicator(image)

--- a/src/Core/Common/DuplicateAnImage/Documentation.rst
+++ b/src/Core/Common/DuplicateAnImage/Documentation.rst
@@ -24,6 +24,13 @@ C++
 .. literalinclude:: Code.cxx
    :lines: 18-
 
+Python
+......
+
+.. literalinclude:: Code.py
+   :language: python
+   :lines: 1, 16-
+
 
 Classes demonstrated
 --------------------


### PR DESCRIPTION
Add Python code for `DuplicateAnImage` example.