### PR TITLE
BUG: Fix pixel printing in `IterateRegionWithAccessToIndex` examples

### DIFF
--- a/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/Code.cxx
@@ -57,7 +57,7 @@ main(int argc, char * argv[])
 
   while (!imageIterator.IsAtEnd())
   {
-    std::cout << "Index: " << imageIterator.GetIndex() << " value: " << imageIterator.Get() << std::endl;
+    std::cout << "Index: " << imageIterator.GetIndex() << " value: " << (int)imageIterator.Get() << std::endl;
 
     // Set the current pixel to white
     imageIterator.Set(255);

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/Code.cxx
@@ -57,7 +57,7 @@ main(int argc, char * argv[])
 
   while (!imageIterator.IsAtEnd())
   {
-    std::cout << "Index: " << imageIterator.GetIndex() << " value: " << imageIterator.Get() << std::endl;
+    std::cout << "Index: " << imageIterator.GetIndex() << " value: " << (int)imageIterator.Get() << std::endl;
 
     ++imageIterator;
   }


### PR DESCRIPTION
Fix pixel printing in `IterateRegionWithAccessToIndex` examples: cast the
pixel values to `int` to allow properly printing them.

The CI shows an unrecognized symbol, e.g. in build:
https://github.com/InsightSoftwareConsortium/ITKExamples/runs/895512782?check_suite_focus=true