### PR TITLE
BUG: Disable MutualInformationAffine example

### DIFF
--- a/src/Core/Transform/CMakeLists.txt
+++ b/src/Core/Transform/CMakeLists.txt
@@ -29,13 +29,15 @@ compare_to_baseline(EXAMPLE_NAME GlobalRegistrationTwoImagesAffine
     output
   )
 
-add_example(MutualInformationAffine)
-compare_to_baseline(EXAMPLE_NAME MutualInformationAffine
-  BASELINE_PREFIX
-    fixed
-    moving
-    output
-  )
+# TODO revisit input/baseline images and example paramters
+#   before reenabling
+#add_example(MutualInformationAffine)
+#compare_to_baseline(EXAMPLE_NAME MutualInformationAffine
+#  BASELINE_PREFIX
+#    fixed
+#    moving
+#    output
+#  )
 
 add_example(GlobalRegistrationTwoImagesBSpline)
 compare_to_baseline(EXAMPLE_NAME GlobalRegistrationTwoImagesBSpline


### PR DESCRIPTION
[Issue 178](https://github.com/InsightSoftwareConsortium/ITKExamples/issues/178) is a blocking issue for checks on several outstanding PRs. This issue is related to the `MutualInformationAffine` test and baseline comparison, which passes locally but returns unsatisfactory results (see the [Mutual Information Affine example](https://itk.org/ITKExamples/src/Core/Transform/MutualInformationAffine/Documentation.html) and fails which executed remotely with GitHub Actions.

This PR disables building the offending examples to unblock outstanding PRs while the examples are updated.