### PR TITLE
Update to link to ITK Interface Modules

### DIFF
--- a/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertAnRGBitkImageTovtkImageData)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue

--- a/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertAnitkImageTovtkImageData)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue

--- a/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertRGBvtkImageDataToAnitkImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue

--- a/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertvtkImageDataToAnitkImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 # Since we use vtkImageMagnitude
 find_package(VTK REQUIRED
@@ -16,9 +15,10 @@ endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
 target_link_libraries(${PROJECT_NAME}
-  ${ITK_LIBRARIES}
-  ${VTK_LIBRARIES}
-  )
+  PRIVATE
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Bridge/VtkGlue/VTKImageToITKImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VTKImageToITKImage/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VTKImageToITKImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -22,7 +21,12 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetAsElevationMap/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetAsElevationMap/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VisualizeEvolvingDense2DLevelSetAsElevationMap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKLevelSetsv4Module
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue

--- a/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetZeroSet/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetZeroSet/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VisualizeEvolvingDense2DLevelSetZeroSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKLevelSetsv4Module
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VisualizeStaticDense2DLevelSetAsElevationMap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -21,7 +21,15 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKLevelSetsv4Module
+    ITK::ITKThresholdingModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VisualizeStaticDense2DLevelSetZeroSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -20,7 +20,15 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKLevelSetsv4Module
+    ITK::ITKThresholdingModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VisualizeStaticMalcolm2DLevelSetLayers)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -20,7 +20,14 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+    ITK::ITKLevelSetsv4Module
+    ITK::ITKThresholdingModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VisualizeStaticShi2DLevelSetLayers)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -20,7 +20,14 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+    ITK::ITKLevelSetsv4Module
+    ITK::ITKThresholdingModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VisualizeStaticWhitaker2DLevelSetLayers)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -20,7 +20,14 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+    ITK::ITKLevelSetsv4Module
+    ITK::ITKThresholdingModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,6 @@ if(itk-module)
   endif()
 endif()
 find_package(ITK 5.2.0 REQUIRED)
-include(${ITK_USE_FILE})
 
 # To avoid linker issues.
 # Module_ITKVtkGlue is true when building inside ITK
@@ -34,7 +33,13 @@ endif()
 
 # For comparing example outputs to their regression baseline's.
 add_executable(ImageCompareCommand ImageCompareCommand.cxx)
-target_link_libraries(ImageCompareCommand ${ITK_LIBRARIES})
+target_link_libraries(ImageCompareCommand
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKTestKernelModule
+)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../CMake/ITKSphinxExamplesMacros.cmake)
 

--- a/src/Core/Common/AddNoiseToBinaryImage/CMakeLists.txt
+++ b/src/Core/Common/AddNoiseToBinaryImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AddNoiseToBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/AddOffsetToIndex/CMakeLists.txt
+++ b/src/Core/Common/AddOffsetToIndex/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AddOffsetToIndex)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/CMakeLists.txt
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyAFilterOnlyToASpecifiedRegionOfAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ApplyCustomOperationToEachPixelInImage/CMakeLists.txt
+++ b/src/Core/Common/ApplyCustomOperationToEachPixelInImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CustomOperationToEachPixelInImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/BoundingBoxOfAPointSet/CMakeLists.txt
+++ b/src/Core/Common/BoundingBoxOfAPointSet/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BoundingBoxOfAPointSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/BresenhamLine/CMakeLists.txt
+++ b/src/Core/Common/BresenhamLine/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BresenhamLine)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/BuildAHelloWorldProgram/CMakeLists.txt
+++ b/src/Core/Common/BuildAHelloWorldProgram/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BuildAHelloWorldProgram)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CastVectorImageToAnotherType/CMakeLists.txt
+++ b/src/Core/Common/CastVectorImageToAnotherType/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CastVectorImageToAnotherType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CheckIfModuleIsPresent/CMakeLists.txt
+++ b/src/Core/Common/CheckIfModuleIsPresent/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CheckIfModuleIsPresent)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ComputeTimeBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/ComputeTimeBetweenPoints/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeTimeBetweenPoints)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ConceptCheckingIsFloatingPoint/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsFloatingPoint/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConceptCheckingIsFloatingPoint)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ConceptCheckingIsSameDimension/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsSameDimension/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConceptCheckingIsSameDimension)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ConceptCheckingIsSameType/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsSameType/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConceptCheckingIsSameType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ConvertArrayToImage/CMakeLists.txt
+++ b/src/Core/Common/ConvertArrayToImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertArrayToImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CovariantVectorDotProduct/CMakeLists.txt
+++ b/src/Core/Common/CovariantVectorDotProduct/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CovariantVectorDotProduct)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CovariantVectorNorm/CMakeLists.txt
+++ b/src/Core/Common/CovariantVectorNorm/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CovariantVectorNorm)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateABackwardDifferenceOperator/CMakeLists.txt
+++ b/src/Core/Common/CreateABackwardDifferenceOperator/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateABackwardDifferenceOperator)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateACovariantVector/CMakeLists.txt
+++ b/src/Core/Common/CreateACovariantVector/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateACovariantVector)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAFixedArray/CMakeLists.txt
+++ b/src/Core/Common/CreateAFixedArray/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAFixedArray)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAIndex/CMakeLists.txt
+++ b/src/Core/Common/CreateAIndex/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAIndex)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAPointSet/CMakeLists.txt
+++ b/src/Core/Common/CreateAPointSet/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAPointSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateASize/CMakeLists.txt
+++ b/src/Core/Common/CreateASize/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateASize)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAVector/CMakeLists.txt
+++ b/src/Core/Common/CreateAVector/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAVector)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAnImage/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImage/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAnImageOfVectors/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImageOfVectors/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAnImageOfVectors)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAnImageRegion/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImageRegion/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAnImageRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAnRGBImage/CMakeLists.txt
+++ b/src/Core/Common/CreateAnRGBImage/CMakeLists.txt
@@ -2,10 +2,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAnRGBImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAnotherInstanceOfAFilter/CMakeLists.txt
+++ b/src/Core/Common/CreateAnotherInstanceOfAFilter/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAnotherInstanceOfAFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateAnotherInstanceOfAnImage/CMakeLists.txt
+++ b/src/Core/Common/CreateAnotherInstanceOfAnImage/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAnotherInstanceOfAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateDerivativeKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateDerivativeKernel/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateDerivativeKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateForwardDifferenceKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateForwardDifferenceKernel/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateForwardDifferenceKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateGaussianDerivativeKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateGaussianDerivativeKernel/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateGaussianDerivativeKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateGaussianKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateGaussianKernel/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateGaussianKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateLaplacianKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateLaplacianKernel/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateLaplacianKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateSobelKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateSobelKernel/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateSobelKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CreateVectorImage/CMakeLists.txt
+++ b/src/Core/Common/CreateVectorImage/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/CropImageBySpecifyingRegion/CMakeLists.txt
+++ b/src/Core/Common/CropImageBySpecifyingRegion/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CropImageBySpecifyingRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/DeepCopyImage/CMakeLists.txt
+++ b/src/Core/Common/DeepCopyImage/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DeepCopyImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/DemonstrateAllOperators/CMakeLists.txt
+++ b/src/Core/Common/DemonstrateAllOperators/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DemonstrateAllOperators)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/DirectWarningToFile/CMakeLists.txt
+++ b/src/Core/Common/DirectWarningToFile/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DirectWarningToFile)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/DisplayImage/CMakeLists.txt
+++ b/src/Core/Common/DisplayImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DisplayImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +32,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Core/Common/DistanceBetweenIndices/CMakeLists.txt
+++ b/src/Core/Common/DistanceBetweenIndices/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DistanceBetweenIndices)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/DistanceBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/DistanceBetweenPoints/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DistanceBetweenPoints)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/DoDataParallelThreading/CMakeLists.txt
+++ b/src/Core/Common/DoDataParallelThreading/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DoDataParallelThreading)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/DuplicateAnImage/CMakeLists.txt
+++ b/src/Core/Common/DuplicateAnImage/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DuplicateAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/EagerModuleLoadingPython/CMakeLists.txt
+++ b/src/Core/Common/EagerModuleLoadingPython/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(EagerModuleLoadingPython)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 install(FILES Code.py CMakeLists.txt
   DESTINATION share/ITKSphinxExamples/Code/Core/Common/EagerModuleLoadingPython/

--- a/src/Core/Common/FilterAndParallelizeImageRegion/CMakeLists.txt
+++ b/src/Core/Common/FilterAndParallelizeImageRegion/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FilterAndParallelizeImageRegion)
 
 find_package(ITK 5.0 REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/FilterImage/CMakeLists.txt
+++ b/src/Core/Common/FilterImage/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FilterImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/FilterImageUsingMultipleThreads/CMakeLists.txt
+++ b/src/Core/Common/FilterImageUsingMultipleThreads/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FilterImageUsingMultipleThreads)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/FilterImageWithoutCopying/CMakeLists.txt
+++ b/src/Core/Common/FilterImageWithoutCopying/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FilterImageWithoutCopying)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/FindMaxAndMinInImage/CMakeLists.txt
+++ b/src/Core/Common/FindMaxAndMinInImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FindMaxAndMinInImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -21,7 +21,13 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Core/Common/GenerateOffsetsShapedImageNeighborhood/CMakeLists.txt
+++ b/src/Core/Common/GenerateOffsetsShapedImageNeighborhood/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(Shapes)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/GetImageSize/CMakeLists.txt
+++ b/src/Core/Common/GetImageSize/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GetImageSize)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/GetNameOfClass/CMakeLists.txt
+++ b/src/Core/Common/GetNameOfClass/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GetNameOfClass)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/GetOrSetMemberVariableOfITKClass/CMakeLists.txt
+++ b/src/Core/Common/GetOrSetMemberVariableOfITKClass/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GetOrSetMemberVariableOfITKClass)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
+++ b/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GetTypeBasicInformation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ImageBufferAndIndexRange/CMakeLists.txt
+++ b/src/Core/Common/ImageBufferAndIndexRange/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ImageBufferAndIndexRange)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ImageRegionIntersection/CMakeLists.txt
+++ b/src/Core/Common/ImageRegionIntersection/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ImageRegionIntersection)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ImageRegionOverlap/CMakeLists.txt
+++ b/src/Core/Common/ImageRegionOverlap/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ImageRegionOverlap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ImportPixelBufferIntoAnImage/CMakeLists.txt
+++ b/src/Core/Common/ImportPixelBufferIntoAnImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ImportPixelBufferIntoAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/InPlaceFilterOfImage/CMakeLists.txt
+++ b/src/Core/Common/InPlaceFilterOfImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(InPlaceFilterOfImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -21,7 +21,14 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKThresholdingModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Core/Common/IsPixelInsideRegion/CMakeLists.txt
+++ b/src/Core/Common/IsPixelInsideRegion/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IsPixelInsideRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateImageStartingAtSeed/CMakeLists.txt
+++ b/src/Core/Common/IterateImageStartingAtSeed/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateImageStartingAtSeed)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
+++ b/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateLineThroughImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +31,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateLineThroughImageWithoutWriteAccess)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateOnAVectorContainer/CMakeLists.txt
+++ b/src/Core/Common/IterateOnAVectorContainer/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateOnAVectorContainer)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/CMakeLists.txt
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateOverARegionWithAShapedNeighborhoodIterator)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/CMakeLists.txt
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateOverARegionWithAShapedNeighborhoodIteratorManual)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateOverSpecificRegion/CMakeLists.txt
+++ b/src/Core/Common/IterateOverSpecificRegion/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateOverSpecificRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateRegionWithAccessToIndexWithWriteAccess)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -17,7 +17,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,7 +32,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateRegionWithAccessToIndexWithoutWriteAccess)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +31,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Core/Common/IterateRegionWithNeighborhood/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithNeighborhood/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateRegionWithNeighborhood)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -21,7 +21,13 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Core/Common/IterateRegionWithWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithWriteAccess/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateRegionWithWriteAccess)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -22,7 +22,13 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Core/Common/IterateRegionWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithoutWriteAccess/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateRegionWithoutWriteAccess)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/IterateWithNeighborhoodWithoutAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateWithNeighborhoodWithoutAccess/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterateWithNeighborhoodWithoutAccess)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/CMakeLists.txt
+++ b/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MakeOutOfBoundsPixelsReturnConstValue)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -23,7 +22,12 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Core/Common/MakePartOfImageTransparent/CMakeLists.txt
+++ b/src/Core/Common/MakePartOfImageTransparent/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MakePartOfImageTransparent)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKIOTIFFModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/Matrix/CMakeLists.txt
+++ b/src/Core/Common/Matrix/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(Matrix)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MatrixInverse/CMakeLists.txt
+++ b/src/Core/Common/MatrixInverse/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MatrixInverse)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MersenneTwisterRandomIntegerGenerator/CMakeLists.txt
+++ b/src/Core/Common/MersenneTwisterRandomIntegerGenerator/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MersenneTwisterRandomIntegerGenerator)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MersenneTwisterRandomNumberGenerator/CMakeLists.txt
+++ b/src/Core/Common/MersenneTwisterRandomNumberGenerator/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MersenneTwisterRandomNumberGenerator)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MiniPipeline/CMakeLists.txt
+++ b/src/Core/Common/MiniPipeline/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MiniPipeline)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKSmoothingModule
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
+++ b/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultiThreadOilPainting)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +31,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Core/Common/MultipleInputsOfDifferentType/CMakeLists.txt
+++ b/src/Core/Common/MultipleInputsOfDifferentType/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultipleInputsOfDifferentType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MultipleInputsOfSameType/CMakeLists.txt
+++ b/src/Core/Common/MultipleInputsOfSameType/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultipleInputsOfSameType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MultipleOutputsOfDifferentType/CMakeLists.txt
+++ b/src/Core/Common/MultipleOutputsOfDifferentType/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultipleOutputsOfDifferentType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/MultipleOutputsOfSameType/CMakeLists.txt
+++ b/src/Core/Common/MultipleOutputsOfSameType/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultipleOutputsOfSameType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/NeighborhoodIteratorOnVectorImage/CMakeLists.txt
+++ b/src/Core/Common/NeighborhoodIteratorOnVectorImage/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(NeighborhoodIteratorOnVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ObserveAnEvent/CMakeLists.txt
+++ b/src/Core/Common/ObserveAnEvent/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ObserveAnEvent)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageSourcesModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/PassImageToFunction/CMakeLists.txt
+++ b/src/Core/Common/PassImageToFunction/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PassImageToFunction)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/PermuteSequenceOfIndices/CMakeLists.txt
+++ b/src/Core/Common/PermuteSequenceOfIndices/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PermuteSequenceOfIndices)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/PiConstant/CMakeLists.txt
+++ b/src/Core/Common/PiConstant/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PiConstant)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/PrintModuleLoadingPython/CMakeLists.txt
+++ b/src/Core/Common/PrintModuleLoadingPython/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PrintModuleLoadingPython)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 install(FILES Code.py CMakeLists.txt
   DESTINATION share/ITKSphinxExamples/Code/Core/Common/PrintModuleLoadingPython/

--- a/src/Core/Common/ProduceImageProgrammatically/CMakeLists.txt
+++ b/src/Core/Common/ProduceImageProgrammatically/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ProduceImageProgrammatically)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/RandomSelectOfPixelsFromRegion/CMakeLists.txt
+++ b/src/Core/Common/RandomSelectOfPixelsFromRegion/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RandomSelectOfPixelsFromRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/CMakeLists.txt
+++ b/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RandomSelectPixelFromRegionWithoutReplacee)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/CMakeLists.txt
+++ b/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReRunPipelineWithChangingLargestPossibleRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ReadAPointSet/CMakeLists.txt
+++ b/src/Core/Common/ReadAPointSet/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadAPointSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ReadWriteVectorImage/CMakeLists.txt
+++ b/src/Core/Common/ReadWriteVectorImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadWriteVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ReturnObjectFromFunction/CMakeLists.txt
+++ b/src/Core/Common/ReturnObjectFromFunction/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReturnObjectFromFunction)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/SetDefaultNumberOfThreads/CMakeLists.txt
+++ b/src/Core/Common/SetDefaultNumberOfThreads/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SetDefaultNumberOfThreads)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/SetPixelValueInOneImage/CMakeLists.txt
+++ b/src/Core/Common/SetPixelValueInOneImage/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SetPixelValueInOneImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/SortITKIndex/CMakeLists.txt
+++ b/src/Core/Common/SortITKIndex/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SortITKIndex)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/StoreNonPixelDataInImage/CMakeLists.txt
+++ b/src/Core/Common/StoreNonPixelDataInImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(StoreNonPixelDataInImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/StreamAPipeline/CMakeLists.txt
+++ b/src/Core/Common/StreamAPipeline/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(StreamAPipeline)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/ThrowException/CMakeLists.txt
+++ b/src/Core/Common/ThrowException/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ThrowException)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/TraceMemoryBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/TraceMemoryBetweenPoints/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(TraceMemoryBetweenPoints)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/TryCatchException/CMakeLists.txt
+++ b/src/Core/Common/TryCatchException/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(TryCatchException)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/UseParallelizeImageRegion/CMakeLists.txt
+++ b/src/Core/Common/UseParallelizeImageRegion/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(UseParallelizeImageRegion)
 
 find_package(ITK 5.0 REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKWatershedsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/VariableLengthVector/CMakeLists.txt
+++ b/src/Core/Common/VariableLengthVector/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VariableLengthVector)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/VectorDotProduct/CMakeLists.txt
+++ b/src/Core/Common/VectorDotProduct/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VectorDotProduct)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx Code.py)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/WatchAFilter/CMakeLists.txt
+++ b/src/Core/Common/WatchAFilter/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WatchAFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKThresholdingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/Common/WriteAPointSet/CMakeLists.txt
+++ b/src/Core/Common/WriteAPointSet/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WriteAPointSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AddConstantToPixelsWithoutDuplicatingImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageAdaptorsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors

--- a/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractChannelOfImageWithMultipleComponents)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageAdaptorsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors

--- a/src/Core/ImageAdaptors/PresentImageAfterOperation/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/PresentImageAfterOperation/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PresentImageAfterOperation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageAdaptorsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors

--- a/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ProcessNthComponentOfVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageAdaptorsModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors

--- a/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ViewComponentVectorImageAsScaleImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageAdaptorsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors

--- a/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/CMakeLists.txt
+++ b/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeMedianOfImageAtPixel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction

--- a/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/CMakeLists.txt
+++ b/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LinearlyInterpolatePositionInImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction

--- a/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/CMakeLists.txt
+++ b/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultiplyKernelWithAnImageAtLocation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction

--- a/src/Core/ImageFunction/ResampleSegmentedImage/CMakeLists.txt
+++ b/src/Core/ImageFunction/ResampleSegmentedImage/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ResampleSegmentedImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction

--- a/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
+++ b/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AccessDataInCells)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/Mesh/AddPointsAndEdges/CMakeLists.txt
+++ b/src/Core/Mesh/AddPointsAndEdges/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AddPointsAndEdges)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/CMakeLists.txt
+++ b/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CalculateAreaAndVolumeOfSimplexMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/Mesh/ConvertMeshToUnstructeredGrid/CMakeLists.txt
+++ b/src/Core/Mesh/ConvertMeshToUnstructeredGrid/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertMeshToUnstructeredGrid)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -21,7 +20,12 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKMeshModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/CMakeLists.txt
+++ b/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/CMakeLists.txt
@@ -3,10 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertTriangleMeshToBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKMeshIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/Mesh/ExtractIsoSurface/CMakeLists.txt
+++ b/src/Core/Mesh/ExtractIsoSurface/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractIsoSurface)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKMeshIO
+    ITK::ITKMeshModule
+    ITK::ITKThresholdingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/Mesh/TranslateOneMesh/CMakeLists.txt
+++ b/src/Core/Mesh/TranslateOneMesh/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(TranslateOneMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKMeshModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/Mesh/WorkingWithPointAndCellData/CMakeLists.txt
+++ b/src/Core/Mesh/WorkingWithPointAndCellData/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WorkingWithPointAndCellData)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/Mesh/WriteMeshToVTP/CMakeLists.txt
+++ b/src/Core/Mesh/WriteMeshToVTP/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WriteMeshToVTP)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh

--- a/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateTriangularQuadEdgeMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKQuadEdgeMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh

--- a/src/Core/QuadEdgeMesh/CutMesh/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/CutMesh/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CutMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKQuadEdgeMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh

--- a/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractVertexOnMeshBoundaries)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshModule
+    ITK::ITKQuadEdgeMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh

--- a/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GetListOfFacesAroundAGivenVertex)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKQuadEdgeMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh

--- a/src/Core/QuadEdgeMesh/PrintVertexNeighbors/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/PrintVertexNeighbors/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PrintVertexNeighbors)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKQuadEdgeMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh

--- a/src/Core/SpatialObjects/Blob/CMakeLists.txt
+++ b/src/Core/SpatialObjects/Blob/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(Blob)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKSpatialObjectsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects

--- a/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
+++ b/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ContourSpatialObject)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKSpatialObjectsModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +31,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKSpatialObjectsModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Core/SpatialObjects/ConvertSpatialObjectToImage/CMakeLists.txt
+++ b/src/Core/SpatialObjects/ConvertSpatialObjectToImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertSpatialObjectToImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKSpatialObjectsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects

--- a/src/Core/SpatialObjects/CreateALineSpatialObject/CMakeLists.txt
+++ b/src/Core/SpatialObjects/CreateALineSpatialObject/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateALineSpatialObject)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKSpatialObjectsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects

--- a/src/Core/SpatialObjects/Ellipse/CMakeLists.txt
+++ b/src/Core/SpatialObjects/Ellipse/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(Ellipse)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKSpatialObjectsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects

--- a/src/Core/TestKernel/GenerateRandomImage/CMakeLists.txt
+++ b/src/Core/TestKernel/GenerateRandomImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GenerateRandomImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/TestKernel

--- a/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/CMakeLists.txt
+++ b/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyAffineTransformFromHomogeneousMatrixAndResample)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/CartesianToAzimuthElevation/CMakeLists.txt
+++ b/src/Core/Transform/CartesianToAzimuthElevation/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CartesianToAzimuthElevation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/CopyACompositeTransform/CMakeLists.txt
+++ b/src/Core/Transform/CopyACompositeTransform/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CopyACompositeTransform)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKTransformIO
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/CopyANonCompositeTransform/CMakeLists.txt
+++ b/src/Core/Transform/CopyANonCompositeTransform/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CopyANonCompositeTransform)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/DeformAVolumeWithAThinPlateSpline/CMakeLists.txt
+++ b/src/Core/Transform/DeformAVolumeWithAThinPlateSpline/CMakeLists.txt
@@ -3,10 +3,19 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DeformAVolumeWithAThinPlateSpline)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(DeformAVolumeWithAThinPlateSpline Code.cxx)
-target_link_libraries(DeformAVolumeWithAThinPlateSpline ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKMeshIO
+    ITK::ITKCommonModule
+    ITK::ITKImageCompareModule
+    ITK::ITKImageGridModule
+    ITK::ITKMeshModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS DeformAVolumeWithAThinPlateSpline
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/GlobalRegistrationTwoImagesAffine/CMakeLists.txt
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesAffine/CMakeLists.txt
@@ -3,11 +3,23 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GlobalRegistrationTwoImagesAffine)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKOptimizersModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKSpatialObjectsModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GlobalRegistrationTwoImagesBSpline)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,18 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFilterBaseModule
+      ITK::ITKImageGridModule
+      ITK::ITKOptimizersModule
+      ITK::ITKRegistrationCommonModule
+      ITK::ITKSpatialObjectsModule
+      ITK::ITKTransformModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +37,17 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFilterBaseModule
+      ITK::ITKImageGridModule
+      ITK::ITKOptimizersModule
+      ITK::ITKRegistrationCommonModule
+      ITK::ITKSpatialObjectsModule
+      ITK::ITKTransformModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Core/Transform/MutualInformationAffine/CMakeLists.txt
+++ b/src/Core/Transform/MutualInformationAffine/CMakeLists.txt
@@ -3,11 +3,23 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MutualInformationAffine)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageCompareModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKOptimizersModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKSmoothingModule
+    ITK::ITKSpatialObjectsModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/ScaleAnImage/CMakeLists.txt
+++ b/src/Core/Transform/ScaleAnImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ScaleAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/TranslateAVectorImage/CMakeLists.txt
+++ b/src/Core/Transform/TranslateAVectorImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(TranslateAVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Core/Transform/TranslateImage/CMakeLists.txt
+++ b/src/Core/Transform/TranslateImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(TranslateImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
@@ -7,10 +7,15 @@ set(test_options 5 0.125 3.0)
 project(ComputeCurvatureAnisotropicDiffusion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAnisotropicSmoothingModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/CMakeLists.txt
@@ -7,10 +7,15 @@ set(test_options 5 0.125)
 project(ComputeCurvatureFlow)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCurvatureFlowModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing

--- a/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/CMakeLists.txt
@@ -7,10 +7,15 @@ set(test_options 5 0.125 1.0)
 project(ComputeGradientAnisotropicDiffusion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAnisotropicSmoothingModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing

--- a/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/CMakeLists.txt
@@ -14,10 +14,14 @@ find_package(ITK REQUIRED
   ITKIOMeta
   ITKIOPNG
   )
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAnisotropicSmoothingModule
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SmoothImageWhilePreservingEdges)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKAnisotropicSmoothingModule
+      ITK::ITKCommonModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageFilterBaseModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKAnisotropicSmoothingModule
+      ITK::ITKCommonModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageFilterBaseModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SmoothImageWhilePreservingEdges2)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKAnisotropicSmoothingModule
+      ITK::ITKCommonModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageFilterBaseModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKAnisotropicSmoothingModule
+      ITK::ITKCommonModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageFilterBaseModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/CMakeLists.txt
+++ b/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/CMakeLists.txt
@@ -7,10 +7,14 @@ set(test_options 0.001 50 2)
 project(SmoothBinaryImageBeforeSurfaceExtraction)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAntiAliasModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AntiAlias

--- a/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ClosingBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKMathematicalMorphologyModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKMathematicalMorphologyModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/CMakeLists.txt
@@ -10,11 +10,16 @@ find_package(ITK REQUIRED
   ITKMathematicalMorphology
   ITKIOPNG
   )
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKBinaryMathematicalMorphologyModule
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/CMakeLists.txt
@@ -14,10 +14,15 @@ find_package(ITK REQUIRED
   ITKMathematicalMorphology
   ITKIOPNG
   )
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKBinaryMathematicalMorphologyModule
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology/

--- a/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
@@ -3,8 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(OpeningBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
-
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -17,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKMathematicalMorphologyModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKMathematicalMorphologyModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PruneBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKCommonModule
+      ITK::ITKMathematicalMorphologyModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +33,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKCommonModule
+      ITK::ITKMathematicalMorphologyModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/BinaryMathematicalMorphology/ThinImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ThinImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ThinImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKBinaryMathematicalMorphologyModule
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology

--- a/src/Filtering/Colormap/ApplyAColormapToAnImage/CMakeLists.txt
+++ b/src/Filtering/Colormap/ApplyAColormapToAnImage/CMakeLists.txt
@@ -7,10 +7,16 @@ set(test_options)
 project(ApplyAColormapToAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKColormapModule
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Colormap

--- a/src/Filtering/Colormap/CreateACustomColormap/CMakeLists.txt
+++ b/src/Filtering/Colormap/CreateACustomColormap/CMakeLists.txt
@@ -7,10 +7,15 @@ set(test_options)
 project(CreateACustomColormap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKColormapModule
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Colormap

--- a/src/Filtering/Colormap/MapScalarsIntoJetColormap/CMakeLists.txt
+++ b/src/Filtering/Colormap/MapScalarsIntoJetColormap/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MapScalarsIntoJetColormap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKColormapModule
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Colormap

--- a/src/Filtering/Convolution/ColorNormalizedCorrelation/CMakeLists.txt
+++ b/src/Filtering/Convolution/ColorNormalizedCorrelation/CMakeLists.txt
@@ -3,11 +3,18 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ColorNormalizedCorrelation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKConvolutionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution

--- a/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
+++ b/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvolveImageWithKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -17,7 +17,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKConvolutionModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,7 +33,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKConvolutionModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/Convolution/NormalizedCorrelation/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelation/CMakeLists.txt
@@ -3,11 +3,18 @@ cmake_minimum_required(VERSION 3.22.1)
 project(NormalizedCorrelation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKConvolutionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution

--- a/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/CMakeLists.txt
@@ -3,11 +3,18 @@ cmake_minimum_required(VERSION 3.22.1)
 project(NormalizedCorrelationOfMaskedImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKConvolutionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/CMakeLists.txt
@@ -3,11 +3,20 @@ cmake_minimum_required(VERSION 3.22.1)
 project(NormalizedCorrelationUsingFFT)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKFFTModule
+    ITK::ITKCommonModule
+    ITK::ITKConvolutionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKFFTImageFilterInit
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/CMakeLists.txt
@@ -3,11 +3,19 @@ cmake_minimum_required(VERSION 3.22.1)
 project(NormalizedCorrelationUsingFFTWithMaskImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKConvolutionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKFFTImageFilterInit
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution

--- a/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BinaryMinMaxCurvatureFlow)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +33,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SmoothImageUsingCurvatureFlow)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageFilterBaseModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageFilterBaseModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SmoothImageUsingMinMaxCurvatureFlow)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageFilterBaseModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageFilterBaseModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SmoothRGBImageUsingCurvatureFlow)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageComposeModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageComposeModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SmoothRGBImageUsingMinMaxCurvatureFlow)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageComposeModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +34,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKCurvatureFlowModule
+      ITK::ITKImageAdaptorsModule
+      ITK::ITKImageComposeModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApproxDistanceMapOfBinary)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -16,7 +16,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,7 +32,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MaurerDistanceMapOfBinary)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
    endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MeanDistanceBetweenAllPointsOnTwoCurves)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 if(ENABLE_QUICKVIEW)
@@ -17,7 +16,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,7 +31,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SignedDistanceMapOfBinary)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKDistanceMapModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/FFT/ComputeFFTInOneDimension/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeFFTInOneDimension/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeFFTInOneDimension)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 install(FILES Code.py CMakeLists.txt
   DESTINATION share/ITKSphinxExamples/Code/Filtering/FFT/ComputeFFTInOneDimension

--- a/src/Filtering/FFT/ComputeForwardFFT/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeForwardFFT/CMakeLists.txt
@@ -3,11 +3,19 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeForwardFFT)
 
 find_package(ITK REQUIRED)
+itk_generate_factory_registration()
 
-include(${ITK_USE_FILE})
 add_executable(${PROJECT_NAME}
   Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKFFTModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKFFTImageFilterInit
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FFT

--- a/src/Filtering/FFT/ComputeImageSpectralDensity/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeImageSpectralDensity/CMakeLists.txt
@@ -3,10 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeImageSpectralDensity)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKFFTModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKFFTImageFilterInit
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/FFT/ComputeInverseFFTOfImage/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeInverseFFTOfImage/CMakeLists.txt
@@ -3,11 +3,19 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeInverseFFTOfImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKFFTModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKFFTImageFilterInit
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FFT

--- a/src/Filtering/FFT/FilterImageInFourierDomain/CMakeLists.txt
+++ b/src/Filtering/FFT/FilterImageInFourierDomain/CMakeLists.txt
@@ -3,10 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FilterImageInFourierDomain)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKFFTModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKImageSourcesModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FFT

--- a/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/CMakeLists.txt
+++ b/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeGeodesicDistanceOnMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKFastMarchingModule
+    ITK::ITKMeshModule
+    ITK::ITKQuadEdgeMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FastMarching

--- a/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/CMakeLists.txt
+++ b/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateDistanceMapFromSeeds)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKFastMarchingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FastMarching

--- a/src/Filtering/ImageCompare/AbsValueOfTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompare/AbsValueOfTwoImages/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AbsValueOfTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageCompareModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompare

--- a/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/CMakeLists.txt
+++ b/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CombineTwoImagesWithCheckerBoardPattern)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageCompareModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompare

--- a/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SquaredDifferenceOfTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageCompareModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompare

--- a/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComposeVectorFromThreeScalarImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageAdaptorsModule
+    ITK::ITKImageComposeModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose

--- a/src/Filtering/ImageCompose/ConvertRealAndImaginaryToComplexImage/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/ConvertRealAndImaginaryToComplexImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertRealAndImaginaryToComplexImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageComposeModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose

--- a/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateVectorImageFromScalarImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageComposeModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose

--- a/src/Filtering/ImageCompose/JoinImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/JoinImages/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(JoinImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageAdaptorsModule
+    ITK::ITKImageComposeModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose

--- a/src/Filtering/ImageFeature/AdditiveGaussianNoiseImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/AdditiveGaussianNoiseImageFilter/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AdditiveGaussianNoiseImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageNoiseModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyAFilterOnlyToASpecifiedImageRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyAFilterToASpecifiedRegionOfAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFeatureModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFeatureModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BilateralFilterAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFeatureModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +35,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFeatureModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageFeature/ComputeLaplacian/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ComputeLaplacian/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeLaplacian)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageFeatureModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/DerivativeImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/DerivativeImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project( DerivativeImage )
 
 find_package( ITK REQUIRED )
-include( ${ITK_USE_FILE} )
 
 add_executable( DerivativeImage Code.cxx )
-target_link_libraries( DerivativeImage ${ITK_LIBRARIES} )
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+    ITK::ITKImageIntensityModule
+)
 
 install( TARGETS DerivativeImage
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/DetectEdgesWithCannyEdgeDetectionFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/DetectEdgesWithCannyEdgeDetectionFilter/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DetectEdgesWithCannyEdgeDetectionFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/ExtractContoursFromImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ExtractContoursFromImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractContoursFromImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FindZeroCrossingsInSignedImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKImageFeatureModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +33,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKImageFeatureModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LaplacianRecursiveGaussianImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/SegmentBloodVessels/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SegmentBloodVessels/CMakeLists.txt
@@ -3,11 +3,15 @@ project(SegmentBloodVessels)
 
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageFeatureModule
+)
 
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageFeature/SharpenImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SharpenImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SharpenImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SobelEdgeDetectionImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFeatureModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature

--- a/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ZeroCrossingBasedEdgeDecor)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFeatureModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFeatureModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyKernelToEveryPixel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyKernelToEveryPixelInNonZeroImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase

--- a/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CastAnImageToAnotherType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase

--- a/src/Filtering/ImageFilterBase/ComputeLocalNoise/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/ComputeLocalNoise/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeLocalNoise)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase

--- a/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CustomOperationToCorrespondingPixelsInTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase

--- a/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PredefinedOperationToCorrespondingPixelsInTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase

--- a/src/Filtering/ImageFusion/ColorBoundariesOfRegions/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/ColorBoundariesOfRegions/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ColorBoundariesOfRegions)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFusionModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion

--- a/src/Filtering/ImageFusion/ColorLabeledRegions/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/ColorLabeledRegions/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ColorLabeledRegions)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFusionModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(OverlayLabelMapOnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFusionModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/CMakeLists.txt
@@ -2,10 +2,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(OverlayLabelMapOnTopOfAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageFusionModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyGradientRecursiveGaussian)
 
 find_package(ITK 4.7.0 REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGradientModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient/

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/CMakeLists.txt
@@ -3,10 +3,18 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyGradientRecursiveGaussianWithVectorInput)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageComposeModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageGradientModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient/

--- a/src/Filtering/ImageGradient/ComputeAndDisplayGradient/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeAndDisplayGradient/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeAndDisplayGradient)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGradientModule
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitude/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitude/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeGradientMagnitude)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGradientModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeGradientMagnitudeRecursiveGaussian)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGradientModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient

--- a/src/Filtering/ImageGradient/GradientOfVectorImage/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/GradientOfVectorImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GradientOfVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageGradientModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient

--- a/src/Filtering/ImageGradient/ImplementationOfSnakes/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ImplementationOfSnakes/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ImplementationOfSnakes)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGradientModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient

--- a/src/Filtering/ImageGrid/AppendTwo3DVolumes/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/AppendTwo3DVolumes/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AppendTwo3DVolumes)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ChangeImageOriginSpacingOrDirection)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/Create3DVolume/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/Create3DVolume/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(Create3DVolume)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME}
   Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CropImageBySpecifyingRegion2)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageGridModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageGridModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/CMakeLists.txt
@@ -2,10 +2,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractRegionOfInterestInOneImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/FitSplineIntoPointSet/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/FitSplineIntoPointSet/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FitSplineIntoPointSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FlipAnImageOverSpecifiedAxes)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/PadAnImageByMirroring/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadAnImageByMirroring/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PadAnImageByMirroring)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/PadAnImageWithAConstant/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadAnImageWithAConstant/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PadAnImageWithAConstant)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/PadImageByWrapping/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadImageByWrapping/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PadImageByWrapping)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PasteImageIntoAnotherOne)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/PermuteAxesOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PermuteAxesOfAnImage/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PermuteAxesOfAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ProcessA2DSliceOfA3DImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common

--- a/src/Filtering/ImageGrid/ResampleAScalarImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAScalarImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ResampleAScalarImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/ResampleAVectorImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAVectorImage/CMakeLists.txt
@@ -6,10 +6,17 @@ set(output_image Output.png)
 project(ResampleAVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid/

--- a/src/Filtering/ImageGrid/ResampleAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAnImage/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ResampleAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RunImageFilterOnRegionOfImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -17,7 +17,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageGridModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKSmoothingModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,7 +35,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageGridModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKSmoothingModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageGrid/ShrinkImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ShrinkImage/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ShrinkImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(Stack2DImagesInto3DImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/TileImagesSideBySide/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/TileImagesSideBySide/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(TileImagesSideBySide)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/UpsampleAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/UpsampleAnImage/CMakeLists.txt
@@ -3,10 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(UpsampleAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WarpAnImageUsingADeformationField)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid

--- a/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AbsValueOfImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageIntensity/AddConstantToEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AddConstantToEveryPixel/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AddConstantToEveryPixel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/AddTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AddTwoImages/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AddTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -22,7 +21,13 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Filtering/ImageIntensity/ApplyAtanImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyAtanImageFilter/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyAtanImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ApplyCosImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyCosImageFilter/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyCosImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyExpNegativeImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ApplySinImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplySinImageFilter/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplySinImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/BinaryANDTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/BinaryANDTwoImages/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BinaryANDTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/BinaryORTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/BinaryORTwoImages/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BinaryORTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/BinaryXORTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/BinaryXORTwoImages/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BinaryXORTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CastImageToAnotherTypeButClampToOutput)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CompareTwoImagesAndSetOutputPixelToMax)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CompareTwoImagesAndSetOutputPixelToMin)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ComputeEdgePotential/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ComputeEdgePotential/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeEdgePotential)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGradientModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ComputeSigmoid/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ComputeSigmoid/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeSigmoid)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ComputerMagInVectorImageToMakeMagImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ComputerMagInVectorImageToMakeMagImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputerMagInVectorImageToMakeMagImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertRGBImageToGrayscaleImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractComponentOfVectorImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/IntensityWindowing/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/IntensityWindowing/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IntensityWindowing)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/InverseOfMaskToImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/InverseOfMaskToImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(InverseOfMaskToImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(InvertImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MaskImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageIntensity/MultiplyImageByScalar/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MultiplyImageByScalar/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultiplyImageByScalar)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/MultiplyTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MultiplyTwoImages/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultiplyTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(NormalizeImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKImageStatisticsModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +35,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKImageStatisticsModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PixelDivisionOfTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/RescaleIntensity/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/RescaleIntensity/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RescaleIntensity)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/ScalePixelSumToConstant/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ScalePixelSumToConstant/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ScalePixelSumToConstant)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/SquareEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/SquareEveryPixel/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SquareEveryPixel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SubtractConstantFromEveryPixel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageIntensity/SubtractTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/SubtractTwoImages/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SubtractTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -21,7 +20,13 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Filtering/ImageIntensity/TransformVectorValuedImagePixels/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/TransformVectorValuedImagePixels/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(TransformVectorValuedImagePixels)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractBoundariesOfConnectedRegionsInBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +17,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKCommonModule
+      ITK::ITKImageLabelModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +32,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKCommonModule
+      ITK::ITKImageLabelModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +17,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKImageLabelModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +33,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKImageLabelModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LabelContoursOfConnectComponent)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKColormapModule
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+      ITK::ITKImageLabelModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +36,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKColormapModule
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+      ITK::ITKImageLabelModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AdaptiveHistogramEqualizationImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Statistics

--- a/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyAccumulateImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics

--- a/src/Filtering/ImageStatistics/CalculateImageMoments/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/CalculateImageMoments/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CalculateImageMoments)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKExamples/Filtering/ImageStatistics

--- a/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeMinMaxVarianceMeanOfImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics

--- a/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/CMakeLists.txt
@@ -3,11 +3,28 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputePCAShapeFromSample)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAnisotropicSmoothingModule
+    ITK::ITKCommonModule
+    ITK::ITKFastMarchingModule
+    ITK::ITKImageGradientModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKImageStatisticsModule
+    ITK::ITKLevelSetsModule
+    ITK::ITKOptimizersModule
+    ITK::ITKSignedDistanceFunctionModule
+    ITK::ITKSpatialFunctionModule
+    ITK::ITKStatisticsModule
+    ITK::ITKThresholdingModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics

--- a/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(StatisticalPropertiesOfRegions)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageStatisticsModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/CMakeLists.txt
@@ -2,10 +2,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyMorphologicalClosingOnAllLabelObjects)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKBinaryMathematicalMorphologyModule
+    ITK::ITKLabelMapModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/CMakeLists.txt
@@ -2,10 +2,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ApplyMorphologicalClosingOnSpecificLabelObject)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKBinaryMathematicalMorphologyModule
+    ITK::ITKLabelMapModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/ConvertImageToLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ConvertImageToLabelMap/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertImageToLabelMap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKConnectedComponentsModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertImageWithLabelsToShapeLabelMap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKConnectedComponentsModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/ConvertLabelMapToImage/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ConvertLabelMapToImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertLabelMapToImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/ExtractGivenLabelObject/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ExtractGivenLabelObject/CMakeLists.txt
@@ -2,10 +2,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractGivenLabelObject)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/InvertImageUsingBinaryNot/CMakeLists.txt
+++ b/src/Filtering/LabelMap/InvertImageUsingBinaryNot/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(InvertImageUsingBinaryNot)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/CMakeLists.txt
+++ b/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(KeepBinaryRegionsThatMeetSpecific)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/KeepRegionsAboveLevel/CMakeLists.txt
+++ b/src/Filtering/LabelMap/KeepRegionsAboveLevel/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(KeepRegionsAboveLevel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKColormapModule
+    ITK::ITKCommonModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/CMakeLists.txt
+++ b/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(KeepRegionsThatMeetSpecific)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKColormapModule
+    ITK::ITKCommonModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/CMakeLists.txt
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LabelBinaryRegionsAndGetProperties)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/LabelBinaryRegionsInImage/CMakeLists.txt
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsInImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LabelBinaryRegionsInImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MaskOneImageGivenLabelMap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/MergeLabelMaps/CMakeLists.txt
+++ b/src/Filtering/LabelMap/MergeLabelMaps/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MergeLabelMaps)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/CMakeLists.txt
+++ b/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/CMakeLists.txt
@@ -6,10 +6,14 @@ set(output_image Output.png)
 project(RemoveHolesNotConnectedToImageBoundaries)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap/

--- a/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RemoveLabelsFromLabelMap)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/LabelMap/ShapeAttributesForBinaryImage/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ShapeAttributesForBinaryImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ShapeAttributesForBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKConnectedComponentsModule
+    ITK::ITKLabelMapModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap

--- a/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/CMakeLists.txt
@@ -3,10 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateABinaryBallStructuringElement)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/CMakeLists.txt
@@ -9,10 +9,14 @@ find_package(ITK REQUIRED
   ITKMathematicalMorphology
   ITKIOPNG
   )
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/CMakeLists.txt
@@ -9,10 +9,14 @@ find_package(ITK REQUIRED
   ITKMathematicalMorphology
   ITKIOPNG
   )
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ErodeBinaryImageUsingFlatStruct)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKMathematicalMorphologyModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
    endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKBinaryMathematicalMorphologyModule
+      ITK::ITKMathematicalMorphologyModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GenerateStructureElementsWithAccurateArea)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/MathematicalMorphology/RegionalMaximal/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/RegionalMaximal/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RegionalMaximal)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/MathematicalMorphology/RegionalMinimal/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/RegionalMinimal/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RegionalMinimal)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ValuedRegionalMaximaImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ValuedRegionalMinimalImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKMathematicalMorphologyModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology

--- a/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/CMakeLists.txt
+++ b/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DataStructureForPieceWiseLinearCurve)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKPathModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Path

--- a/src/Filtering/Path/ExtractContoursFromImage/CMakeLists.txt
+++ b/src/Filtering/Path/ExtractContoursFromImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtractContoursFromImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKDistanceMapModule
+    ITK::ITKPathModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Path

--- a/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CleanQuadEdgeMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKQuadEdgeMeshModule
+    ITK::ITKQuadEdgeMeshFilteringModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/CMakeLists.txt
@@ -3,10 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeNormalsOfAMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKCommonModule
+    ITK::ITKQuadEdgeMeshModule
+    ITK::ITKQuadEdgeMeshFilteringModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputePlanarParameterizationOfAMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKQuadEdgeMeshModule
+    ITK::ITKQuadEdgeMeshFilteringModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering

--- a/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DelaunayConformEdgeFlipping)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKQuadEdgeMeshModule
+    ITK::ITKQuadEdgeMeshFilteringModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering

--- a/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/CMakeLists.txt
+++ b/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BlurringAnImageUsingABinomialKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing

--- a/src/Filtering/Smoothing/ComputesSmoothingWithGaussianKernel/CMakeLists.txt
+++ b/src/Filtering/Smoothing/ComputesSmoothingWithGaussianKernel/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputesSmoothingWithGaussianKernel)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing

--- a/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(FindHigherDerivativesOfImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKSmoothingModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +35,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKSmoothingModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/Smoothing/MeanFilteringOfAnImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/MeanFilteringOfAnImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MeanFilteringOfAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing

--- a/src/Filtering/Smoothing/MedianFilteringOfAnImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MedianFilteringOfAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing

--- a/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MedianFilteringOfAnRGBImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing

--- a/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
+++ b/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SmoothImageWithDiscreteGaussianFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKSmoothingModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKSmoothingModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
+++ b/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DemonstrateThresholdAlgorithms)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKThresholdingModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +33,11 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKThresholdingModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
+++ b/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SeparateGroundUsingOtsu)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKThresholdingModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +34,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKThresholdingModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Filtering/Thresholding/ThresholdAnImage/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImage/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ThresholdAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKThresholdingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ThresholdAnImageUsingBinary)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKThresholdingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ThresholdAnImageUsingOtsu)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageIntensityModule
+    ITK::ITKThresholdingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding

--- a/src/IO/GDCM/ReadAndPrintDICOMTags/CMakeLists.txt
+++ b/src/IO/GDCM/ReadAndPrintDICOMTags/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadAndPrintDICOMTags)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKIOGDCMModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/GDCM

--- a/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/CMakeLists.txt
+++ b/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/CMakeLists.txt
@@ -2,10 +2,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadDICOMSeriesAndWrite3DImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKIOGDCMModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/GDCM

--- a/src/IO/GDCM/ResampleDICOMSeries/CMakeLists.txt
+++ b/src/IO/GDCM/ResampleDICOMSeries/CMakeLists.txt
@@ -3,11 +3,21 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ResampleDICOMSeries)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKIOGDCMModule
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKImageStatisticsModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/GDCM

--- a/src/IO/ImageBase/ConvertFileFormats/CMakeLists.txt
+++ b/src/IO/ImageBase/ConvertFileFormats/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertFileFormats)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase

--- a/src/IO/ImageBase/ConvertImageToAnotherType/CMakeLists.txt
+++ b/src/IO/ImageBase/ConvertImageToAnotherType/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertImageToAnotherType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase

--- a/src/IO/ImageBase/Create3DFromSeriesOf2D/CMakeLists.txt
+++ b/src/IO/ImageBase/Create3DFromSeriesOf2D/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(Create3DFromSeriesOf2D)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase

--- a/src/IO/ImageBase/CreateAListOfFileNames/CMakeLists.txt
+++ b/src/IO/ImageBase/CreateAListOfFileNames/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateAListOfFileNames)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase

--- a/src/IO/ImageBase/GenerateSlicesFromVolume/CMakeLists.txt
+++ b/src/IO/ImageBase/GenerateSlicesFromVolume/CMakeLists.txt
@@ -13,10 +13,14 @@ find_package(ITK REQUIRED
   ITKIOPNG
   ITKIOMeta
   )
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase/

--- a/src/IO/ImageBase/ProcessImageChunks/CMakeLists.txt
+++ b/src/IO/ImageBase/ProcessImageChunks/CMakeLists.txt
@@ -10,10 +10,13 @@ find_package(ITK REQUIRED
   ITKIOPNG
   ITKIOMeta
   )
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKSmoothingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase/

--- a/src/IO/ImageBase/ReadAnImage/CMakeLists.txt
+++ b/src/IO/ImageBase/ReadAnImage/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase/

--- a/src/IO/ImageBase/ReadUnknownImageType/CMakeLists.txt
+++ b/src/IO/ImageBase/ReadUnknownImageType/CMakeLists.txt
@@ -3,10 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadUnknownImageType)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase

--- a/src/IO/ImageBase/RegisterIOFactories/CMakeLists.txt
+++ b/src/IO/ImageBase/RegisterIOFactories/CMakeLists.txt
@@ -3,14 +3,18 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RegisterIOFactories)
 
 find_package(ITK REQUIRED)
+itk_generate_factory_registration()
 # Registering the IO classes manually is usually not necessary,
 # unless this variable is set before calling
-#   "include(${ITK_USE_FILE})"
 set(ITK_NO_IMAGEIO_FACTORY_REGISTER_MANAGER 1)
-include(${ITK_USE_FILE})
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKIOMetaModule
+    ITK::ITKIOPNGModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase

--- a/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
+++ b/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WriteAnImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Base/

--- a/src/IO/Mesh/ReadMesh/CMakeLists.txt
+++ b/src/IO/Mesh/ReadMesh/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadMesh)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKMeshIO
+    ITK::ITKMeshModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/Mesh

--- a/src/IO/TIFF/WriteATIFFImage/CMakeLists.txt
+++ b/src/IO/TIFF/WriteATIFFImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WriteATIFFImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKIOTIFFModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TIFF/

--- a/src/IO/TransformBase/ReadTransformFromFile/CMakeLists.txt
+++ b/src/IO/TransformBase/ReadTransformFromFile/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ReadTransformFromFile)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKTransformIO
+    ITK::ITKTransformFactoryModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TransformBase

--- a/src/IO/TransformBase/WriteTransformToFile/CMakeLists.txt
+++ b/src/IO/TransformBase/WriteTransformToFile/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WriteTransfromFromFile)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKTransformIO
+    ITK::ITKCommonModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TransformBase

--- a/src/IO/TransformFactory/RegisterTransformWithTransformFactory/CMakeLists.txt
+++ b/src/IO/TransformFactory/RegisterTransformWithTransformFactory/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RegisterTransformWithTransformFactory)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKTransformIO
+    ITK::ITKTransformModule
+    ITK::ITKTransformFactoryModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TransformFactory

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GeometricPropertiesOfRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFusionModule
+      ITK::ITKReviewModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +35,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKImageFusionModule
+      ITK::ITKReviewModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
+++ b/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultiphaseChanAndVeseSparseFieldLevelSetSegmentation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKReviewModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review

--- a/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/CMakeLists.txt
+++ b/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SegmentBloodVesselsWithMultiScaleHessianBasedMeasure)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageFeatureModule
+    ITK::ITKImageIntensityModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review

--- a/src/Nonunit/Review/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation/CMakeLists.txt
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SinglephaseChanAndVeseDenseFieldLevelSetSegmentation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKFastMarchingModule
+    ITK::ITKReviewModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review

--- a/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SinglephaseChanAndVeseSparseFieldLevelSetSegmentation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKFastMarchingModule
+    ITK::ITKReviewModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review

--- a/src/Numerics/Optimizers/AmoebaOptimizer/CMakeLists.txt
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AmoebaOptimizer)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx ExampleCostFunction.h)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKOptimizersModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Optimizers

--- a/src/Numerics/Optimizers/ExhaustiveOptimizer/CMakeLists.txt
+++ b/src/Numerics/Optimizers/ExhaustiveOptimizer/CMakeLists.txt
@@ -3,11 +3,20 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExhaustiveOptimizer)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKMetricsv4Module
+    ITK::ITKOptimizersv4Module
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKRegistrationMethodsv4Module
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Optimizers

--- a/src/Numerics/Optimizers/LevenbergMarquardtOptimization/CMakeLists.txt
+++ b/src/Numerics/Optimizers/LevenbergMarquardtOptimization/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LevenbergMarquardtOptimization)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKOptimizersModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Optimizers

--- a/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/CMakeLists.txt
+++ b/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(2DGaussianMixtureModelExpectMax)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/CMakeLists.txt
+++ b/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeHistogramFromGrayscaleImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/CMakeLists.txt
+++ b/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeHistogramOfMaskedRegion)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/ComputeTextureFeatures/CMakeLists.txt
+++ b/src/Numerics/Statistics/ComputeTextureFeatures/CMakeLists.txt
@@ -3,11 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeTextureFeatures)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/CreateGaussianDistribution/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateGaussianDistribution/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateGaussianDistribution)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateHistogramFromListOfMeasurements)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/CreateListOfSampleMeasurements/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateListOfSampleMeasurements/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateListOfSampleMeasurements)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateListOfSamplesFromImageWithoutDuplication)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageComposeModule
+    ITK::ITKStatisticsModule
+    ITK::ITKTestKernelModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/CreateListOfSamplesWithIDs/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateListOfSamplesWithIDs/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CreateListOfSamplesWithIDs)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/DistributeSamplingUsingGMM/CMakeLists.txt
+++ b/src/Numerics/Statistics/DistributeSamplingUsingGMM/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DistributeSamplingUsingGMM)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/CMakeLists.txt
+++ b/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DistributionOfPixelsUsingGMM)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/HistogramCreationAndBinAccess/CMakeLists.txt
+++ b/src/Numerics/Statistics/HistogramCreationAndBinAccess/CMakeLists.txt
@@ -3,11 +3,13 @@ cmake_minimum_required(VERSION 3.22.1)
 project(HistogramCreationAndBinAccess)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Numerics/Statistics/SpatialSearch/CMakeLists.txt
+++ b/src/Numerics/Statistics/SpatialSearch/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SpatialSearch)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics

--- a/src/Registration/Common/ComputeMeanSquareBetweenTwoImages/CMakeLists.txt
+++ b/src/Registration/Common/ComputeMeanSquareBetweenTwoImages/CMakeLists.txt
@@ -3,11 +3,18 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ComputeMeanSquareBetweenTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFunctionModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/GlobalRegistrationOfTwoImages/CMakeLists.txt
+++ b/src/Registration/Common/GlobalRegistrationOfTwoImages/CMakeLists.txt
@@ -3,11 +3,23 @@ cmake_minimum_required(VERSION 3.22.1)
 project(GlobalRegistrationOfTwoImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageFunctionModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKOptimizersModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKSpatialObjectsModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/MatchFeaturePoints/CMakeLists.txt
+++ b/src/Registration/Common/MatchFeaturePoints/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MatchFeaturePoints)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKRegistrationCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/MultiresolutionPyramidFromImage/CMakeLists.txt
+++ b/src/Registration/Common/MultiresolutionPyramidFromImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MultiresolutionPyramidFromImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKRegistrationCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/MutualInformation/CMakeLists.txt
+++ b/src/Registration/Common/MutualInformation/CMakeLists.txt
@@ -3,11 +3,23 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MutualInformation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageCompareModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKOptimizersModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKSmoothingModule
+    ITK::ITKSpatialObjectsModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/CMakeLists.txt
+++ b/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/CMakeLists.txt
@@ -9,10 +9,20 @@ set(output_image3 ImageRegistration1DifferenceBefore.png)
 project(Perform2DTranslationRegistrationWithMeanSquares)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKMetricsv4Module
+    ITK::ITKOptimizersv4Module
+    ITK::ITKRegistrationMethodsv4Module
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/CMakeLists.txt
+++ b/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/CMakeLists.txt
@@ -3,10 +3,22 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PerformMultiModalityRegistrationWithMutualInformation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageCompareModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKOptimizersModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKSmoothingModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/CMakeLists.txt
+++ b/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/CMakeLists.txt
@@ -3,11 +3,18 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RegisterImageToAnotherUsingLandmarks)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageGridModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Registration/Common/WatchRegistration/CMakeLists.txt
+++ b/src/Registration/Common/WatchRegistration/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(WatchRegistration)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -20,7 +20,20 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKImageCompareModule
+    ITK::ITKImageGridModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKOptimizersModule
+    ITK::ITKRegistrationCommonModule
+    ITK::ITKSmoothingModule
+    ITK::ITKTransformModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/CMakeLists.txt
+++ b/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/CMakeLists.txt
@@ -3,11 +3,19 @@ cmake_minimum_required(VERSION 3.22.1)
 project(PerformRegistrationOnVectorImages)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKDisplacementFieldModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKMetricsv4Module
+    ITK::ITKOptimizersv4Module
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Metricsv4

--- a/src/Registration/Metricsv4/RegisterTwoPointSets/CMakeLists.txt
+++ b/src/Registration/Metricsv4/RegisterTwoPointSets/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(RegisterTwoPointSets)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKMetricsv4Module
+    ITK::ITKOptimizersv4Module
+    ITK::ITKTransformModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common

--- a/src/Remote/WikiExamples/CustomUserMatrixToAlignImageWithDICOM/CMakeLists.txt
+++ b/src/Remote/WikiExamples/CustomUserMatrixToAlignImageWithDICOM/CMakeLists.txt
@@ -3,11 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CustomUserMatrixToAlignImageWithDICOM)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKTestKernelModule
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Remote/WikiExamples

--- a/src/Remote/WikiExamples/DisplayITKImage/CMakeLists.txt
+++ b/src/Remote/WikiExamples/DisplayITKImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(DisplayITKImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Remote/WikiExamples

--- a/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/CMakeLists.txt
+++ b/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ClusterPixelsInGrayscaleImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 find_package(VTK REQUIRED)
 set(_vtk_prefix "")
@@ -21,7 +20,15 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
 endif()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKClassifiersModule
+    ITK::ITKCommonModule
+    ITK::ITKConnectedComponentsModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKVtkGlueModule
+    ${VTK_LIBRARIES}
+)
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(

--- a/src/Segmentation/Classifiers/KMeansClusterOfPixelsInImage/CMakeLists.txt
+++ b/src/Segmentation/Classifiers/KMeansClusterOfPixelsInImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(KMeansClusterOfPixelsInImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKClassifiersModule
+    ITK::ITKCommonModule
+    ITK::ITKStatisticsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Classifiers

--- a/src/Segmentation/Classifiers/KMeansClustering/CMakeLists.txt
+++ b/src/Segmentation/Classifiers/KMeansClustering/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(KMeansClustering)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKClassifiersModule
+    ITK::ITKCommonModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Classifiers

--- a/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 3.22.1)
 project(AssignContiguousLabelsToConnectedRegions)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +17,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKColormapModule
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +33,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKColormapModule
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ExtraLargestConnectComponentFromBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKLabelMapModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +36,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+      ITK::ITKImageIntensityModule
+      ITK::ITKLabelMapModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LabelConnectComponentsInBinaryImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKConnectedComponentsModule
+    ITK::ITKImageFusionModule
+    ITK::ITKThresholdingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/ConnectedComponents

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(LabelConnectComponentsInGrayscaleImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 if(ENABLE_QUICKVIEW)
@@ -18,7 +18,15 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+      ITK::ITKImageFusionModule
+      ITK::ITKImageStatisticsModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -28,7 +36,14 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKConnectedComponentsModule
+      ITK::ITKImageFusionModule
+      ITK::ITKImageStatisticsModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/CMakeLists.txt
+++ b/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(BasicRegionGrowing)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKKLMRegionGrowingModule
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/KLMRegionGrowing

--- a/src/Segmentation/LabelVoting/IterativeHoleFilling/CMakeLists.txt
+++ b/src/Segmentation/LabelVoting/IterativeHoleFilling/CMakeLists.txt
@@ -3,10 +3,14 @@ cmake_minimum_required(VERSION 3.22.1)
 project(IterativeHoleFilling)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKLabelVotingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/LabelVoting

--- a/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/CMakeLists.txt
+++ b/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/CMakeLists.txt
@@ -3,10 +3,19 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SegmentWithGeodesicActiveContourLevelSet)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAnisotropicSmoothingModule
+    ITK::ITKFastMarchingModule
+    ITK::ITKImageGradientModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKLevelSetsModule
+    ITK::ITKThresholdingModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/LevelSets

--- a/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/CMakeLists.txt
+++ b/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConnectedComponentsInImage)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKCommonModule
+    ITK::ITKImageFilterBaseModule
+    ITK::ITKRegionGrowingModule
+    ITK::ITKVtkGlueModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/RegionGrowing

--- a/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
+++ b/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SegmentPixelsWithSimilarStats)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
@@ -17,7 +17,13 @@ if(ENABLE_QUICKVIEW)
   endif()
 
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKRegionGrowingModule
+      ${VTK_LIBRARIES}
+  )
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,7 +33,12 @@ if(ENABLE_QUICKVIEW)
   endif()
 else()
   add_executable(${PROJECT_NAME} Code.cxx)
-  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+      ITK::ITKImageIO
+      ITK::ITKCommonModule
+      ITK::ITKRegionGrowingModule
+  )
 endif()
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/Segmentation/Voronoi/VoronoiDiagram/CMakeLists.txt
+++ b/src/Segmentation/Voronoi/VoronoiDiagram/CMakeLists.txt
@@ -3,11 +3,16 @@ cmake_minimum_required(VERSION 3.22.1)
 project(VoronoiDiagram)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKMeshModule
+    ITK::ITKVoronoiModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Voronoi

--- a/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/CMakeLists.txt
+++ b/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/CMakeLists.txt
@@ -3,11 +3,21 @@ cmake_minimum_required(VERSION 3.22.1)
 project(MorphologicalWatershedSegmentation)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAnisotropicSmoothingModule
+    ITK::ITKColormapModule
+    ITK::ITKCommonModule
+    ITK::ITKImageFusionModule
+    ITK::ITKImageGradientModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKWatershedsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Watersheds

--- a/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/CMakeLists.txt
+++ b/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/CMakeLists.txt
@@ -3,11 +3,21 @@ cmake_minimum_required(VERSION 3.22.1)
 project(SegmentWithWatershedImageFilter)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKAnisotropicSmoothingModule
+    ITK::ITKColormapModule
+    ITK::ITKCommonModule
+    ITK::ITKImageFusionModule
+    ITK::ITKImageGradientModule
+    ITK::ITKImageIntensityModule
+    ITK::ITKWatershedsModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Watersheds

--- a/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/CMakeLists.txt
+++ b/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/CMakeLists.txt
@@ -3,10 +3,15 @@ cmake_minimum_required(VERSION 3.22.1)
 project(ConvertAnITKGrayScaleImageToCVMat)
 
 find_package(ITK REQUIRED)
-include(${ITK_USE_FILE})
+itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    ITK::ITKImageIO
+    ITK::ITKCommonModule
+    ITK::ITKVideoBridgeOpenCVModule
+)
 
 install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Video/BridgeOpenCV


### PR DESCRIPTION
Removed all occurrences of ITK_USE_FILE and ITK_LIBRARIES.

The new implementation should reduce over-linking and support specific include directories from ITK build trees.

Addresses #459 