### PR TITLE
Superbuild OpenCV Upgrade

### DIFF
--- a/Superbuild/External-OpenCV.cmake
+++ b/Superbuild/External-OpenCV.cmake
@@ -2,7 +2,7 @@
 # Get and build OpenCV
 
 if( NOT OpenCV_TAG )
-  set( OpenCV_TAG "3.1.0" )
+  set( OpenCV_TAG "4.5.1" )
 endif()
 
 ExternalProject_Add(OpenCV

--- a/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/Code.cxx
+++ b/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/Code.cxx
@@ -21,15 +21,8 @@
 #include "itkOpenCVImageBridge.h"
 
 // includes from OpenCV
-#include "cv.h"
-#if CV_VERSION_MAJOR > 2
-#  include "opencv2/opencv.hpp" // cv::imwrite
-#endif
+#include "opencv2/opencv.hpp" // cv::imwrite
 
-
-#if CV_VERSION_MAJOR > 2
-#  include "opencv2/opencv.hpp" // cv::imwrite
-#endif
 
 int
 main(int argc, char * argv[])


### PR DESCRIPTION
## Description
This PR looks to bump the OpenCV version to `4.5.1` (the latest version). In addition, it looks to fix any warnings/errors that arose from the upgrade. This primarily required adjusting the included header files for `ConvertAnITKGrayScaleImageToCVMat`.

This will close #191 .