### PR TITLE
BUG: Do not use shallow checkout for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
 
     - name: Lint C++
       uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master


### PR DESCRIPTION
To address:

reference is not a tree: 80fc7fe2e2de3d7c0a29bb3f0de7941f708ff5da
lint
Git checkout failed with exit code: 128
lint
Exit code 1 returned from process: file name '/home/runner/runners/2.277.1/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
lint
Git checkout failed on shallow repository, this might because of git fetch with depth '1' doesn't include the checkout commit '80fc7fe2e2de3d7c0a29bb3f0de7941f708ff5da'.
lint
Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see actions/virtual-environments/issues/1816
