### PR TITLE
DOC: Recreate lost Core/Common example visuals with new CIDs

### DIFF
--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Relationship.png.cid
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Relationship.png.cid
@@ -1,1 +1,1 @@
-bafkreiaffqu7nnoby6ix5o3pg5eiucj7ofsxx3wnij4r2kugbdy4jhvuia
+bafkreibyxjcephwjj37w7lftdikdpvwnfpk6ddhx43nn7hvjutekhwir7e

--- a/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Documentation.rst
+++ b/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Documentation.rst
@@ -15,9 +15,9 @@ Apply a custom operation to each pixel in an image.
   :alt: Relationship.png
 
 
-.. figure:: Operator.png
+.. figure:: Operation.png
   :scale: 70%
-  :alt: Operator.png
+  :alt: Operation.png
 
 pixel-wise operation on 2D vector image.
 

--- a/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Operation.png.cid
+++ b/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Operation.png.cid
@@ -1,1 +1,1 @@
-bafkreig3f4d5hwfz2wzmy56o6tc5mb3ljd6jmtsjoruxqfchlz5yv6ixuy
+bafkreiekhuy5b6ymfj5edahs3ncdjjxpymrtnfl5whvyg3n5qz6bs4pbea

--- a/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Relationship.png.cid
+++ b/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Relationship.png.cid
@@ -1,1 +1,1 @@
-bafkreihasqn5hlzyvlxkjqjfv5tupvvyixfiknai2puytootv523dd3tcq
+bafkreif42v622rgfhpb2dm3tn6nqmdvc3bhdhx7zo2z4jrrk2c5lknjfti

--- a/src/Core/Common/BoundingBoxOfAPointSet/BoundingBox.png.cid
+++ b/src/Core/Common/BoundingBoxOfAPointSet/BoundingBox.png.cid
@@ -1,1 +1,1 @@
-bafkreickdblw4cjduumqnb7gn3wtsjshvqrvezh3k7krz657xsosvur2ry
+bafkreidhk57tyxtuiecfspgpm57zhtyxvo2zsxhd76py3fzt6d7ivr7jd4

--- a/src/Core/Common/BresenhamLine/Operation.png.cid
+++ b/src/Core/Common/BresenhamLine/Operation.png.cid
@@ -1,1 +1,1 @@
-bafkreia4xxrlmsbcivkpdtl2ja2mskpuuaht43rmmrt2j3qjqp5ymsf2v4
+bafkreifgp5rnawpvq4lkjd6cngubwwcjy7hdbrr4h3lifriyk2t7n3nzbi

--- a/src/Core/Common/BresenhamLine/Segmentation.png.cid
+++ b/src/Core/Common/BresenhamLine/Segmentation.png.cid
@@ -1,1 +1,1 @@
-bafkreihi6qoq7pqyqf3defuwz7ntxspjurtywy73iba4eyaaqgfm6lmbg4
+bafkreie5puikhxxdz2ng7ar6czjqfus6wvtvx65ew644d7oklgf3klhii4

--- a/src/Core/Common/ConvertArrayToImage/Relationship.png.cid
+++ b/src/Core/Common/ConvertArrayToImage/Relationship.png.cid
@@ -1,1 +1,1 @@
-bafkreihcn43nd4b5dthz4yrq77tyjjfelpvzzmiutnm2slpaznnrscowoq
+bafkreihumtkldoks4bwxcmbzvinys3kcstlr5ax74d52o5ccio6m5zsgrm

--- a/src/Core/Common/ConvertArrayToImage/Sphere.png.cid
+++ b/src/Core/Common/ConvertArrayToImage/Sphere.png.cid
@@ -1,1 +1,1 @@
-bafkreifj3dfi57rvwruuvk5ycftmobp2p5mdho7qpi7x7ykuujbkzb2lca
+bafkreifgxm4kvz36l36qtu6pnecm22yb3ghswwbpvbfk4c67xyijbkxfva

--- a/src/Core/Common/ConvertArrayToImage/Sphere3D.png.cid
+++ b/src/Core/Common/ConvertArrayToImage/Sphere3D.png.cid
@@ -1,1 +1,1 @@
-bafkreid3uloy2yfjqggy5d46aghpb4b5v3q2xaqylkg2uoqsuqc5dh4s7q
+bafkreideyzfcs5tf6c7puc6kubsbmzh3houvqycjpmknjeybw7cjzqox6y

--- a/src/Core/Common/CreateDerivativeKernel/DerivativeKernel.png.cid
+++ b/src/Core/Common/CreateDerivativeKernel/DerivativeKernel.png.cid
@@ -1,1 +1,1 @@
-bafkreigdntizd2xiqvwywb6vab4wwbxcozlm4yghjkoc7dzugzipvhudne
+bafkreifsa2jo72j4il7ozazxz54r3uhltqnowpwhhrdjsqckm57c3mrag4

--- a/src/Core/Common/CreateDerivativeKernel/DerivativeOperator.png.cid
+++ b/src/Core/Common/CreateDerivativeKernel/DerivativeOperator.png.cid
@@ -1,1 +1,1 @@
-bafkreibohzttygqnnh25zror2z5vlhypmwtvfgyvqrfebhcxvme7mehbvy
+bafkreig25mzui7zx2igtvhh4ftlxexhrkgrvwdv5nybxhuoxtklilrbwhu

--- a/src/Core/Common/CreateGaussianKernel/GaussianBlur.png.cid
+++ b/src/Core/Common/CreateGaussianKernel/GaussianBlur.png.cid
@@ -1,1 +1,1 @@
-bafkreifsacuklxb4nc4zo3g3dug7xvsf4kcpt5oosguhcngq5pysgqgnia
+bafkreihdheuit2ay3xbodmnr7vftdkf6wa772e5fifimnvfxqlykrgxl6e

--- a/src/Core/Common/CreateGaussianKernel/GaussianKernel.png.cid
+++ b/src/Core/Common/CreateGaussianKernel/GaussianKernel.png.cid
@@ -1,1 +1,1 @@
-bafkreidlnhsxjw7ivecwinizozzrss54z3hoezddflwcwfag2f7gqjqxgm
+bafkreib6jvmimlki4zyj5t5jwktiarywvc6ysjotmdb47swpsuyng6ozda

--- a/src/Core/Common/CreateVectorImage/Operation.png.cid
+++ b/src/Core/Common/CreateVectorImage/Operation.png.cid
@@ -1,1 +1,1 @@
-bafkreiefasljtdb5w2lpiw3kptqknfqdngzgq6waff2ims43wwsapnjnba
+bafkreifsrpkcchoy6q2qxnba7ughs2oipolrwfsz3pnohpf2splmmzyvmi

--- a/src/Core/Common/CropImageBySpecifyingRegion/3DVolume.png.cid
+++ b/src/Core/Common/CropImageBySpecifyingRegion/3DVolume.png.cid
@@ -1,1 +1,1 @@
-bafkreihtmliqoydru3yo5sbxsddu4sq4hkt6q5e6tnrawz4vbtqrjtwama
+bafkreia5i3pe7lwk3cdkrp4xoan5zd32zvfolo5fo7nxup5ozluerwjlem

--- a/src/Core/Common/CropImageBySpecifyingRegion/ExtractedSlice.png.cid
+++ b/src/Core/Common/CropImageBySpecifyingRegion/ExtractedSlice.png.cid
@@ -1,1 +1,1 @@
-bafkreihbzuilqqwwwoyfhhmke6vb5fby2llly3rmtujmbfujdl2qr3obvu
+bafkreiaukoe4ixr45mwg7u6hjyaqmzwlxxwcdl4r33mqgodt55ru6dlnuy

--- a/src/Core/Common/ImageRegionIntersection/ImageRegionIntersection.png.cid
+++ b/src/Core/Common/ImageRegionIntersection/ImageRegionIntersection.png.cid
@@ -1,1 +1,1 @@
-bafkreih5hkqhoalqpj27vwj7qlq2krgzoxerkgil2ix5ggyh4u5gickawq
+bafkreidvqescwxj2aol6cor3yvkhkwmoif3drjipdltel2kjjkd3qdk3xm

--- a/src/Core/Common/MakePartOfImageTransparent/Transparency.png.cid
+++ b/src/Core/Common/MakePartOfImageTransparent/Transparency.png.cid
@@ -1,1 +1,1 @@
-bafkreickuima2tmul6deufw2xz4tntnq6buzondwva6c34mq3abzkfbdfm
+bafkreifhssibxiumouehdhealbpwkfr3t2etdafvkmpxedjbbmuamdzzha

--- a/src/Core/Common/MiniPipeline/MiniPipeline.png.cid
+++ b/src/Core/Common/MiniPipeline/MiniPipeline.png.cid
@@ -1,1 +1,1 @@
-bafkreiact2ar5jwdldtg7xdkma4goxozct64cwstqcdl3wwib2mycjaeia
+bafkreie76vvgdlcczzaefizla7cpwmo3bhvo6ylomdksp5endfweqem3s4

--- a/src/Core/Common/ReadAPointSet/tetrahedron.png.cid
+++ b/src/Core/Common/ReadAPointSet/tetrahedron.png.cid
@@ -1,1 +1,1 @@
-bafkreibbwfyijzai7xehhftrvkgxhu4aeqyez64sft7cavi7pj24ekuweu
+bafkreibm6jmun54klek4lxgknyqajlqfi4cfyekcigjdkumxppac6gy4yy


### PR DESCRIPTION
Recreate the 20 Core/Common example visuals whose binaries were never published by #440 and are unrecoverable from any public source. The `.cid` files now point at recreated diagrams (published via InsightSoftwareConsortium/ITKTestingData#63); also fixes the `Operator.png`→`Operation.png` reference mismatch. **Blocked on ITKTestingData#63 merging first.**

<details>
<summary>Why the original PNGs are unrecoverable — the hunt</summary>

| Source | Method | Result |
|---|---|---|
| ITKTestingData `gh-pages` `CID/<cid>` | direct fetch of all 20 CIDs | absent (sibling `MakePartOfImageTransparent.png` from the same #440 IS present) |
| data.kitware.com (Girder) | global exact-name search, all 16 unique basenames | 3 exact-name hits, all CID-mismatched; one is the already-published file under its old example name |
| data.kitware.com `ITK/ITKSphinxExamples/Nightly` | full collection walk | 9 old example folders; none contain these diagrams |
| Old `.sha512`/`.md5` hashes | `git log --all --diff-filter=A`, any extension | none — all 20 files were born as `.cid` in #440; the figures never existed before |
| GitHub user-attachments in #440 + #359 | harvested all asset URLs | one unrelated mockup only |
| jph6366 fork | recursive git-tree scan, both branches | zero PNG blobs |
| IPFS (7 gateways) | direct CID fetch | never pinned durably |

The binaries only ever existed on the #440 contributor's machine. If the originals resurface they can replace the recreations.

</details>

<details>
<summary>What changed</summary>

* 20 `.cid` files updated to the CIDs of the recreated diagrams (matplotlib renderings matching each figure's caption/context; review gallery in the comments below and in ITKTestingData#63).
* `ApplyCustomOperationToEachPixelInImage/Documentation.rst`: `figure:: Operator.png` corrected to `Operation.png` — the figure block referenced a name with no corresponding `.cid` file while `Operation.png.cid` sat orphaned.
* No figure blocks removed; all 13 `Documentation.rst` figure references stay live.

</details>

<details>
<summary>Local validation</summary>

CID computation (CIDv1/raw/sha2-256) validated by roundtrip against the published `MakePartOfImageTransparent.png` blob. Each new blob in ITKTestingData#63 is byte-identical to the file hashed into its `.cid` reference here.

</details>

<!--
provenance: claude-code session 2026-06-10
supersedes_approach: original deletion commit 5d1bd8eb (reference removal) reworked per maintainer direction to recreate+republish
blocked_by: InsightSoftwareConsortium/ITKTestingData#63 (CID blobs must land before ExternalData fetch works)
cid_map: .devlocal/recreate_visuals/cid_map.json (local), generator script .devlocal/recreate_visuals/generate.py (local)
original_author: jph6366 (#440)
post_merge_action: verify Module_SphinxExamples configure fetches all 20 blobs
-->
