### PR TITLE
BUG: Fix failing tests reported by CI

### DIFF
--- a/src/Core/Common/CreateDerivativeKernel/Code.py
+++ b/src/Core/Common/CreateDerivativeKernel/Code.py
@@ -27,4 +27,4 @@ print("Size: " + str(derivativeOperator.GetSize()))
 print(derivativeOperator)
 
 for i in range(9):
-    print(derivativeOperator.GetOffset(i) + " " + derivativeOperator.GetElement(i))
+    print(str(derivativeOperator.GetOffset(i)) + " " + str(derivativeOperator.GetElement(i)))

--- a/src/Core/Common/CreateForwardDifferenceKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateForwardDifferenceKernel/CMakeLists.txt
@@ -23,3 +23,9 @@ install(FILES Code.cxx CMakeLists.txt
 enable_testing()
 add_test(NAME CreateForwardDifferenceKernelTest
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateForwardDifferenceKernel)
+
+if( ITK_WRAP_PYTHON )
+  add_test( NAME CreateForwardDifferenceKernelTestPython
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
+    )
+endif()

--- a/src/Core/Common/CreateForwardDifferenceKernel/Code.py
+++ b/src/Core/Common/CreateForwardDifferenceKernel/Code.py
@@ -27,4 +27,4 @@ print("Size: " + str(forwardDifferenceOperator.GetSize()))
 print(forwardDifferenceOperator)
 
 for i in range(9):
-    print(forwardDifferenceOperator.GetOffset(i) + " " + forwardDifferenceOperator.GetElement(i))
+    print(str(forwardDifferenceOperator.GetOffset(i)) + " " + str(forwardDifferenceOperator.GetElement(i)))

--- a/src/Core/Common/CreateGaussianDerivativeKernel/Code.py
+++ b/src/Core/Common/CreateGaussianDerivativeKernel/Code.py
@@ -27,4 +27,4 @@ print("Size: " + str(gaussianDerivativeOperator.GetSize()))
 print(gaussianDerivativeOperator)
 
 for i in range(9):
-    print(gaussianDerivativeOperator.GetOffset(i) + " " + gaussianDerivativeOperator.GetElement(i))
+    print(str(gaussianDerivativeOperator.GetOffset(i)) + " " + str(gaussianDerivativeOperator.GetElement(i)))

--- a/src/Core/Common/CreateGaussianKernel/Code.py
+++ b/src/Core/Common/CreateGaussianKernel/Code.py
@@ -27,4 +27,4 @@ print("Size: " + str(gaussianOperator.GetSize()))
 print(gaussianOperator)
 
 for i in range(9):
-    print(gaussianOperator.GetOffset(i) + " " + gaussianOperator.GetElement(i))
+    print(str(gaussianOperator.GetOffset(i)) + " " + str(gaussianOperator.GetElement(i)))

--- a/src/Core/Common/CreateLaplacianKernel/Code.py
+++ b/src/Core/Common/CreateLaplacianKernel/Code.py
@@ -26,4 +26,4 @@ print("Size: " + str(laplacianOperator.GetSize()))
 print(laplacianOperator)
 
 for i in range(laplacianOperator.GetSize()[0] * laplacianOperator.GetSize()[1]):
-    print(laplacianOperator.GetOffset(i) + " " + laplacianOperator.GetElement(i))
+    print(str(laplacianOperator.GetOffset(i)) + " " + str(laplacianOperator.GetElement(i)))

--- a/src/Core/Common/DuplicateAnImage/Code.py
+++ b/src/Core/Common/DuplicateAnImage/Code.py
@@ -21,7 +21,7 @@ PixelType = itk.UC
 
 ImageType = itk.Image[PixelType, Dimension]
 
-randomImageSource = itk.RandomImageSource[ImageType]()
+randomImageSource = itk.RandomImageSource[ImageType].New()
 randomImageSource.SetNumberOfWorkUnits(1)  # to produce non-random results
 
 image = randomImageSource.GetOutput()

--- a/src/Core/Common/GetTypeBasicInformation/Code.py
+++ b/src/Core/Common/GetTypeBasicInformation/Code.py
@@ -20,14 +20,13 @@ MyType = itk.F
 
 print("Min: " + str(itk.NumericTraits[MyType].min()))
 print("Max: " + str(itk.NumericTraits[MyType].max()))
-print("Zero: " + str(itk.NumericTraits[MyType].Zero()))
 print("ZeroValue: " + str(itk.NumericTraits[MyType].ZeroValue()))
 
 print("Is -1 negative? " + str(itk.NumericTraits[MyType].IsNegative(-1)))
 
 print("Is 1 negative? " + str(itk.NumericTraits[MyType].IsNegative(1)))
 
-print("One: " + str(itk.NumericTraits[MyType].One))
+print("OneValue: " + str(itk.NumericTraits[MyType].OneValue()))
 
 print("Epsilon: " + str(itk.NumericTraits[MyType].epsilon()))
 

--- a/src/Core/Common/SetPixelValueInOneImage/Code.py
+++ b/src/Core/Common/SetPixelValueInOneImage/Code.py
@@ -45,7 +45,7 @@ region.SetSize(size)
 image = ImageType.New()
 image.SetRegions(region)
 image.Allocate()
-image.FillBuffer(itk.NumericTraits[PixelType].Zero())
+image.FillBuffer(itk.NumericTraits[PixelType].ZeroValue())
 
 pixelIndex = itk.Index[Dimension]()
 
@@ -79,7 +79,7 @@ image.SetPixel(pixelIndex, 200)
 pixelIndex[0] = 100
 pixelIndex[1] = 150
 
-image.>SetPixel(pixelIndex, 200)
+image.SetPixel(pixelIndex, 200)
 
 pixelIndex[0] = 105
 pixelIndex[1] = 150


### PR DESCRIPTION
Fix failing tests reported by CI, e.g. in this buid:
https://github.com/InsightSoftwareConsortium/ITKExamples/runs/895512782?check_suite_focus=true

Fixes:
- Convert the returned values of the calls to string so that they can be
  printed properly in the kernel creation examples.
- Remove the brackets to get the `NumericTraits` attribute values in the
  examples calling its attributes.

Take advantage of the commit to add the missing Python test for the
`CreateForwardDifferenceKernel` example.