### PR TITLE
COMP: Migrate GeometricPropertiesOfRegion off deprecated LabelGeometryImageFilter

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -43,7 +43,6 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
   "WITH_MAINTAINER_WARNINGS"
   "which will suppress this warning"
   "WARNING: Cache entry deserialization failed, entry ignored"
-  "LabelGeometryImageFilter.*deprecated"
   "WARNING: Duplicate C\+\+ declaration"
   "note: declared here"
   "RemovedInSphinx[0-9]+Warning"

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
@@ -23,7 +23,8 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageFusionModule
-      ITK::ITKReviewModule
+      ITK::ITKLabelMapModule
+      ITK::ITKImageStatisticsModule
       ${VTK_LIBRARIES}
   )
 
@@ -40,7 +41,8 @@ else()
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageFusionModule
-      ITK::ITKReviewModule
+      ITK::ITKLabelMapModule
+      ITK::ITKImageStatisticsModule
   )
 endif()
 

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
@@ -18,14 +18,13 @@
 #include "itkImage.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageFileReader.h"
-#include "itkLabelGeometryImageFilter.h"
+#include "itkLabelImageToShapeLabelMapFilter.h"
+#include "itkLabelStatisticsImageFilter.h"
 #include "itkLabelToRGBImageFilter.h"
 
 #ifdef ENABLE_QUICKVIEW
 #  include "QuickView.h"
 #endif
-
-#include <sstream>
 
 using ImageType = itk::Image<unsigned int, 2>;
 using RGBPixelType = itk::RGBPixel<unsigned char>;
@@ -41,101 +40,79 @@ main(int argc, char * argv[])
 {
   auto labelImage = ImageType::New();
   auto intensityImage = ImageType::New();
-  int  label = 1;
 
-  if (argc < 2)
+  if (argc < 3)
   {
     // Create a label image that is 0 in the background and where the
-    // objects are labeled
+    // objects are labeled.
     CreateLabelImage(labelImage);
-    labelImage->Print(std::cout);
-    // Create an intensity image.  Some LabelGeometry features (such as
-    // weighted centroid and integrated intensity) depend on an
-    // intensity image.
+    // Create an intensity image. Intensity statistics such as the
+    // integrated intensity depend on an intensity image.
     CreateIntensityImage(intensityImage);
   }
-  else if (argc > 3)
+  else
   {
     labelImage = itk::ReadImage<ImageType>(argv[1]);
-
     intensityImage = itk::ReadImage<ImageType>(argv[2]);
-
-    label = std::stoi(argv[3]);
   }
 
-  // NOTE: As of April 8, 2015 the filter does not work with non-zero
-  // origins
-  double origin[2] = { 0.0, 0.0 };
-  labelImage->SetOrigin(origin);
-  intensityImage->SetOrigin(origin);
+  // Shape attributes (size, centroid, ellipsoid axes, elongation, ...).
+  using LabelImageToShapeLabelMapFilterType = itk::LabelImageToShapeLabelMapFilter<ImageType>;
+  auto shapeFilter = LabelImageToShapeLabelMapFilterType::New();
+  shapeFilter->SetInput(labelImage);
+  shapeFilter->Update();
 
-  using LabelGeometryImageFilterType = itk::LabelGeometryImageFilter<ImageType>;
-  auto labelGeometryImageFilter = LabelGeometryImageFilterType::New();
-  labelGeometryImageFilter->SetInput(labelImage);
-  labelGeometryImageFilter->SetIntensityInput(intensityImage);
+  // Intensity statistics computed over each labeled region.
+  using LabelStatisticsImageFilterType = itk::LabelStatisticsImageFilter<ImageType, ImageType>;
+  auto statisticsFilter = LabelStatisticsImageFilterType::New();
+  statisticsFilter->SetInput(intensityImage);
+  statisticsFilter->SetLabelInput(labelImage);
+  statisticsFilter->Update();
 
-  // These generate optional outputs.
-  labelGeometryImageFilter->CalculatePixelIndicesOn();
-  labelGeometryImageFilter->CalculateOrientedBoundingBoxOn();
-  labelGeometryImageFilter->CalculateOrientedLabelRegionsOn();
-  labelGeometryImageFilter->CalculateOrientedIntensityRegionsOn();
+  auto labelMap = shapeFilter->GetOutput();
+  std::cout << "Number of labels: " << labelMap->GetNumberOfLabelObjects() << std::endl;
+  std::cout << std::endl;
 
-  labelGeometryImageFilter->Update();
-  LabelGeometryImageFilterType::LabelsType allLabels = labelGeometryImageFilter->GetLabels();
+  for (unsigned int n = 0; n < labelMap->GetNumberOfLabelObjects(); ++n)
+  {
+    const auto labelObject = labelMap->GetNthLabelObject(n);
+    const auto labelValue = labelObject->GetLabel();
 
+    std::cout << "\tLabel: " << static_cast<int>(labelValue) << std::endl;
+    std::cout << "\tPhysical size: " << labelObject->GetPhysicalSize() << std::endl;
+    std::cout << "\tNumber of pixels: " << labelObject->GetNumberOfPixels() << std::endl;
+    std::cout << "\tCentroid: " << labelObject->GetCentroid() << std::endl;
+    std::cout << "\tEquivalent ellipsoid diameter: " << labelObject->GetEquivalentEllipsoidDiameter() << std::endl;
+    std::cout << "\tElongation: " << labelObject->GetElongation() << std::endl;
+    std::cout << "\tFlatness: " << labelObject->GetFlatness() << std::endl;
+    std::cout << "\tPrincipal axes: " << labelObject->GetPrincipalAxes() << std::endl;
+    std::cout << "\tBounding box: " << labelObject->GetBoundingBox() << std::endl;
+
+    if (statisticsFilter->HasLabel(labelValue))
+    {
+      std::cout << "\tIntegrated intensity: " << statisticsFilter->GetSum(labelValue) << std::endl;
+      std::cout << "\tMean intensity: " << statisticsFilter->GetMean(labelValue) << std::endl;
+    }
+
+    std::cout << std::endl << std::endl;
+  }
+
+#ifdef ENABLE_QUICKVIEW
   using RGBFilterType = itk::LabelToRGBImageFilter<ImageType, RGBImageType>;
   auto rgbLabelImage = RGBFilterType::New();
   rgbLabelImage->SetInput(labelImage);
 
-  using RGBFilterType = itk::LabelToRGBImageFilter<ImageType, RGBImageType>;
-  auto rgbOrientedImage = RGBFilterType::New();
-  rgbOrientedImage->SetInput(labelGeometryImageFilter->GetOrientedLabelImage(allLabels[label]));
-
-#ifdef ENABLE_QUICKVIEW
   QuickView viewer;
   viewer.ShareCameraOff();
   viewer.InterpolateOff();
-
   viewer.AddImage(rgbLabelImage->GetOutput(),
                   true,
-                  argc > 3 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated label image");
+                  argc > 2 ? itksys::SystemTools::GetFilenameName(argv[1]) : "Generated label image");
   viewer.AddImage(intensityImage.GetPointer(),
                   true,
-                  argc > 3 ? itksys::SystemTools::GetFilenameName(argv[2]) : "Generated intensity image");
-
-  std::stringstream desc;
-  desc << "Oriented Label: " << allLabels[label];
-  viewer.AddImage(rgbOrientedImage->GetOutput(), true, desc.str());
-
-  std::stringstream desc2;
-  desc2 << "Oriented Intensity: " << allLabels[label];
-  viewer.AddImage(labelGeometryImageFilter->GetOrientedIntensityImage(allLabels[label]), true, desc2.str());
+                  argc > 2 ? itksys::SystemTools::GetFilenameName(argv[2]) : "Generated intensity image");
   viewer.Visualize();
 #endif
-
-  LabelGeometryImageFilterType::LabelsType::iterator allLabelsIt;
-  std::cout << "Number of labels: " << labelGeometryImageFilter->GetNumberOfLabels() << std::endl;
-  std::cout << std::endl;
-
-  for (allLabelsIt = allLabels.begin(); allLabelsIt != allLabels.end(); ++allLabelsIt)
-  {
-    LabelGeometryImageFilterType::LabelPixelType labelValue = *allLabelsIt;
-    std::cout << "\tLabel: " << (int)labelValue << std::endl;
-    std::cout << "\tVolume: " << labelGeometryImageFilter->GetVolume(labelValue) << std::endl;
-    std::cout << "\tIntegrated Intensity: " << labelGeometryImageFilter->GetIntegratedIntensity(labelValue)
-              << std::endl;
-    std::cout << "\tCentroid: " << labelGeometryImageFilter->GetCentroid(labelValue) << std::endl;
-    std::cout << "\tWeighted Centroid: " << labelGeometryImageFilter->GetWeightedCentroid(labelValue) << std::endl;
-    std::cout << "\tAxes Length: " << labelGeometryImageFilter->GetAxesLength(labelValue) << std::endl;
-    std::cout << "\tMajorAxisLength: " << labelGeometryImageFilter->GetMajorAxisLength(labelValue) << std::endl;
-    std::cout << "\tMinorAxisLength: " << labelGeometryImageFilter->GetMinorAxisLength(labelValue) << std::endl;
-    std::cout << "\tEccentricity: " << labelGeometryImageFilter->GetEccentricity(labelValue) << std::endl;
-    std::cout << "\tElongation: " << labelGeometryImageFilter->GetElongation(labelValue) << std::endl;
-    std::cout << "\tOrientation: " << labelGeometryImageFilter->GetOrientation(labelValue) << std::endl;
-    std::cout << "\tBounding box: " << labelGeometryImageFilter->GetBoundingBox(labelValue) << std::endl;
-
-    std::cout << std::endl << std::endl;
-  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/Documentation.rst
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/Documentation.rst
@@ -4,7 +4,8 @@ Geometric Properties of Labeled Region
 ======================================
 
 .. index::
-   single: LabelGeometryImageFilter
+   single: LabelImageToShapeLabelMapFilter
+   single: LabelStatisticsImageFilter
    pair: geometric; property
    pair: geometric; region
 
@@ -24,119 +25,63 @@ Results
 
 Output::
 
-  Image (0x7fd274c5f3c0)
-  RTTI typeinfo:   itk::Image<unsigned int, 2u>
-  Reference Count: 1
-  Modified Time: 46
-  Debug: Off
-  Object Name:
-  Observers:
-    none
-  Source: (none)
-  Source output name: (none)
-  Release Data: Off
-  Data Released: False
-  Global Release Data: Off
-  PipelineMTime: 0
-  UpdateMTime: 0
-  RealTimeStamp: 0 seconds
-  LargestPossibleRegion:
+  Number of labels: 3
+
+  	Label: 85
+  	Physical size: 16
+  	Number of pixels: 16
+  	Centroid: [7.5, 7.5]
+  	Equivalent ellipsoid diameter: [4.51352, 4.51352]
+  	Elongation: 1
+  	Flatness: 1
+  	Principal axes: 1 0
+  0 1
+
+  	Bounding box: ImageRegion
     Dimension: 2
-    Index: [0, 0]
-    Size: [20, 20]
-  BufferedRegion:
+    Index: [6, 6]
+    Size: [4, 4]
+
+  	Integrated intensity: 2487
+  	Mean intensity: 155.438
+
+
+  	Label: 127
+  	Physical size: 25
+  	Number of pixels: 25
+  	Centroid: [14, 14]
+  	Equivalent ellipsoid diameter: [5.6419, 5.6419]
+  	Elongation: 1
+  	Flatness: 1
+  	Principal axes: 1 0
+  0 1
+
+  	Bounding box: ImageRegion
     Dimension: 2
-    Index: [0, 0]
-    Size: [20, 20]
-  RequestedRegion:
+    Index: [12, 12]
+    Size: [5, 5]
+
+  	Integrated intensity: 4310
+  	Mean intensity: 172.4
+
+
+  	Label: 191
+  	Physical size: 15
+  	Number of pixels: 15
+  	Centroid: [14, 3]
+  	Equivalent ellipsoid diameter: [3.32063, 5.7515]
+  	Elongation: 1.73205
+  	Flatness: 1.73205
+  	Principal axes: 0 1
+  -1 -0
+
+  	Bounding box: ImageRegion
     Dimension: 2
-    Index: [0, 0]
-    Size: [20, 20]
-  Spacing: [1, 1]
-  Origin: [0, 0]
-  Direction:
-  1 0
-  0 1
+    Index: [12, 2]
+    Size: [5, 3]
 
-  IndexToPointMatrix:
-  1 0
-  0 1
-
-  PointToIndexMatrix:
-  1 0
-  0 1
-
-  Inverse Direction:
-  1 0
-  0 1
-
-  PixelContainer:
-    ImportImageContainer (0x7fd274c5f5b0)
-      RTTI typeinfo:   itk::ImportImageContainer<unsigned long, unsigned int>
-      Reference Count: 1
-      Modified Time: 47
-      Debug: Off
-      Object Name:
-      Observers:
-        none
-      Pointer: 0x7fd27502d800
-      Container manages memory: true
-      Size: 400
-      Capacity: 400
-  Number of labels: 4
-
-  Label: 0
-  Volume: 344
-  Integrated Intensity: 44128
-  Centroid: [9.06977, 9.54942]
-  Weighted Centroid: [9.44273, 9.96021]
-  Axes Length: [23.6173, 23.9599]
-  MajorAxisLength: 23.9599
-  MinorAxisLength: 23.6173
-  Eccentricity: 0.168492
-  Elongation: 1.0145
-  Orientation: 2.74768
-  Bounding box: [0, 19, 0, 19]
-
-
-  Label: 85
-  Volume: 16
-  Integrated Intensity: 2544
-  Centroid: [7.5, 7.5]
-  Weighted Centroid: [7.44811, 7.47602]
-  Axes Length: [4.6188, 4.6188]
-  MajorAxisLength: 4.6188
-  MinorAxisLength: 4.6188
-  Eccentricity: 0
-  Elongation: 1
-  Orientation: 1.5708
-  Bounding box: [6, 9, 6, 9]
-
-  Label: 127
-  Volume: 25
-  Integrated Intensity: 3263
-  Centroid: [14, 14]
-  Weighted Centroid: [13.6883, 14.1192]
-  Axes Length: [5.7735, 5.7735]
-  MajorAxisLength: 5.7735
-  MinorAxisLength: 5.7735
-  Eccentricity: 0
-  Elongation: 1
-  Orientation: 1.5708
-  Bounding box: [12, 16, 12, 16]
-
-  Label: 191
-  Volume: 15
-  Integrated Intensity: 1840
-  Centroid: [14, 3]
-  Weighted Centroid: [13.8647, 3.10978]
-  Axes Length: [3.4641, 5.7735]
-  MajorAxisLength: 5.7735
-  MinorAxisLength: 3.4641
-  Eccentricity: 0.8
-  Elongation: 1.66667
-  Orientation: 0
-  Bounding box: [12, 16, 2, 4]
+  	Integrated intensity: 2155
+  	Mean intensity: 143.667
 
 Code
 ----
@@ -150,4 +95,6 @@ C++
 Classes demonstrated
 --------------------
 
-.. breathelink:: itk::LabelGeometryImageFilter
+.. breathelink:: itk::LabelImageToShapeLabelMapFilter
+
+.. breathelink:: itk::LabelStatisticsImageFilter


### PR DESCRIPTION
Migrate the `GeometricPropertiesOfRegion` example off the deprecated `itk::LabelGeometryImageFilter` (deprecated in ITK because it has known computational bugs) to the supported replacements named in the ITK class documentation, and fix a latent build break in the example's `CMakeLists.txt`.

<details>
<summary>What changed and why</summary>

- `Code.cxx`: compute geometric properties with `itk::LabelImageToShapeLabelMapFilter` and per-label intensity statistics with `itk::LabelStatisticsImageFilter` instead of `itk::LabelGeometryImageFilter`.
- `CMakeLists.txt`: the example linked `ITK::ITKReviewModule`, which is not part of the default ITK build, so the example failed to configure standalone (and was silently skipped). Now links `ITK::ITKLabelMapModule` + `ITK::ITKImageStatisticsModule`.
- `Documentation.rst`: updated index terms, `Output::` block, and `breathelink` targets to the new filters.
- `CMake/CTestCustom.cmake.in`: dropped the now-dead `"LabelGeometryImageFilter.*deprecated"` warning exception.

This was surfaced by the warning audit (#461): the deprecation was the only genuine compiler warning in the example sources.

</details>

<details>
<summary>Verification</summary>

Built and run standalone on Linux/gcc 13.3 against ITK `main`: configures, compiles with **0 warnings / 0 deprecations**, runs to completion (exit 0) printing shape + intensity properties for all 3 labels. `pre-commit run --all-files` passes.

</details>

<!--
provenance: claude-code session 2026-06-14
branch: fix-audit-warnings (off origin/main abbaf330)
verified: cortex gcc 13.3, ITK main; standalone example build+run exit 0, 0 warnings
related: warning-audit PR #461
-->
