### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -9,7 +9,7 @@ template <class TImage>
 class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFilter);
   /** Standard class type alias. */
   using Self = ImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -9,7 +9,7 @@ template <class TImage>
 class ImageFilterMultipleOutputs : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageFilterMultipleOutputs);
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFilterMultipleOutputs);
   /** Standard class type alias. */
   using Self = ImageFilterMultipleOutputs;
   using Superclass = ImageToImageFilter<TImage, TImage>;

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -9,7 +9,7 @@ template <class TImage>
 class MyInPlaceImageFilter : public InPlaceImageFilter<TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MyInPlaceImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MyInPlaceImageFilter);
   /** Standard class type alias. */
   using Self = MyInPlaceImageFilter;
   using Superclass = InPlaceImageFilter<TImage>;

--- a/src/Developer/itkImageFilterMultipleInputs.h
+++ b/src/Developer/itkImageFilterMultipleInputs.h
@@ -9,7 +9,7 @@ template <class TImage>
 class ImageFilterMultipleInputs : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageFilterMultipleInputs);
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFilterMultipleInputs);
   /** Standard class type alias. */
   using Self = ImageFilterMultipleInputs;
   using Superclass = ImageToImageFilter<TImage, TImage>;

--- a/src/Developer/itkOilPaintingImageFilter.h
+++ b/src/Developer/itkOilPaintingImageFilter.h
@@ -18,7 +18,7 @@ template <class TImage>
 class OilPaintingImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(OilPaintingImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(OilPaintingImageFilter);
   /** Standard class type alias. */
   using Self = OilPaintingImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;

--- a/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
@@ -11,7 +11,7 @@ namespace itk
 class ExampleCostFunction2 : public SingleValuedCostFunction
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ExampleCostFunction2);
+  ITK_DISALLOW_COPY_AND_MOVE(ExampleCostFunction2);
   /** Standard class typedefs. */
   typedef ExampleCostFunction2     Self;
   typedef SingleValuedCostFunction Superclass;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.