### PR TITLE
DOC: Fix the Python code removal line limits

### DIFF
--- a/src/Core/Common/GetTypeBasicInformation/Documentation.rst
+++ b/src/Core/Common/GetTypeBasicInformation/Documentation.rst
@@ -42,7 +42,7 @@ Python
 
 .. literalinclude:: Code.py
    :language: python
-   :lines: 1, 18-
+   :lines: 1, 16-
 
 
 Classes demonstrated

--- a/src/Core/Common/SetPixelValueInOneImage/Documentation.rst
+++ b/src/Core/Common/SetPixelValueInOneImage/Documentation.rst
@@ -36,7 +36,7 @@ Python
 
 .. literalinclude:: Code.py
    :language: python
-   :lines: 1, 18-
+   :lines: 1, 17-
 
 
 Classes demonstrated


### PR DESCRIPTION
Fix the Python code removal line limits to the appropriate values for each
example.