### PR TITLE
COMP: CI maintenance for reduced upkeep (Dependabot + Python floor + remove broken Sphinx hack)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -319,11 +319,6 @@ jobs:
 
           echo "Workspace: ${{ github.workspace }}"
 
-      - name: Remove Duplicate Declaration Warnings
-        run: |
-          SITE_PACKAGES_DIR=$(python3 "-c" "from distutils import sysconfig; print(sysconfig.get_python_lib())")
-          sed -i "6559d" ${SITE_PACKAGES_DIR}/sphinx/domains/cpp.py
-
       - name: Restore ExternalData cache
         uses: actions/cache@v4
         with:

--- a/Formatting/conf.py.in
+++ b/Formatting/conf.py.in
@@ -45,6 +45,11 @@ if os.environ.get("READTHEDOCS", "") == "True":
 # C++ is the primary (default) Sphinx domain.
 primary_domain = 'cpp'
 
+# The same ITK class is intentionally documented by more than one example,
+# so the C++ domain reports duplicate declarations. Suppress that subtype
+# (effective on Sphinx versions that tag the warning).
+suppress_warnings = ['duplicate_declaration.cpp']
+
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.todo', 'sphinx.ext.imgmath', 'sphinx.ext.ifconfig',

--- a/Superbuild/External-Python.cmake
+++ b/Superbuild/External-Python.cmake
@@ -1,4 +1,4 @@
-set(MIN_PYTHON_VERSION 3.7)
+set(MIN_PYTHON_VERSION 3.11)
 find_package(Python3 ${MIN_PYTHON_VERSION} COMPONENTS Interpreter REQUIRED)
 
 set(_itk_venv "${CMAKE_CURRENT_BINARY_DIR}/itkpython")


### PR DESCRIPTION
Low-risk CI/infrastructure maintenance to reduce future upkeep. No build-behavior changes that require a doc-build to validate (those are tracked separately).

<details>
<summary>Changes</summary>

- **Add Dependabot** (`.github/dependabot.yml`) for the `github-actions` ecosystem (weekly, grouped) so action versions stay current without manual tracking. Several actions were emitting Node-20 deprecation warnings.
- **Raise Superbuild Python floor** 3.7 to 3.11 (`Superbuild/External-Python.cmake`); 3.7 is end-of-life and the CI matrix already uses 3.11.
- **Remove the broken "Remove Duplicate Declaration Warnings" step.** In the pinned `sphinx==7.2.6`, `sed -i "6559d" .../domains/cpp.py` edits an unrelated template-parsing heuristic, not the duplicate-declaration warning (emitted elsewhere), so it mutated an unrelated code path while suppressing nothing, and it relied on `distutils` (removed in Python 3.12). Replaced with `suppress_warnings = ['duplicate_declaration.cpp']` in `conf.py.in`, which is ignored by 7.2.6 and becomes effective once Sphinx is upgraded.

</details>

<details>
<summary>Verification</summary>

`pre-commit run --all-files` passes. `suppress_warnings` confirmed harmless on `sphinx==7.2.6` (key ignored, no config error) and effective at silencing duplicate C++ declarations on current Sphinx. A follow-up will bump Sphinx and modernize the breathe/breathelink extensions (validated against a full doc build), after which the CTest "Duplicate C++ declaration" exception can also be dropped.

</details>

<!--
provenance: claude-code session 2026-06-14
branch: infra-modernize (off origin/main abbaf330)
deferred-followup: Sphinx bump 7.2.6 to current + breathe(pip)+vendor breathelink (fix py2 iterkeys) + texlive slim + suppression-audit pruning; all gated on a CI doc-build
-->
