### PR TITLE
STYLE: Remove Initialize() calls on new point sets RegisterTwoPointSets

### DIFF
--- a/src/Registration/Metricsv4/RegisterTwoPointSets/Code.cxx
+++ b/src/Registration/Metricsv4/RegisterTwoPointSets/Code.cxx
@@ -82,11 +82,7 @@ main(int argc, char * argv[])
   using PointType = PointSetType::PointType;
 
   auto fixedPoints = PointSetType::New();
-  fixedPoints->Initialize();
-
   auto movingPoints = PointSetType::New();
-  movingPoints->Initialize();
-
 
   // two ellipses, one rotated slightly
   /*

--- a/src/Registration/Metricsv4/RegisterTwoPointSets/Code.py
+++ b/src/Registration/Metricsv4/RegisterTwoPointSets/Code.py
@@ -35,8 +35,6 @@ def make_circles(l_dimension: int = 2):
 
     fixed_points = PointSetType.New()
     moving_points = PointSetType.New()
-    fixed_points.Initialize()
-    moving_points.Initialize()
 
     step = 0.1
     for count in range(0, int(2 * pi / step) + 1):

--- a/src/Registration/Metricsv4/RegisterTwoPointSets/RegisterTwoPointSets.ipynb
+++ b/src/Registration/Metricsv4/RegisterTwoPointSets/RegisterTwoPointSets.ipynb
@@ -54,8 +54,6 @@
     "\n",
     "    fixed_points = PointSetType.New()\n",
     "    moving_points = PointSetType.New()\n",
-    "    fixed_points.Initialize()\n",
-    "    moving_points.Initialize()\n",
     "\n",
     "    count = 0\n",
     "    step = 0.1\n",


### PR DESCRIPTION
Rebase of @N-Dekker's PR #434 onto current `main`.

When a point set is just created by `New()`, it is already properly initialized. Removes redundant `Initialize()` calls from `RegisterTwoPointSets` — follow-up to [ITK#4976](https://github.com/InsightSoftwareConsortium/ITK/pull/4976) commit bc044c1d.

<!--
provenance: claude-code session 2026-04-17
original_pr: https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/pull/434
original_author: N-Dekker
rebase_note: Clean rebase, no conflicts.
-->