### PR TITLE
BUG: Superbuild installs ITK Python 5.2.2 prerelease

### DIFF
--- a/Superbuild/External-Python.cmake
+++ b/Superbuild/External-Python.cmake
@@ -13,5 +13,5 @@ ExternalProject_Add(ITKPython
   DOWNLOAD_COMMAND ""
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ${PYTHON_EXECUTABLE} -m venv "${_itk_venv}"
-  INSTALL_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --ignore-installed itk>=5.2rc2 sphinx==3.0.4 six
+  INSTALL_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --ignore-installed --pre itk>=5.2rc2 sphinx==3.0.4 six
   )


### PR DESCRIPTION
PR addresses CMake build failure seen in [Issue 201](https://github.com/InsightSoftwareConsortium/ITKExamples/issues/201).