### PR TITLE
ENH: Create Vector Dot Product and Covariant Vector Python Examples

### DIFF
--- a/src/Core/Common/CreateACovariantVector/CMakeLists.txt
+++ b/src/Core/Common/CreateACovariantVector/CMakeLists.txt
@@ -5,7 +5,7 @@ project( CreateACovariantVector )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
-add_executable( CreateACovariantVector Code.cxx )
+add_executable( CreateACovariantVector Code.cxx Code.py)
 target_link_libraries( CreateACovariantVector ${ITK_LIBRARIES} )
 
 install( TARGETS CreateACovariantVector
@@ -13,7 +13,7 @@ install( TARGETS CreateACovariantVector
   COMPONENT Runtime
 )
 
-install( FILES Code.cxx CMakeLists.txt
+install( FILES Code.cxx Code.py CMakeLists.txt
   DESTINATION share/ITKExamples/Code/Core/Common/CreateACovariantVector
   COMPONENT Code
 )
@@ -21,3 +21,9 @@ install( FILES Code.cxx CMakeLists.txt
 enable_testing()
 add_test( NAME CreateACovariantVectorTest
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateACovariantVector )
+
+if( ITK_WRAP_PYTHON )
+  add_test( NAME CreateACovariantVectorTestPython
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
+    )
+endif()

--- a/src/Core/Common/CreateACovariantVector/Code.py
+++ b/src/Core/Common/CreateACovariantVector/Code.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License")
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+import itk
+
+Dimension = 3
+CoordType = itk.D
+
+VectorType = itk.CovariantVector[CoordType, Dimension]
+
+v = VectorType()
+v[0] = 1.0
+v[1] = 2.0
+v[2] = 3.0
+print("v: " + str(v))

--- a/src/Core/Common/CreateACovariantVector/Documentation.rst
+++ b/src/Core/Common/CreateACovariantVector/Documentation.rst
@@ -27,6 +27,13 @@ C++
 .. literalinclude:: Code.cxx
    :lines: 18-
 
+Python
+......
+
+.. literalinclude:: Code.py
+   :language: python
+   :lines: 1, 20-
+
 
 Classes demonstrated
 --------------------

--- a/src/Core/Common/VectorDotProduct/CMakeLists.txt
+++ b/src/Core/Common/VectorDotProduct/CMakeLists.txt
@@ -5,7 +5,7 @@ project( VectorDotProduct )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
-add_executable( VectorDotProduct Code.cxx )
+add_executable( VectorDotProduct Code.cxx Code.py)
 target_link_libraries( VectorDotProduct ${ITK_LIBRARIES} )
 
 install( TARGETS VectorDotProduct
@@ -13,7 +13,7 @@ install( TARGETS VectorDotProduct
   COMPONENT Runtime
 )
 
-install( FILES Code.cxx CMakeLists.txt
+install( FILES Code.cxx Code.py CMakeLists.txt
   DESTINATION share/ITKExamples/Code/Core/Common/VectorDotProduct
   COMPONENT Code
 )
@@ -21,3 +21,9 @@ install( FILES Code.cxx CMakeLists.txt
 enable_testing()
 add_test( NAME VectorDotProductTest
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VectorDotProduct )
+
+if( ITK_WRAP_PYTHON )
+  add_test( NAME VectorDotProductTestPython
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
+    )
+endif()

--- a/src/Core/Common/VectorDotProduct/Code.py
+++ b/src/Core/Common/VectorDotProduct/Code.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License")
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+import itk
+from numpy.core import double
+
+Dimension = 3
+CoordType = itk.D
+
+VectorType = itk.Vector[CoordType, Dimension]
+
+u = VectorType()
+u[0] = -1.
+u[1] = 1.
+u[2] = -1.
+
+v = VectorType()
+v[0] = 1.
+v[1] = 2.
+v[2] = 3.
+
+print("u: " + str(u))
+print("v: " + str(v))
+print("DotProduct( u, v ) = " + str(u * v))
+print("DotProduct( u, v ) = " + str(u - double(u * v) * v))

--- a/src/Core/Common/VectorDotProduct/Documentation.rst
+++ b/src/Core/Common/VectorDotProduct/Documentation.rst
@@ -31,6 +31,13 @@ C++
 .. literalinclude:: Code.cxx
    :lines: 18-
 
+Python
+......
+
+.. literalinclude:: Code.py
+   :language: python
+   :lines: 1, 20-
+
 
 Classes demonstrated
 --------------------


### PR DESCRIPTION
## Description

1. This example will do vector dot product arithmetic using itk's python package. In addition it will update the documentation and create a test.

**NOTE:** I import `double` from `numpy.core` to cast the output of `u * v`. If I don't do the cast (i.e. `str(u - (u * v) * v)` ), I get the following error:

```
TypeError: unsupported operand type(s) for *: 'float' and 'itkVectorD3'
```
2. The another example will create a `CovariantVector` object using itk's python package. In addition it will update the documentation and create a test.
  


