### PR TITLE
COMP: Fix CMP0177 install-path warning in WriteAnImage

### DIFF
--- a/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
+++ b/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
@@ -13,12 +13,12 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 install(TARGETS ${PROJECT_NAME}
-  DESTINATION bin/ITKSphinxExamples/Base/
+  DESTINATION bin/ITKSphinxExamples/Base
   COMPONENT Runtime
 )
 
 install(FILES Code.cxx CMakeLists.txt
-  DESTINATION share/ITKSphinxExamples/Code/Base//WriteAnImage
+  DESTINATION share/ITKSphinxExamples/Code/Base/WriteAnImage
   COMPONENT Code
 )
 


### PR DESCRIPTION
Normalize the two `install()` DESTINATION paths in `WriteAnImage/CMakeLists.txt` so the documentation and python-superbuild dashboards stop failing on a CMake developer warning.

This is the single warning currently failing `build-test-documentation` and `build-test-python-superbuild` on `main` and on every open PR built against a recent CMake.

<details>
<summary>Root cause</summary>

`src/IO/ImageBase/WriteAnImage/CMakeLists.txt` had a doubled separator in the `install(FILES ...)` DESTINATION (`Code/Base//WriteAnImage`) and a trailing slash in the `install(TARGETS ...)` DESTINATION. CMake 3.31+ enables policy **CMP0177** (install DESTINATION paths are normalized), which emits a `CMake Warning (dev)` on the unnormalized paths. The dashboard gate (`itkexamples_common.cmake:498`) counts any build warning as a failure, so the doc + superbuild jobs go red. The `build-test-cxx` jobs pin CMake 3.24.2 (pre-CMP0177), which is why only the doc/superbuild jobs were affected.

</details>

<details>
<summary>Impact / why now</summary>

The doc and python-superbuild jobs build a full ITK with a CMake new enough to enable CMP0177. The same single warning was observed on `main` and on PRs #452 and #464 (the latter touches nothing related, confirming it is inherited). Normalizing the paths removes the trigger under any CMake version; nothing else changes.

</details>

<!--
provenance: claude-code session 2026-06-14
unblocks: build-test-documentation + build-test-python-superbuild on main, #452, #464 (and #453 after rebase)
file: src/IO/ImageBase/WriteAnImage/CMakeLists.txt lines 16,21
-->
