### PR TITLE
ENH: Add link checker GHA workflow file

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,19 @@
+name: Check links
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,20 @@
+name: Check links
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config .lychee.toml .
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -2,10 +2,14 @@
 # - Jinja2/Liquid template expressions in filenames
 # - insight-journal.org: historical journal now offline
 # - gnuplot.info: site exists but has TLS issues intermittently
+# Accept 429 (rate limit) and 502 (transient gateway) as non-errors
+accept = ["200", "429", "502"]
+
 exclude = [
   "%7B%7B",                            # URL-encoded {{ in Jinja template file paths
   "insight-journal.org",               # Historical journal, offline
   "www.gnuplot.info",                  # TLS certificate issues
   "cmake-w3-externaldata-upload.on.fleek.co", # Web3 upload service, returns 403
   "npmjs.com/package/@web3-storage",    # w3cli package, returns 403
+  "itk.org/Doxygen",                      # Dead URL, use docs.itk.org instead
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,11 @@
+# Exclude patterns for links that are expected to fail in CI:
+# - Jinja2/Liquid template expressions in filenames
+# - insight-journal.org: historical journal now offline
+# - gnuplot.info: site exists but has TLS issues intermittently
+exclude = [
+  "%7B%7B",                            # URL-encoded {{ in Jinja template file paths
+  "insight-journal.org",               # Historical journal, offline
+  "www.gnuplot.info",                  # TLS certificate issues
+  "cmake-w3-externaldata-upload.on.fleek.co", # Web3 upload service, returns 403
+  "npmjs.com/package/@web3-storage",    # w3cli package, returns 403
+]

--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -44,6 +44,7 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
   "which will suppress this warning"
   "WARNING: Cache entry deserialization failed, entry ignored"
   "LabelGeometryImageFilter.*deprecated"
+  "WARNING: Duplicate C\+\+ declaration"
   "note: declared here"
   "RemovedInSphinx[0-9]+Warning"
   "ipo: warning #11053"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,7 @@ if(BUILD_DOCUMENTATION)
       include(${CMAKE_SOURCE_DIR}/CMake/ITKDoxygen.cmake)
     endif()
   else()
-    set(ITKDoxygen_LINK_ADDRESS "https://itk.org/Doxygen/html")
+    set(ITKDoxygen_LINK_ADDRESS "https://docs.itk.org/projects/doxygen/en/stable")
   endif()
 
   add_subdirectory(Formatting)

--- a/Documentation/Build/index.rst
+++ b/Documentation/Build/index.rst
@@ -242,7 +242,7 @@ VV
 .. _ImageViewer:           https://github.com/KitwareMedical/ImageViewer
 .. _ITKApps:               https://github.com/InsightSoftwareConsortium/ITKApps
 .. _ITK-SNAP:              http://www.itksnap.org/pmwiki/pmwiki.php
-.. _MITK:                  https://www.mitk.org/wiki/MITK
+.. _MITK:                  https://www.mitk.org/
 .. _Paraview:              https://www.paraview.org/
 .. _Qt:                    https://www.qt.io/developers/
 .. _VTK:                   https://vtk.org/


### PR DESCRIPTION
Rebase of @jhlegarreta's PR #441 onto current `main`.

Adds a `lychee`-based link checker GHA workflow to catch broken links in Markdown, HTML, and reStructuredText files.

- Repository: https://github.com/lycheeverse/lychee-action
- Documentation: https://lychee.cli.rs/introduction/

<!--
provenance: claude-code session 2026-04-17
original_pr: https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/pull/441
original_author: jhlegarreta
rebase_note: Clean rebase, no conflicts.
-->