### PR TITLE
BUG: fix syntax error regarding shape attribute

### DIFF
--- a/src/Core/Common/GetImageSize/Code.py
+++ b/src/Core/Common/GetImageSize/Code.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import sys
+import numpy as np
 import itk
 
 if len(sys.argv) != 2:
@@ -36,7 +37,7 @@ size = itk.size(image)
 print(size)
 
 # Corresponds to the NumPy ndarray shape. Note that the ordering is reversed.
-print(image.shape)
+print(np.asarray(image).shape)
 
 # An example image had w = 200 and h = 100
 # (it is wider than it is tall). The above output


### PR DESCRIPTION
The error was:
```text
55: Test command: "C:\Program Files\Python37\python.exe" "C:/Dev/ITKExamples/src/Core/Common/GetImageSize/Code.py" "C:/Dev/ITKExamples/Build/src/Core/Common/GetImageSize/Yinyang.png"
55: Test timeout computed to be: 1500
55: itkSize2 ([512, 342])
55: itkSize2 ([512, 342])
55: Traceback (most recent call last):
55:   File "C:/Dev/ITKExamples/src/Core/Common/GetImageSize/Code.py", line 40, in <module>
55:     print(image.shape)
55: AttributeError: 'itkImageUC2' object has no attribute 'shape'
1/1 Test #55: GetImageSizeTestPython ...........***Failed    2.68 sec
```