### PR TITLE
ENH: Update ITK CI tags to v5.2rc02

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -132,17 +132,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -260,7 +260,7 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "e2c71059e47d5e77c647aab5b799121090fdf4ec"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "Release"
 
     steps:

--- a/Superbuild/External-ITK.cmake
+++ b/Superbuild/External-ITK.cmake
@@ -2,7 +2,7 @@
 # Get and build itk
 
 if(NOT ITK_TAG)
-  set(ITK_TAG "v5.1.0")
+  set(ITK_TAG "v5.2rc02")
 endif()
 
 set(_vtk_args)


### PR DESCRIPTION
Update ITK CI to reference ITK `master` branch as of 02-10-2021.