### PR TITLE
COMP: Audit — disable all CTest warning suppressions to surface hidden warnings

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -34,75 +34,77 @@ set(CTEST_CUSTOM_COVERAGE_EXCLUDE
  ".*/Utilities/.*"
  )
 
+# AUDIT: every warning suppression below is temporarily disabled so CI
+# surfaces the warnings each pattern was hiding. Restore selectively.
 set(CTEST_CUSTOM_WARNING_EXCEPTION
   ${CTEST_CUSTOM_WARNING_EXCEPTION}
-  "has no symbols"
-  "UseITK\\.cmake"
-  "This warning is for project developers"
-  "DirectWarningToFile"
-  "WITH_MAINTAINER_WARNINGS"
-  "which will suppress this warning"
-  "WARNING: Cache entry deserialization failed, entry ignored"
-  "LabelGeometryImageFilter.*deprecated"
-  "WARNING: Duplicate C\+\+ declaration"
-  "note: declared here"
-  "RemovedInSphinx[0-9]+Warning"
-  "ipo: warning #11053"
-  "ipo: warning #11053"
-  "vxl.core.vnl.algo"
-  "vxl.core.vnl"
-  "vxl.v3p.netlib"
-  "itkjpeg"
-  "usr.include.stdint.h"
-  "Warning itk::Statistics::Histogram"
-  "itkIOCommonTest.cxx:.*warning:.* is deprecated"
-  "/usr/bin/ld: warning: libnetcdf.so.3, needed by.*may conflict with libnetcdf.so.4"
-  "itkQuadEdgeMeshEdgeMergeDecimationFilter.hxx:.*warning: unused parameter.*iEdge.*"
-  "vnl_diag_matrix.h"
-  "WARNING non-zero return value in ctest"
-  "Warning.*Anachronism.*"
-  "attempted multiple inclusion of file"
-  "warning LNK4221"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Dd][Ii][Cc][Oo][Mm][Pp]arser[/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Ee]xpat[/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Jj][Pp][Ee][Gg][/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Kk][Ww][Ss]ys[/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Mm]eta[Ii][Oo][/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Nn]etlib[/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Nn][Ii][Ff][Tt][Ii][/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Oo]pen[Jj][Pp][Ee][Gg][/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Pp][Nn][Gg][/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Tt][Ii][Ff][Ff][/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Vv][Nn][Ll][/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Vv][Nn][Ll][Ii]nstantiation[/\\\\].*[Ww]arning.*"
-  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Zz][Ll][Ii][Bb][/\\\\].*[Ww]arning.*"
-  ".*Microsoft.*include.*win.*.h.*[Ww]arning.*"
-  ".*include.opencv2.*warning.*"
-  ".*core.vidl.*warning.*"
-  ".*core.vnl.vnl_matrix_fixed.h.*warning.*"
-  # DCMTK
-  "Note: checking out.*"
-  "-- Warning: SNDFILE support will be disabled because libsndfile was not found.*"
-  # FFTW ExternalProject
-  ".*fftw[fd]/src/fftw[fd]./*"
-  "libtool: install: warning: relinking .libfftw3f?_threads.la."
-  # OpenCV
-  "opencv/modules"
-
-  # Ignore clang's summary warning, assuming prior text has matched some
-  # other warning expression:
-  "[0-9,]+ warnings? generated."
+#  "has no symbols"
+#  "UseITK\\.cmake"
+#  "This warning is for project developers"
+#  "DirectWarningToFile"
+#  "WITH_MAINTAINER_WARNINGS"
+#  "which will suppress this warning"
+#  "WARNING: Cache entry deserialization failed, entry ignored"
+#  "LabelGeometryImageFilter.*deprecated"
+#  "WARNING: Duplicate C\+\+ declaration"
+#  "note: declared here"
+#  "RemovedInSphinx[0-9]+Warning"
+#  "ipo: warning #11053"
+#  "ipo: warning #11053"
+#  "vxl.core.vnl.algo"
+#  "vxl.core.vnl"
+#  "vxl.v3p.netlib"
+#  "itkjpeg"
+#  "usr.include.stdint.h"
+#  "Warning itk::Statistics::Histogram"
+#  "itkIOCommonTest.cxx:.*warning:.* is deprecated"
+#  "/usr/bin/ld: warning: libnetcdf.so.3, needed by.*may conflict with libnetcdf.so.4"
+#  "itkQuadEdgeMeshEdgeMergeDecimationFilter.hxx:.*warning: unused parameter.*iEdge.*"
+#  "vnl_diag_matrix.h"
+#  "WARNING non-zero return value in ctest"
+#  "Warning.*Anachronism.*"
+#  "attempted multiple inclusion of file"
+#  "warning LNK4221"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Dd][Ii][Cc][Oo][Mm][Pp]arser[/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Ee]xpat[/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Jj][Pp][Ee][Gg][/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Kk][Ww][Ss]ys[/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Mm]eta[Ii][Oo][/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Nn]etlib[/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Nn][Ii][Ff][Tt][Ii][/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Oo]pen[Jj][Pp][Ee][Gg][/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Pp][Nn][Gg][/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Tt][Ii][Ff][Ff][/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Vv][Nn][Ll][/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Vv][Nn][Ll][Ii]nstantiation[/\\\\].*[Ww]arning.*"
+#  ".*[/\\\\][Mm]odules[/\\\\][Tt]hird[Pp]arty[/\\\\][Zz][Ll][Ii][Bb][/\\\\].*[Ww]arning.*"
+#  ".*Microsoft.*include.*win.*.h.*[Ww]arning.*"
+#  ".*include.opencv2.*warning.*"
+#  ".*core.vidl.*warning.*"
+#  ".*core.vnl.vnl_matrix_fixed.h.*warning.*"
+#  # DCMTK
+#  "Note: checking out.*"
+#  "-- Warning: SNDFILE support will be disabled because libsndfile was not found.*"
+#  # FFTW ExternalProject
+#  ".*fftw[fd]/src/fftw[fd]./*"
+#  "libtool: install: warning: relinking .libfftw3f?_threads.la."
+#  # OpenCV
+#  "opencv/modules"
+#
+#  # Ignore clang's summary warning, assuming prior text has matched some
+#  # other warning expression:
+#  "[0-9,]+ warnings? generated."
   )
 
 if(APPLE)
 set(CTEST_CUSTOM_WARNING_EXCEPTION
   ${CTEST_CUSTOM_WARNING_EXCEPTION}
-  "warning -.: directory name .* does not exist"
-  "ld.*warning.*duplicate dylib.*"
+#  "warning -.: directory name .* does not exist"
+#  "ld.*warning.*duplicate dylib.*"
   )
 endif()
 
 set(CTEST_CUSTOM_ERROR_EXCEPTION
   ${CTEST_CUSTOM_ERROR_EXCEPTION}
-  "RemovedInSphinx[0-9]+Warning"
+#  "RemovedInSphinx[0-9]+Warning"
   )


### PR DESCRIPTION
Diagnostic PR: temporarily comments out **every** `CTEST_CUSTOM_WARNING_EXCEPTION` / `CTEST_CUSTOM_ERROR_EXCEPTION` pattern in `CMake/CTestCustom.cmake.in` so CI surfaces the warnings each suppression was hiding. Not intended to merge as-is — the goal is to read the CDash output and then restore only the suppressions that are still warranted.

Follow-up to the suppression-audit note on #449 (`CTestCustom.cmake.in` — "we should review all the suppressions and re-evaluate whether they are needed").

<details>
<summary>What to look at in CI</summary>

- CDash will likely show many warnings (third-party `Modules/ThirdParty/...`, vnl, OpenCV, Sphinx deprecations, etc.).
- `CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS` is still 199, so CDash truncates the list at 199 — the count is a floor, not the true total.
- The `set()` scaffolding and `${VAR}` continuation lines are preserved, so the configured `CTestCustom.cmake` stays valid with an empty exception list.

</details>

<details>
<summary>Next steps</summary>

1. Categorize surfaced warnings: (a) third-party / vendored code we don't control → keep suppression; (b) our own examples/docs → fix at source; (c) stale patterns matching nothing → delete.
2. Restore suppressions in category (a), drop category (c), open fixes for category (b).

</details>

<!--
provenance: claude-code session 2026-06-13
branch: audit/uncomment-ctest-warning-suppressions (off origin/main)
head_commit: 5d8bd42e
related: PR #449 self-review comment r3407862591 (CTestCustom.cmake.in suppression audit)
file: CMake/CTestCustom.cmake.in
intent: diagnostic only; do not merge until suppressions are selectively restored
-->
