### PR TITLE
COMP: Disable nbsphinx

### DIFF
--- a/Formatting/conf.py.in
+++ b/Formatting/conf.py.in
@@ -41,7 +41,7 @@ primary_domain = 'cpp'
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode', 'sphinx.ext.imgconverter', 'breathe', 'doxylink',
-    'breathelink', 'nbsphinx', 'sphinx_contributors',
+    'breathelink', 'sphinx_contributors',
     'IPython.sphinxext.ipython_console_highlighting',]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
The sphinx build is hanging when nbsphinx is parsing the notebooks with
the recent sphinx/nbsphinx stack. Disable nbsphinx for now.
