### PR TITLE
DOC: Fix dashboard link

### DIFF
--- a/Documentation/Contribute/DashboardSubmission.rst
+++ b/Documentation/Contribute/DashboardSubmission.rst
@@ -119,5 +119,5 @@ back up.  To do this
 Thank you for contributing to the quality of the ITK Examples!
 
 .. _CDash:                 https://www.cdash.org/
-.. _ITKExamples dashboard: https://open.cdash.org/index.php?project=Insight&filtercount=1&showfilters=1&field1=groupname/string&compare1=63&value1=Examples
+.. _ITKExamples dashboard: https://open.cdash.org/index.php?project=Insight&filtercount=1&showfilters=0&field1=buildname/string&compare1=63&value1=Examples
 .. _setup a cronjob:       https://en.wikipedia.org/wiki/Cron

--- a/Documentation/Contribute/index.rst
+++ b/Documentation/Contribute/index.rst
@@ -31,4 +31,4 @@ facets are important to the success of the project.
 .. _reStructuredText:        http://docutils.sourceforge.net/rst.html
 .. _Sphinx:                  https://www.sphinx-doc.org/en/master/
 .. _Quick reStructuredText:  http://docutils.sourceforge.net/docs/user/rst/quickref.html
-.. _Dashboard:               https://open.cdash.org/index.php?project=Insight&filtercount=1&showfilters=1&field1=groupname/string&compare1=63&value1=Examples
+.. _Dashboard:               https://open.cdash.org/index.php?project=Insight&filtercount=1&showfilters=0&field1=buildname/string&compare1=63&value1=Examples

--- a/Formatting/templates/indexcontent.html
+++ b/Formatting/templates/indexcontent.html
@@ -43,7 +43,8 @@
          <span class="linkdescr">who wrote the code</span></p>
     </td>
     <td class="contentstable" width="50%">
-      <p class="biglink"><a class="biglink" href="https://open.cdash.org/index.php?project=Insight&filtercount=1&showfilters=1&field1=groupname/string&compare1=63&value1=Examples">Dashboard</a><br/>
+      <p class="biglink"><a class="biglink"
+        href="https://open.cdash.org/index.php?project=Insight&filtercount=1&showfilters=0&field1=buildname/string&compare1=63&value1=Examples">Dashboard</a><br/>
          <span class="linkdescr">software quality dashboard</span></p>
     </td>
   </tr>


### PR DESCRIPTION
Use Build Name instead of Group to obtain all GitHub Actions builds.
