### PR TITLE
COMP: Recover lost ExternalData objects from actions cache (do not merge)

### DIFF
--- a/.github/workflows/recover-externaldata-cache.yml
+++ b/.github/workflows/recover-externaldata-cache.yml
@@ -1,0 +1,53 @@
+name: Recover ExternalData cache
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/recover-externaldata-cache.yml
+
+jobs:
+  recover:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Restore cxx ExternalData cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/../bld/ExternalData/Objects
+          key: externaldata-v1-recover
+          restore-keys: |
+            externaldata-v1-
+
+      - name: Restore docs ExternalData cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/../bld-docs/ExternalData/Objects
+          key: externaldata-docs-v1-recover
+          restore-keys: |
+            externaldata-docs-v1-
+
+      - name: Restore superbuild ExternalData cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/../bld-superbuild/ExternalData/Objects
+          key: externaldata-superbuild-v1-recover
+          restore-keys: |
+            externaldata-superbuild-v1-ubuntu-24.04-
+
+      - name: Inventory recovered objects
+        run: |
+          mkdir -p recovered
+          for d in ../bld/ExternalData/Objects ../bld-docs/ExternalData/Objects ../bld-superbuild/ExternalData/Objects; do
+            if [ -d "$d" ]; then
+              rsync -a "$d/" recovered/
+            fi
+          done
+          find recovered -type f | wc -l
+          ls -R recovered | head -50
+
+      - name: Upload recovered objects
+        uses: actions/upload-artifact@v4
+        with:
+          name: recovered-externaldata-objects
+          path: recovered/
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
One-off recovery workflow — **do not merge**. Restores the ExternalData actions caches and uploads `Objects/CID/*` as an artifact, so 19 figure objects that exist nowhere else can be published to ITKTestingData.

<details>
<summary>Background</summary>

PR #359 added 19 documentation figures under `src/Core/Common/*` as `.cid` content links, but the objects were never durably published: they 404 on the ITKTestingData gh-pages and itk.org mirrors, 403 on Pinata, and time out on public IPFS gateways (ipfs.io, dweb.link, w3s.link). The GitHub Actions ExternalData cache is the last remaining copy — CI only stays green because `actions/cache` restores them; any fresh clone fails to fetch (first seen investigating the PR #456 macos failures).

Affected examples include ConvertArrayToImage (Sphere3D.png), BoundingBoxOfAPointSet (BoundingBox.png), CreateGaussianKernel, CreateDerivativeKernel, BresenhamLine, ReadAPointSet, and others — full list in the build log of any uncached build.

Plan: run this workflow once, download the artifact, verify each object's bytes hash to its referenced CID, upload to ITKTestingData, confirm mirror reachability, then close this PR without merging.

</details>

<!--
provenance: claude-code session 2026-06-11
missing CIDs include: bafkreid3uloy2yfjqggy5d46aghpb4b5v3q2xaqylkg2uoqsuqc5dh4s7q (Sphere3D.png), bafkreickdblw4cjduumqnb7gn3wtsjshvqrvezh3k7krz657xsosvur2ry (BoundingBox.png)
origin: ITKSphinxExamples PR #359 (ed7c181b), author jphardee
post_recovery_action: upload objects to ITKTestingData, verify mirrors, close this PR unmerged
-->
